### PR TITLE
Make cluster_backup_image config optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Made ``CLUSTER_BACKUP_IMAGE`` configuration parameter optional to remove
+  dependency on external Docker image.
+
 * Will now pass the ``WEBHOOK_URL`` and credentials to the created backup cronjob.
 
 * Watch on Kubernetes Secrets that have the
@@ -17,10 +20,10 @@ Unreleased
   ``.spec.nodes.master.settings``, or ``.spec.nodes.data.*.settings``.
 
 * To allow CrateDB user password updates, Kubernetes Secrets referenced in the
-  ``.spec.users`` section of a CrateDB custom resource, will have a label
-  ``operator.cloud.crate.io/user-password`` applied.
+  ``.spec.users`` section of a CrateDB custom resource, will have a
+  ``operator.cloud.crate.io/user-password`` label applied.
 
-* Change the Pod spreading on Azure to use the underlying Azure zone instead of
+* Changed the pod spreading on Azure to use the underlying Azure zone instead of
   the fault/failure domain.
 
 * Fixed configuration parsing of the :envvar:`KUBECONFIG` environment variable.
@@ -47,6 +50,7 @@ Unreleased
 
 * Fixed a bug that would prevent the version of the Docker image of the
   ``mkdir-heapdump`` init container to be updated when a cluster is upgraded.
+
 
 1.0b4 (2020-11-03)
 ------------------

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -44,8 +44,8 @@ class Config:
     #: AWS pass the availability zone as a CrateDB node attribute.
     CLOUD_PROVIDER: Optional[CloudProvider] = None
 
-    #: The Docker image that contians scripts to run cluster backups.
-    CLUSTER_BACKUP_IMAGE: str
+    #: The Docker image that contains scripts to run cluster backups.
+    CLUSTER_BACKUP_IMAGE: Optional[str] = None
 
     #: The volume size for the ``PersistentVolume`` that is used as a storage
     #: location for Java heap dumps.
@@ -125,7 +125,9 @@ class Config:
                     f"'{cloud_provider}'. Needs to be of {allowed}."
                 )
 
-        self.CLUSTER_BACKUP_IMAGE = self.env("CLUSTER_BACKUP_IMAGE")
+        self.CLUSTER_BACKUP_IMAGE = self.env(
+            "CLUSTER_BACKUP_IMAGE", default=self.CLUSTER_BACKUP_IMAGE
+        )
 
         debug_volume_size = self.env(
             "DEBUG_VOLUME_SIZE", default=str(self.DEBUG_VOLUME_SIZE)

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -354,25 +354,30 @@ async def cluster_create(
     )
 
     if "backups" in spec:
-        backup_metrics_labels = base_labels.copy()
-        backup_metrics_labels[LABEL_COMPONENT] = "backup"
-        backup_metrics_labels.update(meta.get("labels", {}))
-        kopf.register(
-            fn=subhandler_partial(
-                create_backups,
-                owner_references,
-                namespace,
-                name,
-                backup_metrics_labels,
-                http_port,
-                prometheus_port,
-                spec["backups"],
-                image_pull_secrets,
-                "ssl" in spec["cluster"],
-                logger,
-            ),
-            id="backup",
-        )
+        if config.CLUSTER_BACKUP_IMAGE is None:
+            logger.info(
+                "Not deploying backup tools because no backup image is defined."
+            )
+        else:
+            backup_metrics_labels = base_labels.copy()
+            backup_metrics_labels[LABEL_COMPONENT] = "backup"
+            backup_metrics_labels.update(meta.get("labels", {}))
+            kopf.register(
+                fn=subhandler_partial(
+                    create_backups,
+                    owner_references,
+                    namespace,
+                    name,
+                    backup_metrics_labels,
+                    http_port,
+                    prometheus_port,
+                    spec["backups"],
+                    image_pull_secrets,
+                    "ssl" in spec["cluster"],
+                    logger,
+                ),
+                id="backup",
+            )
 
 
 @kopf.on.update(API_GROUP, "v1", RESOURCE_CRATEDB)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -3,7 +3,7 @@ Configuration
 
 The configuration for the CrateDB Kubernetes Operator follows the `12 Factor
 Principles`_ and uses environment variables. All environment variables are
-expected to use upper-case letters and must be prefixed with
+expected to use upper case letters and must be prefixed with
 ``CRATEDB_OPERATOR_``.
 
 .. envvar:: BOOTSTRAP_TIMEOUT
@@ -59,8 +59,6 @@ expected to use upper-case letters and must be prefixed with
    ``.spec.nodes.master.settings`` or ``.spec.nodes.data.*.settings``.
 
 .. envvar:: CLUSTER_BACKUP_IMAGE
-
-   (**Required**)
 
    When enabling backups for a cluster, the operator deploys a Prometheus_
    exporter to be scraped for backup metrics, and a Kubernetes CronJob that


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

https://github.com/crate/crate-operator/issues/109

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
