### PR TITLE
Support zone awareness on Azure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Support Pod spreading across zones on Azure using weighted Pod
+  affinity on ``failure-domain.beta.kubernetes.io/zone`` topology. See also
+  https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone
+
 * Ensured that Kubernetes API client's connections are closed properly.
 
 1.0b3 (2020-08-11)

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -199,7 +199,7 @@ def get_statefulset_affinity(name: str, logger: logging.Logger) -> Optional[V1Af
         return None
 
     zone_affinity = None
-    if config.CLOUD_PROVIDER == CloudProvider.AWS:
+    if config.CLOUD_PROVIDER in {CloudProvider.AWS, CloudProvider.AZURE}:
         zone_affinity = [
             V1WeightedPodAffinityTerm(
                 pod_affinity_term=V1PodAffinityTerm(

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -41,7 +41,7 @@ expected to use upper-case letters and must be prefixed with
    Allowed values:
 
    - ``aws``
-   - ``azure`` (unused)
+   - ``azure``
 
 .. envvar:: CLUSTER_BACKUP_IMAGE
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -30,6 +30,7 @@ from crate.operator.constants import (
     LABEL_NAME,
     LABEL_PART_OF,
     RESOURCE_CRATEDB,
+    CloudProvider,
 )
 from crate.operator.create import (
     create_debug_volume,
@@ -158,10 +159,13 @@ class TestStatefulSetAffinity:
         ]
         assert terms.topology_key == "kubernetes.io/hostname"
 
-    def test_cloud_provider_aws(self, faker):
+    @pytest.mark.parametrize("provider", [CloudProvider.AWS, CloudProvider.AZURE])
+    def test_cloud_provider(self, provider, faker):
         name = faker.domain_word()
         with mock.patch("crate.operator.create.config.TESTING", False):
-            with mock.patch("crate.operator.create.config.CLOUD_PROVIDER", "aws"):
+            with mock.patch(
+                "crate.operator.create.config.CLOUD_PROVIDER", provider.value
+            ):
                 affinity = get_statefulset_affinity(name, logging.getLogger(__name__))
 
         apa = affinity.pod_anti_affinity


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

On the Node: The kubelet populates this with the zone information as defined by the cloudprovider. This will be set only if you are using a cloudprovider. However, you should consider setting this on the nodes if it makes sense in your topology.

-- [Docs: failure-domain.beta.kubernetes.io/zone](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone)

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
