### PR TITLE
Preserve keys in annotations, labels, and settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Fixed a bug in the CrateDB CustomResourceDefinition which would prevent
+  annotations, labels, or settings in the node or cluster specs to be
+  preserved.
+
 * Renamed the ``kopf.zalando.org/last-handled-configuration`` annotation, which
   Kopf uses to track changes, to ``operator.cloud.crate.io/last``.
 

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -152,6 +152,7 @@ spec:
                 settings:
                   description: Additional settings to apply to all nodes in the cluster.
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 ssl:
                   properties:
                     keystore:
@@ -226,9 +227,11 @@ spec:
                       annotations:
                         description: Additional annotations to put on the corresponding pods.
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       labels:
                         description: Additional labels to put on the corresponding pods.
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: Uniquely identifying name of this type of node.
                         pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
@@ -274,6 +277,7 @@ spec:
                       settings:
                         description: Additional settings to apply to all nodes of that type in the cluster.
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                     required:
                     - name
                     - replicas
@@ -286,9 +290,11 @@ spec:
                     annotations:
                       description: Additional annotations to put on the corresponding pods.
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     labels:
                       description: Additional labels to put on the corresponding pods.
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     replicas:
                       description: Number of master nodes. Should be an odd number.
                       minimum: 3
@@ -330,6 +336,7 @@ spec:
                     settings:
                       description: Additional settings to apply to all master nodes in the cluster.
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   required:
                   - replicas
                   - resources


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

With Kubernetes version 1.16, keys in objects would only be preserved
if they are either defined in the CustomResourceDefinition or if the
`x-kubernetes-preserve-unknown-fields` key in the object is set to
`true`. The following fields did not specify either keys or the magic
flag, thus never retained any value, rendering them useless.

* `.spec.cluster.settings`
* `.spec.nodes.data.*.annotations`
* `.spec.nodes.data.*.labels`
* `.spec.nodes.data.*.settings`
* `.spec.nodes.master.annotations`
* `.spec.nodes.master.labels`
* `.spec.nodes.master.settings`


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
