### PR TITLE
Allow overriding node.attr.zone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 Unreleased
 ----------
 
+* Fixed an inconsistent behavior where the configuration option
+  :envvar:`CLOUD_PROVIDER` would override an explicitly defined
+  ``node.attr.zone`` in either ``.spec.cluster.settings``,
+  ``.spec.nodes.master.settings``, or ``.spec.nodes.data.*.settings``.
+
 * To allow CrateDB user password updates, Kubernetes Secrets referenced in the
   ``.spec.users`` section of a CrateDB custom resource, will have a label
   ``operator.cloud.crate.io/user-password`` applied.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -43,6 +43,21 @@ expected to use upper-case letters and must be prefixed with
    - ``aws``
    - ``azure``
 
+   Under the hood, the operator will pass a ``zone`` attribute to all CrateDB
+   nodes. This attribute can also be defined explicitly or override the one set
+   by the operator. To do this on a cluster level, set ``.spec.cluster.settings``:
+
+   .. code-block:: yaml
+
+      kind: CrateDB
+      spec:
+        cluster:
+          settings:
+            node.attr.zone: "some-value"
+
+   To set or override the attribute on a node type level, set it in
+   ``.spec.nodes.master.settings`` or ``.spec.nodes.data.*.settings``.
+
 .. envvar:: CLUSTER_BACKUP_IMAGE
 
    (**Required**)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Before this change, even if you specified a node.attr.zone parameter it would have been explicitly overridden by the operator.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
