### PR TITLE
Remove username validation from the custom resource definition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Removed username validation from the custom resource definition.
+  Since CrateDB accepts every string as a username, we also don't want
+  to validate the username in the crate-operator.
+
 1.0 (2020-12-03)
 ----------------
 

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -383,7 +383,6 @@ spec:
                 properties:
                   name:
                     description: The username for a CrateDB cluster user.
-                    pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                     type: string
                   password:
                     properties:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

#### Remove username validation from the custom resource definition.

Since CrateDB accepts every string as a username we also don't want
that check in the crate-operator.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
