### PR TITLE
Missing await meant we're not sending any notifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Fixed the notifications, which were broken for some time due to a missing 'await'
+
 1.1.0 (2021-03-02)
 ------------------
 

--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -98,7 +98,7 @@ class StateBasedSubHandler(abc.ABC):
                 notification["event"],
                 notification["payload"],
             )
-            webhook_client.send_notification(
+            await webhook_client.send_notification(
                 self.namespace,
                 self.name,
                 notification["event"],


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
