### PR TITLE
Prune custom resources except for the `status` field

### DIFF
--- a/deploy/manifests/00-crd-cratedb.yaml
+++ b/deploy/manifests/00-crd-cratedb.yaml
@@ -205,66 +205,65 @@ spec:
             nodes:
               properties:
                 data:
+                  items:
+                    properties:
+                      annotations:
+                        description: Additional annotations to put on the corresponding pods.
+                        type: object
+                      labels:
+                        description: Additional labels to put on the corresponding pods.
+                        type: object
+                      name:
+                        description: Uniquely identifying name of this type of node.
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                        type: string
+                      replicas:
+                        description: Number of CrateDB nodes of this type.
+                        minimum: 1
+                        type: number
+                      resources:
+                        properties:
+                          cpus:
+                            description: Requested and limited CPUs for each CrateDB container. Supports the syntax documented in https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
+                            type: number
+                          disk:
+                            properties:
+                              count:
+                                description: Number of disks
+                                type: number
+                              size:
+                                description: Size of the disk.
+                                type: string
+                              storageClass:
+                                description: The name of a Kubernetes StorageClass
+                                type: string
+                            required:
+                            - count
+                            - size
+                            - storageClass
+                            type: object
+                          heapRatio:
+                            description: Allocated heap size relative to memory
+                            format: float
+                            type: number
+                          memory:
+                            description: Requested and limited memory for each CrateDB container. Supports the syntax documented in https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
+                            type: string
+                        required:
+                        - cpus
+                        - disk
+                        - heapRatio
+                        - memory
+                        type: object
+                      settings:
+                        description: Additional settings to apply to all nodes of that type in the cluster.
+                        type: object
+                    required:
+                    - name
+                    - replicas
+                    - resources
+                    type: object
                   minItems: 1
-                  properties:
-                    items:
-                      properties:
-                        annotations:
-                          description: Additional annotations to put on the corresponding pods.
-                          type: object
-                        labels:
-                          description: Additional labels to put on the corresponding pods.
-                          type: object
-                        name:
-                          description: Uniquely identifying name of this type of node.
-                          pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
-                          type: string
-                        replicas:
-                          description: Number of CrateDB nodes of this type.
-                          minimum: 1
-                          type: number
-                        resources:
-                          properties:
-                            cpus:
-                              description: Requested and limited CPUs for each CrateDB container. Supports the syntax documented in https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
-                              type: number
-                            disk:
-                              properties:
-                                count:
-                                  description: Number of disks
-                                  type: number
-                                size:
-                                  description: Size of the disk.
-                                  type: string
-                                storageClass:
-                                  description: The name of a Kubernetes StorageClass
-                                  type: string
-                              required:
-                              - count
-                              - size
-                              - storageClass
-                              type: object
-                            heapRatio:
-                              description: Allocated heap size relative to memory
-                              format: float
-                              type: number
-                            memory:
-                              description: Requested and limited memory for each CrateDB container. Supports the syntax documented in https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
-                              type: string
-                          required:
-                          - cpus
-                          - disk
-                          - heapRatio
-                          - memory
-                          type: object
-                        settings:
-                          description: Additional settings to apply to all nodes of that type in the cluster.
-                          type: object
-                      required:
-                      - name
-                      - replicas
-                      - resources
-                      type: object
                   type: array
                 master:
                   properties:
@@ -357,34 +356,33 @@ spec:
               - prometheus
               type: object
             users:
-              properties:
-                items:
-                  properties:
-                    name:
-                      description: The username for a CrateDB cluster user.
-                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
-                      type: string
-                    password:
-                      properties:
-                        secretKeyRef:
-                          properties:
-                            key:
-                              description: The key within the Kubernetes Secret that holds the user's password.
-                              type: string
-                            name:
-                              description: Name of a Kubernetes Secret that contains the password for the user.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                      required:
-                      - secretKeyRef
-                      type: object
-                  required:
-                  - name
-                  - password
-                  type: object
+              items:
+                properties:
+                  name:
+                    description: The username for a CrateDB cluster user.
+                    pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    type: string
+                  password:
+                    properties:
+                      secretKeyRef:
+                        properties:
+                          key:
+                            description: The key within the Kubernetes Secret that holds the user's password.
+                            type: string
+                          name:
+                            description: Name of a Kubernetes Secret that contains the password for the user.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    required:
+                    - secretKeyRef
+                    type: object
+                required:
+                - name
+                - password
+                type: object
               type: array
           required:
           - cluster


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This change is necessary to support Kubernetes 1.16+

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
