### PR TITLE
Adjust license owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN python setup.py clean bdist_wheel
 FROM python:3.8-slim
 
 LABEL license="AGPLv3" \
-      maintainer="Crate.io AT GmbH <office@crate.io>" \
+      maintainer="Crate.IO GmbH <office@crate.io>" \
       name="CrateDB Kubernetes Operator" \
       repository="crate/crate-operator"
 

--- a/crate/operator/__init__.py
+++ b/crate/operator/__init__.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/backup.py
+++ b/crate/operator/backup.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/cratedb.py
+++ b/crate/operator/cratedb.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/exceptions.py
+++ b/crate/operator/exceptions.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/kube_auth.py
+++ b/crate/operator/kube_auth.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/upgrade.py
+++ b/crate/operator/upgrade.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/utils/__init__.py
+++ b/crate/operator/utils/__init__.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/utils/formatting.py
+++ b/crate/operator/utils/formatting.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/utils/kubeapi.py
+++ b/crate/operator/utils/kubeapi.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/utils/secrets.py
+++ b/crate/operator/utils/secrets.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/utils/typing.py
+++ b/crate/operator/utils/typing.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/crate/operator/webhooks.py
+++ b/crate/operator/webhooks.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/deploy/manifests/00-crd-cratedb.yaml
+++ b/deploy/manifests/00-crd-cratedb.yaml
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/devtools/create_tag.sh
+++ b/devtools/create_tag.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/docs/source/crate_operator_ext.py
+++ b/docs/source/crate_operator_ext.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -33,7 +33,7 @@ def read(path: str) -> str:
 
 setup(
     name="crate-operator",
-    author="Crate.io AT GmbH",
+    author="Crate.IO GmbH",
     author_email="office@crate.io",
     description="CrateDB Kubernetes Operator",
     license="AGPLv3",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_cratedb.py
+++ b/tests/test_cratedb.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_kubeapi.py
+++ b/tests/test_kubeapi.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.io AT GmbH
+# Copyright (C) 2020 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

As it turns out the license owner is "Crate.IO GmbH" and not "Crate.io AT GmbH".

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
