### PR TITLE
Set watch request timeouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Set timeouts for event watching in the underlying Kopf framework to prevent
+  the operator from getting stuck.
+
 * Support Pod spreading across zones on Azure using weighted Pod
   affinity on ``failure-domain.beta.kubernetes.io/zone`` topology. See also
   https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Every now and then, the operator might get stuck when watching for events on the K8s API. By setting some timeouts this can be mitigated.

Refs https://github.com/nolar/kopf/issues/232
Refs https://kopf.readthedocs.io/en/latest/configuration/#api-timeouts

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
