### PR TITLE
Pass the webhook params to the backup job

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Will now pass the ``WEBHOOK_URL`` and credentials to the created backup cronjob.
+
 * Watch on Kubernetes Secrets that have the
   ``operator.cloud.crate.io/user-password`` label assigned and update the users
   of all CrateDB resources in the same namespace if the password changed.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -64,7 +64,9 @@ expected to use upper-case letters and must be prefixed with
 
    When enabling backups for a cluster, the operator deploys a Prometheus_
    exporter to be scraped for backup metrics, and a Kubernetes CronJob that
-   creates backups every defined interval. This variable needs to point to a
+   creates backups every defined interval. If :envvar:`WEBHOOK_URL` and
+   related credentials are specified, the backup CronJob will post backup
+   creation events back to the webhook URL. This variable needs to point to a
    Docker image *and* tag to use it for the exporter and CronJob.
 
 .. envvar:: DEBUG_VOLUME_SIZE


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

We want the backup jobs to notify us when they are complete (or failed). For this, pass on the webhook configuration that is already present in the operator to the created cronjob.

The params are passed as plain text variables since there's no obvious benefit in passing them as secrets (and it's much harder to do in a generic way).


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
