### PR TITLE
On Azure, pass the failure/fault domain to CrateDB nodes as `zone`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Unreleased
   affinity on ``failure-domain.beta.kubernetes.io/zone`` topology. See also
   https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone
 
+  CrateDB nodes are also aware of this topology thought the ``zone`` node
+  attribute.
+
 * Ensured that Kubernetes API client's connections are closed properly.
 
 1.0b3 (2020-08-11)

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -393,7 +393,10 @@ def get_statefulset_crate_command(
 
     if config.CLOUD_PROVIDER == CloudProvider.AWS:
         url = "http://169.254.169.254/latest/meta-data/placement/availability-zone"
-        settings["-Cnode.attr.zone"] = f"$(curl -q {url})"
+        settings["-Cnode.attr.zone"] = f"$(curl -q '{url}')"
+    elif config.CLOUD_PROVIDER == CloudProvider.AZURE:
+        url = "http://169.254.169.254/metadata/instance/compute/platformFaultDomain?api-version=2020-06-01&format=text"  # noqa
+        settings["-Cnode.attr.zone"] = f"$(curl -q '{url}' -H 'Metadata: true')"
 
     return ["/docker-entrypoint.sh", "crate"] + [
         f"{k}={v}" for k, v in settings.items()


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

In order to allow CrateDB to route replicas in a reliable way, the
`zone` node attribute is set to the value of the Kubernetes pod's node
attribute `failure-domain.beta.kubernetes.io/zone` as documented in
https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone

Refs #94


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
