### PR TITLE
Change the external traffic policy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Changed the external traffic policy to local. This allows seeing the actual IP of
+  the client that is connecting to CrateDB.
+
 * Fixed the notifications, which were broken for some time due to a missing 'await'
 
 1.1.0 (2021-03-02)

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -815,6 +815,7 @@ def get_data_service(
             ],
             selector={LABEL_COMPONENT: "cratedb", LABEL_NAME: name},
             type="LoadBalancer",
+            external_traffic_policy="Local",
         ),
     )
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Changing it to "Local" keeps the IP address of the actual client connecting, instead of showing the node IP.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
