### PR TITLE
Add github action to build and publish docker images on new releases

### DIFF
--- a/.github/workflows/docker_image.yaml
+++ b/.github/workflows/docker_image.yaml
@@ -1,0 +1,34 @@
+name: Build and publish Docker Image
+
+on:
+  push:
+    tags:
+    - "*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@dd2e615
+        with:
+          images: crate/crate-operator
+          tag-match: '^[0-9]+\.[0-9]+(\.[0-9])?$'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and publish
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This github action will trigger when a new tag is release and will build/publish/tag the docker image accordingly.
For a version like `1.0.0` or `1.0` there will also be a `latest` tag built, for versions like `1.0b1` there will not be a latest tag.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
