### PR TITLE
Fixed bug that prevented the cluster name to be passed to CrateDB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fixed a bug that prevented the cluster name from ``.spec.cluster.name`` to be
+  used as CrateDB's cluster name.
+
 * Fixed broken creation of StatefulSets when ``CLOUD_PROVIDER`` was set to
   ``aws`` due to missing ``topology_key`` in Pod affinity declaration.
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -308,6 +308,7 @@ def get_statefulset_crate_command(
     master_nodes: List[str],
     total_nodes_count: int,
     crate_node_name_prefix: str,
+    cluster_name: str,
     node_name: str,
     node_spec: Dict[str, Any],
     cluster_settings: Optional[Dict[str, str]],
@@ -317,7 +318,7 @@ def get_statefulset_crate_command(
 ) -> List[str]:
     settings = {
         "-Cstats.enabled": "true",
-        "-Ccluster.name": name,
+        "-Ccluster.name": cluster_name,
         # This is a clever way of doing string split in SH and picking the last
         # item. Here's how it works:
         #
@@ -578,6 +579,7 @@ def get_statefulset(
     labels: LabelType,
     treat_as_master: bool,
     treat_as_data: bool,
+    cluster_name: str,
     node_name: str,
     node_name_prefix: str,
     node_spec: Dict[str, Any],
@@ -618,6 +620,7 @@ def get_statefulset(
             master_nodes=master_nodes,
             total_nodes_count=total_nodes_count,
             crate_node_name_prefix=node_name_prefix,
+            cluster_name=cluster_name,
             node_name=node_name,
             node_spec=node_spec,
             cluster_settings=cluster_settings,
@@ -673,6 +676,7 @@ def create_statefulset(
     labels: LabelType,
     treat_as_master: bool,
     treat_as_data: bool,
+    cluster_name: str,
     node_name: str,
     node_name_prefix: str,
     node_spec: Dict[str, Any],
@@ -701,6 +705,7 @@ def create_statefulset(
             labels,
             treat_as_master,
             treat_as_data,
+            cluster_name,
             node_name,
             node_name_prefix,
             node_spec,

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -164,6 +164,7 @@ async def cluster_create(
     # nor implicit master nodes.
     treat_as_master = True
     sts = []
+    cluster_name = spec["cluster"]["name"]
     if has_master_nodes:
         sts.append(
             create_statefulset(
@@ -174,6 +175,7 @@ async def cluster_create(
                 cratedb_labels,
                 treat_as_master,
                 False,
+                cluster_name,
                 "master",
                 "master-",
                 spec["nodes"]["master"],
@@ -203,6 +205,7 @@ async def cluster_create(
                 cratedb_labels,
                 treat_as_master,
                 True,
+                cluster_name,
                 node_name,
                 f"data-{node_name}-",
                 node_spec,

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -200,6 +200,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["data-node-0", "data-node-1", "data-node-2"],
             total_nodes_count=3,
             crate_node_name_prefix="data-node-",
+            cluster_name="my-cluster",
             node_name="node",
             node_spec={"resources": {"cpus": 1, "disk": {"count": 1}}},
             cluster_settings=None,
@@ -209,14 +210,15 @@ class TestStatefulSetCrateCommand:
         )
         assert ["/docker-entrypoint.sh", "crate"] == cmd[0:2]
 
-    def test_cluster_name_is_name(self, random_string):
-        name = random_string()
+    def test_cluster_name(self, random_string):
+        cluster_name = random_string()
         cmd = get_statefulset_crate_command(
             namespace="some-namespace",
-            name=name,
+            name="cluster1",
             master_nodes=["data-node-0", "data-node-1", "data-node-2"],
             total_nodes_count=3,
             crate_node_name_prefix="data-node-",
+            cluster_name=cluster_name,
             node_name="node",
             node_spec={"resources": {"cpus": 1, "disk": {"count": 1}}},
             cluster_settings=None,
@@ -224,7 +226,7 @@ class TestStatefulSetCrateCommand:
             is_master=True,
             is_data=True,
         )
-        assert f"-Ccluster.name={name}" in cmd
+        assert f"-Ccluster.name={cluster_name}" in cmd
 
     def test_node_name(self, random_string):
         node_name = random_string()
@@ -235,6 +237,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["data-node-0", "data-node-1", "data-node-2"],
             total_nodes_count=3,
             crate_node_name_prefix=crate_node_name_prefix,
+            cluster_name="my-cluster",
             node_name=node_name,
             node_spec={"resources": {"cpus": 1, "disk": {"count": 1}}},
             cluster_settings=None,
@@ -258,6 +261,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["node-0", "node-1", "node-2"],
             total_nodes_count=total,
             crate_node_name_prefix="node-",
+            cluster_name="my-cluster",
             node_name="node",
             node_spec={"resources": {"cpus": 1, "disk": {"count": 1}}},
             cluster_settings=None,
@@ -276,6 +280,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["node-0", "node-1", "node-2"],
             total_nodes_count=3,
             crate_node_name_prefix="node-",
+            cluster_name="my-cluster",
             node_name="node",
             node_spec={"resources": {"cpus": 1, "disk": {"count": count}}},
             cluster_settings=None,
@@ -294,6 +299,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["node-0", "node-1", "node-2"],
             total_nodes_count=3,
             crate_node_name_prefix="node-",
+            cluster_name="my-cluster",
             node_name="node",
             node_spec={"resources": {"cpus": cpus, "disk": {"count": 1}}},
             cluster_settings=None,
@@ -312,6 +318,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["node-0", "node-1", "node-2"],
             total_nodes_count=3,
             crate_node_name_prefix="node-",
+            cluster_name="my-cluster",
             node_name="node",
             node_spec={"resources": {"cpus": 1, "disk": {"count": 1}}},
             cluster_settings=None,
@@ -330,6 +337,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["node-0", "node-1", "node-2"],
             total_nodes_count=3,
             crate_node_name_prefix="node-",
+            cluster_name="my-cluster",
             node_name="node",
             node_spec={"resources": {"cpus": 1, "disk": {"count": 1}}},
             cluster_settings=None,
@@ -351,6 +359,7 @@ class TestStatefulSetCrateCommand:
             master_nodes=["node-0", "node-1", "node-2"],
             total_nodes_count=3,
             crate_node_name_prefix="node-",
+            cluster_name="my-cluster",
             node_name="node",
             node_spec={
                 "resources": {"cpus": 1, "disk": {"count": 1}},
@@ -534,6 +543,7 @@ class TestStatefulSet:
         apps = AppsV1Api()
         core = CoreV1Api()
         name = faker.domain_word()
+        cluster_name = faker.domain_word()
         node_name = faker.domain_word()
         await create_statefulset(
             apps,
@@ -548,6 +558,7 @@ class TestStatefulSet:
             },
             True,
             True,
+            cluster_name,
             node_name,
             f"data-{node_name}-",
             {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The cluster name as defined in `.spec.cluster.name` wasn't passed on to
the StatefulSet's CrateDB command, thus CrateDB's `cluster.name` setting
wasn't set correctly, but instead had the value of the `.metadata.name`.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
