### PR TITLE
Make tests more resilient

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -48,9 +48,7 @@ async def is_cluster_healthy(conn_factory: Callable[[], Connection]):
 
 @pytest.mark.k8s
 @pytest.mark.asyncio
-async def test_restart_cluster(
-    faker, namespace, cleanup_handler, cratedb_crd, kopf_runner
-):
+async def test_restart_cluster(faker, namespace, cleanup_handler, kopf_runner):
     coapi = CustomObjectsApi()
     core = CoreV1Api()
     name = faker.domain_word()

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -73,7 +73,6 @@ async def test_scale_cluster(
     faker,
     namespace,
     cleanup_handler,
-    cratedb_crd,
     kopf_runner,
 ):
     coapi = CustomObjectsApi()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,8 +15,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
+import logging
+
+from kubernetes_asyncio.client import StorageV1Api, V1ObjectMeta, V1StorageClass
 
 from crate.operator.constants import BACKOFF_TIME
+from crate.operator.utils.kubeapi import call_kubeapi
+
+logger = logging.getLogger(__name__)
+
+LOCAL_FS_STORAGE_CLASS_NAME = "crate-operator-local-fs"
 
 
 async def assert_wait_for(
@@ -41,3 +49,18 @@ async def assert_wait_for(
 async def does_namespace_exist(core, namespace: str) -> bool:
     namespaces = await core.list_namespace()
     return namespace in (ns.metadata.name for ns in namespaces.items)
+
+
+async def create_local_fs_storage_class():
+    sapi = StorageV1Api()
+    await call_kubeapi(
+        sapi.create_storage_class,
+        logger,
+        continue_on_conflict=True,
+        body=V1StorageClass(
+            metadata=V1ObjectMeta(name=LOCAL_FS_STORAGE_CLASS_NAME),
+            provisioner="kubernetes.io/no-provisioner",
+            reclaim_policy="Delete",
+            volume_binding_mode="WaitForFirstConsumer",
+        ),
+    )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

When the operator deploys a CrateDB cluster, the StatefulSet adds a
local PersistentVolume to each pod which can be used for debugging.
Historically, the operator used the "default" storage class for these
PVs. However, since "default" may map to block storages in the cloud,
e.g. on Azure or AWS, K8s would attempt to mount the same block device
onto multiple pods, which isn't possible. To mitigate the issue, the
operator's tests now ensure there's a local file system.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
