### PR TITLE
Set configured log level for all loggers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 Unreleased
 ----------
 
+* Set the configured log level for all loggers. This ensures that even with
+  Kopf's ``--debug`` or ``--verbose`` CLI flags, Kubernetes API responses are
+  not logged anymore when the log level is ``INFO`` or higher. This is to avoid
+  leaking secrets into the operator log when it e.g. reads Kubernetes secrets.
+
 1.0b2 (2020-07-16)
 ------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN pip install --no-cache-dir -U pip wheel && \
 USER crate-operator
 
 ENTRYPOINT ["kopf", "run", "--standalone"]
-CMD ["--verbose", "main.py"]
+CMD ["main.py"]

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -144,8 +144,10 @@ class Config:
             )
 
         self.LOG_LEVEL = self.env("LOG_LEVEL", default=self.LOG_LEVEL)
-        log = logging.getLogger("crate")
-        log.setLevel(logging.getLevelName(self.LOG_LEVEL))
+        level = logging.getLevelName(self.LOG_LEVEL)
+        for logger_name in ("", "crate", "kopf", "kubernetes_asyncio"):
+            logger = logging.getLogger(logger_name)
+            logger.setLevel(level)
 
         rolling_restart_timeout = self.env(
             "ROLLING_RESTART_TIMEOUT", default=str(self.ROLLING_RESTART_TIMEOUT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def kopf_runner(request, cratedb_crd):
         "CRATEDB_OPERATOR_KUBECONFIG": request.config.getoption(KUBECONFIG_OPTION),
     }
     with mock.patch.dict(os.environ, env):
-        with KopfRunner(["run", "--verbose", "--standalone", main.__file__]) as runner:
+        with KopfRunner(["run", "--standalone", main.__file__]) as runner:
             yield runner
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

A side-effect of this change is that Kopf's `--debug`, `--quiet`, and
`--verbose` CLI flags don't have any effect anymore.

Thanks for the report, @nuriel77.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
