### PR TITLE
Update bootstrapping of users to add label to secrets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,9 @@ Changelog
 Unreleased
 ----------
 
-* Kubernetes Secrets, that contain passwords used by CrateDB users, will
-  receive a ``operator.cloud.crate.io/user-password`` label on resume.
+* To allow CrateDB user password updates, Kubernetes Secrets referenced in the
+  ``.spec.users`` section of a CrateDB custom resource, will have a label
+  ``operator.cloud.crate.io/user-password`` applied.
 
 * Change the Pod spreading on Azure to use the underlying Azure zone instead of
   the fault/failure domain.

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -30,6 +30,7 @@ from psycopg2 import DatabaseError, OperationalError
 from crate.operator.constants import (
     API_GROUP,
     BACKOFF_TIME,
+    LABEL_USER_PASSWORD,
     RESOURCE_CRATEDB,
     SYSTEM_USERNAME,
 )
@@ -259,3 +260,13 @@ async def test_bootstrap_users(
     await assert_wait_for(
         True, does_user_exist, host, password2, username2, timeout=BACKOFF_TIME * 3
     )
+
+    secret_user_1 = await core.read_namespaced_secret(
+        namespace=namespace.metadata.name, name=f"user-{name}-1"
+    )
+    secret_user_2 = await core.read_namespaced_secret(
+        namespace=namespace.metadata.name, name=f"user-{name}-2"
+    )
+
+    assert LABEL_USER_PASSWORD in secret_user_1.metadata.labels
+    assert LABEL_USER_PASSWORD in secret_user_2.metadata.labels


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Update bootstrapping of the users to set the ``cloud.crate.io/user-password: true`` label to the secrets of each user.

Story: https://trello.com/c/s8qWFI5L/102-8-password-recovery-for-cloud-clusters
Planning: https://github.com/crate/cloud-api/issues/1488

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
