### PR TITLE
Use default backoff time when raising TemporaryError

### DIFF
--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -24,7 +24,7 @@ from kubernetes_asyncio.stream import WsApiClient
 from psycopg2.extensions import QuotedString
 
 from crate.operator.config import config
-from crate.operator.constants import BACKOFF_TIME, SYSTEM_USERNAME
+from crate.operator.constants import CONNECT_TIMEOUT, SYSTEM_USERNAME
 from crate.operator.cratedb import create_user, get_connection
 from crate.operator.utils.kubeapi import (
     ensure_user_password_label,
@@ -280,7 +280,7 @@ async def bootstrap_users(
     """
     host = await get_host(core, namespace, name)
     password = await get_system_user_password(core, namespace, name)
-    async with get_connection(host, password, timeout=BACKOFF_TIME / 4.0) as conn:
+    async with get_connection(host, password, timeout=CONNECT_TIMEOUT) as conn:
         async with conn.cursor() as cursor:
             for user_spec in users:
                 username = user_spec["name"]

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -28,7 +28,7 @@ LABEL_USER_PASSWORD = f"operator.{API_GROUP}/user-password"
 
 SYSTEM_USERNAME = "system"
 
-BACKOFF_TIME = 60.0
+CONNECT_TIMEOUT = 10.0
 
 
 class CloudProvider(str, enum.Enum):

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -23,7 +23,6 @@ from kubernetes_asyncio.client import CoreV1Api, V1PodList
 from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.constants import (
-    BACKOFF_TIME,
     LABEL_COMPONENT,
     LABEL_MANAGED_BY,
     LABEL_NAME,
@@ -163,8 +162,7 @@ async def restart_cluster(
         # of the Pod.
         await core.delete_namespaced_pod(namespace=namespace, name=next_pod_name)
         raise kopf.TemporaryError(
-            f"Waiting for pod {next_pod_name} ({next_pod_uid}) to be terminated.",
-            delay=BACKOFF_TIME,
+            f"Waiting for pod {next_pod_name} ({next_pod_uid}) to be terminated."
         )
     elif next_pod_name in all_pod_names:
         total_nodes = get_total_nodes_count(old["spec"]["nodes"])
@@ -188,13 +186,10 @@ async def restart_cluster(
                 patch.status["pendingPods"] = None  # Remove attribute from `.status`
                 return
         else:
-            raise kopf.TemporaryError(
-                "Cluster is not healthy yet.", delay=BACKOFF_TIME / 2.0
-            )
+            raise kopf.TemporaryError("Cluster is not healthy yet.")
     else:
         raise kopf.TemporaryError(
-            "Scheduling rerun because there are pods to be restarted",
-            delay=BACKOFF_TIME,
+            "Scheduling rerun because there are pods to be restarted"
         )
 
 

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -26,7 +26,6 @@ from kubernetes_asyncio.client import AppsV1Api, CoreV1Api, V1Container, V1State
 from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.stream import WsApiClient
 
-from crate.operator.constants import BACKOFF_TIME
 from crate.operator.cratedb import connection_factory, is_cluster_healthy
 from crate.operator.operations import get_total_nodes_count
 from crate.operator.utils import quorum
@@ -231,7 +230,7 @@ async def check_for_deallocation(
     if rows:
         allocations = ", ".join(f"{row[0]}={row[1]}" for row in rows) or "None"
         logger.info("Current pending allocation %s", allocations)
-        raise kopf.TemporaryError("Pending allocation", delay=BACKOFF_TIME / 2.0)
+        raise kopf.TemporaryError("Pending allocation")
 
 
 async def deallocate_nodes(

--- a/crate/operator/update_user_password.py
+++ b/crate/operator/update_user_password.py
@@ -16,7 +16,7 @@
 
 import logging
 
-from crate.operator.constants import BACKOFF_TIME
+from crate.operator.constants import CONNECT_TIMEOUT
 from crate.operator.cratedb import get_connection, update_user
 from crate.operator.utils.formatting import b64decode
 
@@ -39,7 +39,7 @@ async def update_user_password(
     :param new_password: The new password of the user that should be updated.
     """
     async with get_connection(
-        host, b64decode(old_password), username, timeout=BACKOFF_TIME / 4.0
+        host, b64decode(old_password), username, timeout=CONNECT_TIMEOUT
     ) as conn:
         async with conn.cursor() as cursor:
             logger.info("Updating password for user '%s'", username)

--- a/crate/operator/utils/kubeapi.py
+++ b/crate/operator/utils/kubeapi.py
@@ -21,7 +21,7 @@ from typing import Awaitable, Callable, Optional
 from kubernetes_asyncio.client import ApiException, CoreV1Api, V1ObjectMeta, V1Secret
 
 from crate.operator.config import config
-from crate.operator.constants import BACKOFF_TIME, LABEL_USER_PASSWORD
+from crate.operator.constants import LABEL_USER_PASSWORD
 from crate.operator.utils.formatting import b64decode
 from crate.operator.utils.typing import K8sModel, SecretKeyRef
 
@@ -162,7 +162,7 @@ async def get_public_host(core: CoreV1Api, namespace: str, name: str) -> str:
         except ApiException:
             pass
 
-        await asyncio.sleep(BACKOFF_TIME / 2)
+        await asyncio.sleep(5.0)
 
 
 async def get_host(core: CoreV1Api, namespace: str, name: str) -> str:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -29,7 +29,6 @@ from psycopg2 import DatabaseError, OperationalError
 
 from crate.operator.constants import (
     API_GROUP,
-    BACKOFF_TIME,
     LABEL_USER_PASSWORD,
     RESOURCE_CRATEDB,
     SYSTEM_USERNAME,
@@ -38,7 +37,7 @@ from crate.operator.cratedb import get_connection
 from crate.operator.utils.formatting import b64encode
 from crate.operator.utils.kubeapi import get_public_host, get_system_user_password
 
-from .utils import assert_wait_for
+from .utils import DEFAULT_TIMEOUT, assert_wait_for
 
 pytestmark = [pytest.mark.k8s, pytest.mark.asyncio]
 
@@ -142,7 +141,7 @@ async def test_bootstrap_license(
         f"crate-data-data-{name}-0",
         False,
         {"secretKeyRef": {"key": "license", "name": f"license-{name}"}},
-        timeout=BACKOFF_TIME * 3,
+        timeout=DEFAULT_TIMEOUT * 3,
     )
 
 
@@ -238,7 +237,8 @@ async def test_bootstrap_users(
 
     host = await asyncio.wait_for(
         get_public_host(core, namespace.metadata.name, name),
-        timeout=BACKOFF_TIME * 5,  # It takes a while to retrieve an external IP on AKS.
+        # It takes a while to retrieve an external IP on AKS.
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     password_system = await get_system_user_password(
@@ -250,15 +250,15 @@ async def test_bootstrap_users(
         host,
         password_system,
         SYSTEM_USERNAME,
-        timeout=BACKOFF_TIME * 5,
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     await assert_wait_for(
-        True, does_user_exist, host, password1, username1, timeout=BACKOFF_TIME * 3
+        True, does_user_exist, host, password1, username1, timeout=DEFAULT_TIMEOUT * 3
     )
 
     await assert_wait_for(
-        True, does_user_exist, host, password2, username2, timeout=BACKOFF_TIME * 3
+        True, does_user_exist, host, password2, username2, timeout=DEFAULT_TIMEOUT * 3
     )
 
     secret_user_1 = await core.read_namespaced_secret(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -22,11 +22,11 @@ import pytest
 from aiopg import Connection
 from kubernetes_asyncio.client import CoreV1Api, CustomObjectsApi
 
-from crate.operator.constants import API_GROUP, BACKOFF_TIME, RESOURCE_CRATEDB
+from crate.operator.constants import API_GROUP, RESOURCE_CRATEDB
 from crate.operator.cratedb import connection_factory, get_healthiness
 from crate.operator.utils.kubeapi import get_public_host, get_system_user_password
 
-from .utils import assert_wait_for
+from .utils import DEFAULT_TIMEOUT, assert_wait_for
 
 
 async def do_pods_exist(core: CoreV1Api, namespace: str, expected: Set[str]) -> bool:
@@ -115,7 +115,8 @@ async def test_restart_cluster(
 
     host = await asyncio.wait_for(
         get_public_host(core, namespace.metadata.name, name),
-        timeout=BACKOFF_TIME * 5,  # It takes a while to retrieve an external IP on AKS.
+        # It takes a while to retrieve an external IP on AKS.
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     password = await get_system_user_password(core, namespace.metadata.name, name)
@@ -137,7 +138,7 @@ async def test_restart_cluster(
         is_cluster_healthy,
         connection_factory(host, password),
         err_msg="Cluster wasn't healthy after 5 minutes.",
-        timeout=BACKOFF_TIME * 5,
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     pods = await core.list_namespaced_pod(namespace=namespace.metadata.name)
@@ -164,5 +165,5 @@ async def test_restart_cluster(
         core,
         namespace.metadata.name,
         original_pods,
-        timeout=BACKOFF_TIME * 15,
+        timeout=DEFAULT_TIMEOUT * 15,
     )

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -23,7 +23,7 @@ import pytest
 from aiopg import Connection
 from kubernetes_asyncio.client import CoreV1Api, CustomObjectsApi
 
-from crate.operator.constants import API_GROUP, BACKOFF_TIME, RESOURCE_CRATEDB
+from crate.operator.constants import API_GROUP, RESOURCE_CRATEDB
 from crate.operator.cratedb import (
     connection_factory,
     get_healthiness,
@@ -32,7 +32,7 @@ from crate.operator.cratedb import (
 from crate.operator.scale import parse_replicas
 from crate.operator.utils.kubeapi import get_public_host, get_system_user_password
 
-from .utils import assert_wait_for
+from .utils import DEFAULT_TIMEOUT, assert_wait_for
 
 
 @pytest.mark.parametrize(
@@ -160,7 +160,8 @@ async def test_scale_cluster(
 
     host = await asyncio.wait_for(
         get_public_host(core, namespace.metadata.name, name),
-        timeout=BACKOFF_TIME * 5,  # It takes a while to retrieve an external IP on AKS.
+        # It takes a while to retrieve an external IP on AKS.
+        timeout=DEFAULT_TIMEOUT * 5,
     )
     password = await get_system_user_password(core, namespace.metadata.name, name)
 
@@ -170,7 +171,7 @@ async def test_scale_cluster(
         connection_factory(host, password),
         repl_master_from + repl_hot_from + repl_cold_from,
         err_msg="Cluster wasn't healthy after 5 minutes.",
-        timeout=BACKOFF_TIME * 5,
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     patch_body = []
@@ -213,5 +214,5 @@ async def test_scale_cluster(
         connection_factory(host, password),
         repl_master_to + repl_hot_to + repl_cold_to,
         err_msg="Cluster wasn't healthy after 5 minutes.",
-        timeout=BACKOFF_TIME * 5,
+        timeout=DEFAULT_TIMEOUT * 5,
     )

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -25,17 +25,12 @@ from kubernetes_asyncio.client import (
 )
 from psycopg2 import DatabaseError, OperationalError
 
-from crate.operator.constants import (
-    API_GROUP,
-    BACKOFF_TIME,
-    LABEL_USER_PASSWORD,
-    RESOURCE_CRATEDB,
-)
+from crate.operator.constants import API_GROUP, LABEL_USER_PASSWORD, RESOURCE_CRATEDB
 from crate.operator.cratedb import get_connection
 from crate.operator.utils.formatting import b64encode
 from crate.operator.utils.kubeapi import get_public_host
 
-from .utils import assert_wait_for
+from .utils import DEFAULT_TIMEOUT, assert_wait_for
 
 pytestmark = [pytest.mark.k8s, pytest.mark.asyncio]
 
@@ -127,7 +122,8 @@ async def test_update_cluster_password(
 
     host = await asyncio.wait_for(
         get_public_host(core, namespace.metadata.name, name),
-        timeout=BACKOFF_TIME * 5,  # It takes a while to retrieve an external IP on AKS.
+        # It takes a while to retrieve an external IP on AKS.
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     await core.patch_namespaced_secret(
@@ -144,5 +140,5 @@ async def test_update_cluster_password(
         host,
         new_password,
         username,
-        timeout=BACKOFF_TIME * 5,
+        timeout=DEFAULT_TIMEOUT * 5,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,16 +19,16 @@ import logging
 
 from kubernetes_asyncio.client import StorageV1Api, V1ObjectMeta, V1StorageClass
 
-from crate.operator.constants import BACKOFF_TIME
 from crate.operator.utils.kubeapi import call_kubeapi
 
 logger = logging.getLogger(__name__)
 
 LOCAL_FS_STORAGE_CLASS_NAME = "crate-operator-local-fs"
+DEFAULT_TIMEOUT = 60
 
 
 async def assert_wait_for(
-    condition, coro_func, *args, err_msg="", timeout=BACKOFF_TIME, **kwargs
+    condition, coro_func, *args, err_msg="", timeout=DEFAULT_TIMEOUT, **kwargs
 ):
     ret_val = await coro_func(*args, **kwargs)
     duration = 0.0


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


The [default value for backoff](https://github.com/nolar/kopf/blob/a6d302bbf1efc39e371167ed66dbbfadff8a66ca/kopf/reactor/handling.py#L21) is defined in Kopf as `1min`, which is the
same as the value we provided.
Therefore we can get rid of the `BACKOFF_TIME` constant and instead use
dedicated a `CONNECT_TIMEOUT` when creating new database connections and
a `DEFAULT_TIMEOUT` for tests.




## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
