### PR TITLE
Set the idle timeout of Service load balancer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Set the idle timeout of Service loadbalancer to cloud provider specific
+  maximum.
+
 * Fixed a bug that prevented the cluster name from ``.spec.cluster.name`` to be
   used as CrateDB's cluster name.
 


### PR DESCRIPTION
The annotations on the `Service` allow to set connection handling of
cloud specific load balancers.

**AWS**

```yaml
service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout: "4000"  # seconds
```

- https://kubernetes.io/docs/concepts/services-networking/service/#connection-draining-on-aws

**Azure**

```yaml
service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset: "true"
service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout: "30"  # minutes
```

- https://docs.microsoft.com/en-us/azure/aks/load-balancer-standard#additional-customizations-via-kubernetes-annotations
- https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-tcp-reset

---

**Warning!**

Be aware of long running queries invoked by HTTP clients (e.g. Admin UI,
crash, etc). Due to the failover behaviour of load balancers of cloud
providers, queries that exceed the load balancer timeout may be
automatically retried on a different CrateDB upstream node without the
client noticing it. This can lead to queries overloading the CrateDB
cluster, e.g. in case of a `COPY FROM` "spawned" multiple times.
Please consider using clients that use the Postgres protocol, e.g. JDBC
for Java.

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
