### PR TITLE
Fixed Sphinx docs building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "kubernetes-asyncio==11.2.0",
     ],
     extras_require={
-        "docs": ["sphinx", "sphinx-autodoc-typehints"],
+        "docs": ["sphinx<3.1", "sphinx-autodoc-typehints"],
         "testing": ["faker==4.1.0", "pytest==5.4.2", "pytest-asyncio==0.12.0"],
     },
     python_requires=">=3.8",


### PR DESCRIPTION
With the recent Sphinx 3.1 release, something around documenting type annotations changed, causing issues like these:

```
crate/operator/config.py:docstring of crate.operator.config.Config.IMAGE_PULL_SECRETS:: WARNING: py:class reference target not found: Optional[List[str]]
crate/operator/config.py:docstring of crate.operator.config.Config.KUBECONFIG:: WARNING: py:class reference target not found: Optional[str]
crate/operator/utils/typing.py:docstring of crate.operator.utils.typing.SecretKeyRefContainer.secretKeyRef:: WARNING: py:class reference target not found: SecretKeyRef
```

~I haven't gotten to the bottom of that yet, but I have some hints.~ This is related to https://github.com/sphinx-doc/sphinx/issues/7808. In the mean time, let's make sure our tests pass by pinning Sphinx to < 3.1