### PR TITLE
Return public hostname for CrateDB service when IP is not given

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -19,7 +19,7 @@ from crate.operator.constants import (
 )
 from crate.operator.cratedb import get_connection
 from crate.operator.utils.formatting import b64encode
-from crate.operator.utils.kubeapi import get_public_ip, get_system_user_password
+from crate.operator.utils.kubeapi import get_public_host, get_system_user_password
 
 from .utils import assert_wait_for
 
@@ -223,8 +223,8 @@ async def test_bootstrap_users(
         },
     )
 
-    ip_address = await asyncio.wait_for(
-        get_public_ip(core, namespace.metadata.name, name),
+    host = await asyncio.wait_for(
+        get_public_host(core, namespace.metadata.name, name),
         timeout=BACKOFF_TIME * 5,  # It takes a while to retrieve an external IP on AKS.
     )
 
@@ -234,26 +234,16 @@ async def test_bootstrap_users(
     await assert_wait_for(
         True,
         does_user_exist,
-        ip_address,
+        host,
         password_system,
         SYSTEM_USERNAME,
         timeout=BACKOFF_TIME * 5,
     )
 
     await assert_wait_for(
-        True,
-        does_user_exist,
-        ip_address,
-        password1,
-        username1,
-        timeout=BACKOFF_TIME * 3,
+        True, does_user_exist, host, password1, username1, timeout=BACKOFF_TIME * 3,
     )
 
     await assert_wait_for(
-        True,
-        does_user_exist,
-        ip_address,
-        password2,
-        username2,
-        timeout=BACKOFF_TIME * 3,
+        True, does_user_exist, host, password2, username2, timeout=BACKOFF_TIME * 3,
     )

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -9,7 +9,7 @@ from kubernetes_asyncio.client import CoreV1Api, CustomObjectsApi
 from crate.operator.constants import API_GROUP, BACKOFF_TIME, RESOURCE_CRATEDB
 from crate.operator.cratedb import connection_factory, get_healthiness
 from crate.operator.operations import restart_cluster
-from crate.operator.utils.kubeapi import get_public_ip, get_system_user_password
+from crate.operator.utils.kubeapi import get_public_host, get_system_user_password
 
 from .utils import assert_wait_for
 
@@ -93,8 +93,8 @@ async def test_restart_cluster(
         },
     )
 
-    ip_address = await asyncio.wait_for(
-        get_public_ip(core, namespace.metadata.name, name),
+    host = await asyncio.wait_for(
+        get_public_host(core, namespace.metadata.name, name),
         timeout=BACKOFF_TIME * 5,  # It takes a while to retrieve an external IP on AKS.
     )
 
@@ -115,7 +115,7 @@ async def test_restart_cluster(
     await assert_wait_for(
         True,
         is_cluster_healthy,
-        connection_factory(ip_address, password),
+        connection_factory(host, password),
         err_msg="Cluster wasn't healthy after 5 minutes.",
         timeout=BACKOFF_TIME * 5,
     )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Azure's AKS service provides public IP addresses for load balancers,
whereas AWS' EKS defines hostnames. Checking for either supports running
tests on either Kubernetes setup.



## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
