### PR TITLE
Close the K8s API client's connections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Ensured that Kubernetes API client's connections are closed properly.
+
 1.0b3 (2020-08-11)
 ------------------
 

--- a/crate/operator/upgrade.py
+++ b/crate/operator/upgrade.py
@@ -41,18 +41,18 @@ async def update_statefulset(
     )
 
 
-async def upgrade_cluster(namespace: str, name: str, body: kopf.Body):
+async def upgrade_cluster(apps: AppsV1Api, namespace: str, name: str, body: kopf.Body):
     """
     Update the Docker image in all StatefulSets for the cluster.
 
     For the changes to take affect, the cluster needs to be restarted.
 
+    :param apps: An instance of the Kubernetes Apps V1 API.
     :param namespace: The Kubernetes namespace for the CrateDB cluster.
     :param name: The name for the ``CrateDB`` custom resource.
     :param body: The full body of the ``CrateDB`` custom resource per
         :class:`kopf.Body`.
     """
-    apps = AppsV1Api()
     crate_image = (
         body.spec["cluster"]["imageRegistry"] + ":" + body.spec["cluster"]["version"]
     )

--- a/crate/operator/utils/kubeapi.py
+++ b/crate/operator/utils/kubeapi.py
@@ -105,35 +105,32 @@ async def call_kubeapi(
 
 
 async def resolve_secret_key_ref(
-    namespace: str, secret_key_ref: SecretKeyRef, core: Optional[CoreV1Api] = None
+    core: CoreV1Api, namespace: str, secret_key_ref: SecretKeyRef,
 ) -> str:
     """
     Lookup the secret value defined by ``secret_key_ref`` in ``namespace``.
 
+    :param core: An instance of the Kubernetes Core V1 API.
     :param namespace: The namespace where to lookup a secret and its value.
     :param secret_key_ref: a ``secretKeyRef`` containing the secret name and
         key within that holds the desired value.
-    :param core: An instance of the Kubernetes Core V1 API.
     """
-    core = core or CoreV1Api()
     secret_name = secret_key_ref["name"]
     key = secret_key_ref["key"]
     secret = await core.read_namespaced_secret(namespace=namespace, name=secret_name)
     return b64decode(secret.data[key])
 
 
-async def get_system_user_password(
-    namespace: str, name: str, core: Optional[CoreV1Api] = None
-) -> str:
+async def get_system_user_password(core: CoreV1Api, namespace: str, name: str) -> str:
     """
     Return the password for the system user of cluster ``name`` in ``namespace``.
 
+    :param core: An instance of the Kubernetes Core V1 API.
     :param namespace: The namespace where the CrateDB cluster is deployed.
     :param name: The name of the CrateDB cluster.
-    :param core: An instance of the Kubernetes Core V1 API.
     """
     return await resolve_secret_key_ref(
-        namespace, {"key": "password", "name": f"user-system-{name}"}, core,
+        core, namespace, {"key": "password", "name": f"user-system-{name}"},
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from kubernetes_asyncio.client import (
     V1Namespace,
     V1ObjectMeta,
 )
+from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.config import load_kube_config
 
 from crate.operator.config import config
@@ -102,6 +103,12 @@ async def kube_config(request, load_config):
     context = request.config.getoption(KUBECONTEXT_OPTION)
     if config:
         await load_kube_config(config_file=config, context=context)
+
+
+@pytest.fixture(name="api_client")
+async def k8s_asyncio_api_client(kube_config) -> ApiClient:
+    async with ApiClient() as api_client:
+        yield api_client
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -41,9 +41,9 @@ class TestBackup:
         deployments = await apps.list_namespaced_deployment(namespace=namespace)
         return name in (d.metadata.name for d in deployments.items)
 
-    async def test_create(self, faker, namespace):
-        apps = AppsV1Api()
-        batchv1_beta1 = BatchV1beta1Api()
+    async def test_create(self, faker, namespace, api_client):
+        apps = AppsV1Api(api_client)
+        batchv1_beta1 = BatchV1beta1Api(api_client)
         name = faker.domain_word()
 
         backups_spec = {
@@ -107,9 +107,9 @@ class TestBackup:
             f"backup-metrics-{name}",
         )
 
-    async def test_not_enabled(self, faker, namespace):
-        apps = AppsV1Api()
-        batchv1_beta1 = BatchV1beta1Api()
+    async def test_not_enabled(self, faker, namespace, api_client):
+        apps = AppsV1Api(api_client)
+        batchv1_beta1 = BatchV1beta1Api(api_client)
         name = faker.domain_word()
 
         ret = await asyncio.gather(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -75,9 +75,10 @@ async def test_bootstrap_license(
     namespace,
     cleanup_handler,
     kopf_runner,
+    api_client,
 ):
-    coapi = CustomObjectsApi()
-    core = CoreV1Api()
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
     license = base64.b64encode(faker.binary(64)).decode()
 
@@ -151,9 +152,10 @@ async def test_bootstrap_users(
     namespace,
     cleanup_handler,
     kopf_runner,
+    api_client,
 ):
-    coapi = CustomObjectsApi()
-    core = CoreV1Api()
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
     password1 = faker.password(length=40)
     password2 = faker.password(length=30)
@@ -245,7 +247,7 @@ async def test_bootstrap_users(
     )
 
     password_system = await get_system_user_password(
-        namespace.metadata.name, name, core
+        core, namespace.metadata.name, name
     )
     await assert_wait_for(
         True,

--- a/tests/test_kubeapi.py
+++ b/tests/test_kubeapi.py
@@ -34,8 +34,8 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.mark.k8s
-async def test_success(faker, namespace):
-    core = CoreV1Api()
+async def test_success(faker, namespace, api_client):
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
     password = faker.password(length=12)
     await call_kubeapi(
@@ -55,8 +55,10 @@ async def test_success(faker, namespace):
 
 
 @pytest.mark.k8s
-async def test_absent_raises(faker, namespace):
-    core = CoreV1Api()
+async def test_absent_raises(
+    faker, namespace, api_client,
+):
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
     with pytest.raises(ApiException):
         await call_kubeapi(
@@ -69,9 +71,9 @@ async def test_absent_raises(faker, namespace):
 
 
 @pytest.mark.k8s
-async def test_absent_logs(faker, namespace, caplog):
+async def test_absent_logs(faker, namespace, caplog, api_client):
     caplog.set_level(logging.DEBUG, logger=__name__)
-    core = CoreV1Api()
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
     ns = namespace.metadata.name
     await call_kubeapi(
@@ -89,8 +91,8 @@ async def test_absent_logs(faker, namespace, caplog):
 
 
 @pytest.mark.k8s
-async def test_conflict_raises(faker, namespace):
-    core = CoreV1Api()
+async def test_conflict_raises(faker, namespace, api_client):
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
     ns = namespace.metadata.name
     password1 = faker.password(length=12)
@@ -119,9 +121,9 @@ async def test_conflict_raises(faker, namespace):
 
 
 @pytest.mark.k8s
-async def test_conflict_logs(faker, namespace, caplog):
+async def test_conflict_logs(faker, namespace, caplog, api_client):
     caplog.set_level(logging.DEBUG, logger=__name__)
-    core = CoreV1Api()
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
     ns = namespace.metadata.name
     password1 = faker.password(length=12)

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -74,9 +74,10 @@ async def test_scale_cluster(
     namespace,
     cleanup_handler,
     kopf_runner,
+    api_client,
 ):
-    coapi = CustomObjectsApi()
-    core = CoreV1Api()
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
     name = faker.domain_word()
 
     # Clean up persistent volume after the test
@@ -143,7 +144,7 @@ async def test_scale_cluster(
         get_public_host(core, namespace.metadata.name, name),
         timeout=BACKOFF_TIME * 5,  # It takes a while to retrieve an external IP on AKS.
     )
-    password = await get_system_user_password(namespace.metadata.name, name, core)
+    password = await get_system_user_password(core, namespace.metadata.name, name)
 
     await assert_wait_for(
         True,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Previously, when instantiating any of the kubernetes-asyncio APIs, such
as `CoreV1Api`, we didn't pass in an explicit `api_client` instance,
causing a new one to be created each time, which then would never close
the connection.

To change that, the `ApiClient` is only ever instantiated inside
`main.yaml` and instances of the `AppsV1Api`, `CoreV1Api`, etc. are
passed to functions. The only exception is the `WsApiClient` which is
instantiated when needed to keep the load on the K8s cluster low, by
closing those long-running connections right away after use.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
