### PR TITLE
Use zone attribute instead of fault domain on Azure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Change the Pod spreading on Azure to use the underlying Azure zone instead of
+  the fault/failure domain.
+
 * Fixed configuration parsing of the :envvar:`KUBECONFIG` environment variable.
 
 * Fixed a bug in the CrateDB CustomResourceDefinition which would prevent

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -395,10 +395,10 @@ def get_statefulset_crate_command(
 
     if config.CLOUD_PROVIDER == CloudProvider.AWS:
         url = "http://169.254.169.254/latest/meta-data/placement/availability-zone"
-        settings["-Cnode.attr.zone"] = f"$(curl -q '{url}')"
+        settings["-Cnode.attr.zone"] = f"$(curl -s '{url}')"
     elif config.CLOUD_PROVIDER == CloudProvider.AZURE:
-        url = "http://169.254.169.254/metadata/instance/compute/platformFaultDomain?api-version=2020-06-01&format=text"  # noqa
-        settings["-Cnode.attr.zone"] = f"$(curl -q '{url}' -H 'Metadata: true')"
+        url = "http://169.254.169.254/metadata/instance/compute/zone?api-version=2020-06-01&format=text"  # noqa
+        settings["-Cnode.attr.zone"] = f"$(curl -s '{url}' -H 'Metadata: true')"
 
     return ["/docker-entrypoint.sh", "crate"] + [
         f"{k}={v}" for k, v in settings.items()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -407,7 +407,7 @@ class TestStatefulSetCrateCommand:
             ),
             (
                 CloudProvider.AZURE,
-                "http://169.254.169.254/metadata/instance/compute/platformFaultDomain?api-version=2020-06-01&format=text",  # noqa
+                "http://169.254.169.254/metadata/instance/compute/zone?api-version=2020-06-01&format=text",  # noqa
             ),
         ],
     )
@@ -430,7 +430,7 @@ class TestStatefulSetCrateCommand:
         additional_args = ""
         if provider == CloudProvider.AZURE:
             additional_args = " -H 'Metadata: true'"
-        assert f"-Cnode.attr.zone=$(curl -q '{url}'{additional_args})" in cmd
+        assert f"-Cnode.attr.zone=$(curl -s '{url}'{additional_args})" in cmd
 
 
 class TestStatefulSetCrateEnv:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

When using an AKS cluster created with `az aks create --zones 1 2 3`,
the various K8s nodes in different zones may share the fault domain.
That means, even if they are spread in different zones, and thus have a
high redundancy, that node attribute can't be used for replication
settings in CrateDB. Hence, using the zone attribute.


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
