### PR TITLE
Added missing `topology_key` in Pod affinity declaration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fixed broken creation of StatefulSets when ``CLOUD_PROVIDER`` was set to
+  ``aws`` due to missing ``topology_key`` in Pod affinity declaration.
+
 * Added the changelog to the documentation.
 
 1.0b1 (2020-07-07)

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -197,6 +197,11 @@ def get_statefulset_affinity(name: str, logger: logging.Logger) -> Optional[V1Af
                             ),
                         ],
                     ),
+                    # `failure-domain.beta.kubernetes.io/zone` is deprecated
+                    # and should be replaced by the compatible term for future
+                    # Kubernetes versions. See also:
+                    # https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone
+                    topology_key="failure-domain.beta.kubernetes.io/zone",
                 ),
                 weight=100,
             )


### PR DESCRIPTION
for AWS deployments.

## Summary of the changes / Why this is an improvement

This caused the deployment of the StatefulSets to fail in case
`CRATE_OPERATOR_CLOUD_PROVIDER` was set to `aws`.




## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
