### PR TITLE
Fix bug in restarting cluster when upgrading and scaling

### DIFF
--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -339,8 +339,12 @@ async def cluster_update(
         requires_restart = True
 
     if requires_restart:
+        # We need to derive the desired number of nodes from the old spec,
+        # since the new could have a different total number of nodes if a
+        # scaling operation is in progress as well.
+        expected_nodes = get_total_nodes_count(old["spec"]["nodes"])
         await with_timeout(
-            restart_cluster(namespace, name),
+            restart_cluster(namespace, name, expected_nodes),
             config.ROLLING_RESTART_TIMEOUT,
             (
                 f"Failed to restart cluster {namespace}/{name} after "

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -126,7 +126,7 @@ async def restart_statefulset(
         logger.info("Cluster has recovered. Moving on ...")
 
 
-async def restart_cluster(namespace: str, name: str) -> None:
+async def restart_cluster(namespace: str, name: str, total_nodes: int) -> None:
     """
     Perform a rolling restart of the CrateDB cluster ``name`` in ``namespace``.
 
@@ -138,6 +138,8 @@ async def restart_cluster(namespace: str, name: str) -> None:
 
     :param namespace: The Kubernetes namespace where to look up CrateDB cluster.
     :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param total_nodes: The total number of nodes that the cluster should
+        consist of, per the CrateDB cluster spec.
     """
     coapi = CustomObjectsApi()
     core = CoreV1Api()
@@ -152,8 +154,6 @@ async def restart_cluster(namespace: str, name: str) -> None:
     password = await get_system_user_password(namespace, name, core)
     host = await get_host(core, namespace, name)
     conn_factory = connection_factory(host, password)
-
-    total_nodes = get_total_nodes_count(cluster["spec"]["nodes"])
 
     if "master" in cluster["spec"]["nodes"]:
         await restart_statefulset(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -124,7 +124,7 @@ async def test_restart_cluster(
     original_pods = {p.metadata.uid for p in pods.items}
 
     await asyncio.wait_for(
-        restart_cluster(namespace.metadata.name, name), BACKOFF_TIME * 15
+        restart_cluster(namespace.metadata.name, name, 3), BACKOFF_TIME * 15
     )
 
     pods = await core.list_namespaced_pod(namespace=namespace.metadata.name)


### PR DESCRIPTION
When a cluster is being upgraded while simultaneously scaling it up or
down, the restart would take the new, desired, number of nodes into
account while waiting for the cluster to become healthy again, even
though the cluster, at that time, would only have the old number of
nodes. This, inevitably, would thus lead to timeouts during restarts.
