### PR TITLE
Update permissions of the service account to be able to watch secrets

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -68,6 +68,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Update permissions of the service account to be able to watch secrets.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
