### PR TITLE
Fix #60: Update image of mkdir-heapdump init container on upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fixed a bug that would prevent the version of the Docker image of the
+  ``mkdir-heapdump`` init container to be updated when a cluster is upgraded.
+
 1.0b4 (2020-11-03)
 ------------------
 

--- a/crate/operator/upgrade.py
+++ b/crate/operator/upgrade.py
@@ -34,7 +34,12 @@ async def update_statefulset(
         body={
             "spec": {
                 "template": {
-                    "spec": {"containers": [{"name": "crate", "image": crate_image}]}
+                    "spec": {
+                        "containers": [{"name": "crate", "image": crate_image}],
+                        "initContainers": [
+                            {"name": "mkdir-heapdump", "image": crate_image}
+                        ],
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
