### PR TITLE
Ref #48: Make create handler more resilient

### DIFF
--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -1,0 +1,28 @@
+from functools import wraps
+from typing import Callable
+
+
+def subhandler_partial(awaitable: Callable, *args, **kwargs):
+    """
+    A utility function to create a partial coroutine suitable for ``kopf.register``.
+
+    When scheduling asynchronous sub-handlers in Kopf, one needs to be careful
+    to not create coroutines when they're not used in an execution cycle.
+
+        >>> async def some_coro(arg1, kwarg1=None):
+        ...     pass
+        >>> kopf.register(
+        ...     fn=subhandler_partial(
+        ...         some_coro,
+        ...         'abc',
+        ...         kwarg1='foo',
+        ...     ),
+        ...     id="some-id",
+        ... )
+    """
+
+    @wraps(awaitable)
+    async def _wrapper(**_):
+        await awaitable(*args, **kwargs)
+
+    return _wrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ include_trailing_comma = true
 known_first_party = crate,tests
 line_length = 88
 multi_line_output = 3
-not_skip = __init__.py
 
 [tool:pytest]
 addopts = --strict-markers

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 
 import pytest
@@ -76,21 +75,17 @@ class TestBackup:
                 },
             },
         }
-        cronjob, deployment = await asyncio.gather(
-            *create_backups(
-                apps,
-                batchv1_beta1,
-                None,
-                namespace.metadata.name,
-                name,
-                {LABEL_COMPONENT: "backup", LABEL_NAME: name},
-                12345,
-                23456,
-                backups_spec,
-                None,
-                True,
-                logging.getLogger(__name__),
-            )
+        await create_backups(
+            None,
+            namespace.metadata.name,
+            name,
+            {LABEL_COMPONENT: "backup", LABEL_NAME: name},
+            12345,
+            23456,
+            backups_spec,
+            None,
+            True,
+            logging.getLogger(__name__),
         )
         await assert_wait_for(
             True,
@@ -108,24 +103,18 @@ class TestBackup:
         )
 
     async def test_not_enabled(self, faker, namespace, api_client):
-        apps = AppsV1Api(api_client)
-        batchv1_beta1 = BatchV1beta1Api(api_client)
         name = faker.domain_word()
 
-        ret = await asyncio.gather(
-            *create_backups(
-                apps,
-                batchv1_beta1,
-                None,
-                namespace.metadata.name,
-                name,
-                {},
-                12345,
-                23456,
-                {},
-                None,
-                True,
-                logging.getLogger(__name__),
-            )
+        ret = await create_backups(
+            None,
+            namespace.metadata.name,
+            name,
+            {},
+            12345,
+            23456,
+            {},
+            None,
+            True,
+            logging.getLogger(__name__),
         )
-        assert ret == []
+        assert ret == ()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -145,14 +145,8 @@ async def test_bootstrap_license(
     )
 
 
-@mock.patch("crate.operator.bootstrap.bootstrap_license")
 async def test_bootstrap_users(
-    bootstrap_license_mock: mock.AsyncMock,
-    faker,
-    namespace,
-    cleanup_handler,
-    kopf_runner,
-    api_client,
+    faker, namespace, cleanup_handler, kopf_runner, api_client,
 ):
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import asyncio
 import logging
 import string
 from typing import Set
@@ -74,7 +73,7 @@ class TestConfigMaps:
         core = CoreV1Api(api_client)
         name = faker.domain_word()
         await create_sql_exporter_config(
-            core, None, namespace.metadata.name, name, {}, logging.getLogger(__name__)
+            None, namespace.metadata.name, name, {}, logging.getLogger(__name__)
         )
         await assert_wait_for(
             True,
@@ -111,15 +110,8 @@ class TestDebugVolume:
             )
         )
 
-        pv, pvc = await asyncio.gather(
-            *create_debug_volume(
-                core,
-                None,
-                namespace.metadata.name,
-                name,
-                {},
-                logging.getLogger(__name__),
-            )
+        await create_debug_volume(
+            None, namespace.metadata.name, name, {}, logging.getLogger(__name__),
         )
         await assert_wait_for(
             True, self.does_pv_exist, core, f"temp-pv-{namespace.metadata.name}-{name}",
@@ -602,7 +594,6 @@ class TestStatefulSet:
         cluster_name = faker.domain_word()
         node_name = faker.domain_word()
         await create_statefulset(
-            apps,
             None,
             namespace.metadata.name,
             name,
@@ -712,20 +703,18 @@ class TestServices:
     async def test_create(self, faker, namespace, api_client):
         core = CoreV1Api(api_client)
         name = faker.domain_word()
-        s_data, s_discovery = await asyncio.gather(
-            *create_services(
-                core,
-                None,
-                namespace.metadata.name,
-                name,
-                {},
-                1,
-                2,
-                3,
-                faker.domain_name(),
-                logging.getLogger(__name__),
-            )
+        await create_services(
+            None,
+            namespace.metadata.name,
+            name,
+            {},
+            1,
+            2,
+            3,
+            faker.domain_name(),
+            logging.getLogger(__name__),
         )
+
         await assert_wait_for(
             True,
             self.do_services_exist,
@@ -750,12 +739,7 @@ class TestSystemUser:
         password = faker.password(length=12)
         with mock.patch("crate.operator.create.gen_password", return_value=password):
             secret = await create_system_user(
-                core,
-                None,
-                namespace.metadata.name,
-                name,
-                {},
-                logging.getLogger(__name__),
+                None, namespace.metadata.name, name, {}, logging.getLogger(__name__),
             )
         await assert_wait_for(
             True,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,8 +51,7 @@ async def does_namespace_exist(core, namespace: str) -> bool:
     return namespace in (ns.metadata.name for ns in namespaces.items)
 
 
-async def create_local_fs_storage_class():
-    sapi = StorageV1Api()
+async def create_local_fs_storage_class(sapi: StorageV1Api):
     await call_kubeapi(
         sapi.create_storage_class,
         logger,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Historically, the create handler for clusters was implemented in a
best-effort and with a bit of a "it'll be fine" approach. Kubernetes
resources were created and when they already existed that was fine. When
the create handler failed, though, the whole handler was being retried,
including the creation of already existing resources.

Now, with this change, only the individual sub-handlers will be retried,
making the process more efficient. The handler is now reentrant.

Unlike attempted in 07720e3080047c765211f6c56d70000b8b3a5043, the
ApiClient is now instantiated inside the individual sub-handlers, to
ensure a connection is available and open. Otherwise, sub-handlers will
fail with a `RuntimeError`: "Session is closed".

Refs #48
Refs 07720e3080047c765211f6c56d70000b8b3a5043

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
