### PR TITLE
Prevent scaling/upgrading/restarting when a snapshot/backup is in progress

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,18 @@ Changelog
 Unreleased
 ----------
 
+* Added a check for any running snapshots (either k8s jobs or CREATE SNAPSHOT stmts.)
+  before performing scaling/upgrades/restarts. This ensures we don't inadvertently
+  interfere with an existing snapshot operation
+
+* Fixed a bug that caused us not to wait for a cluster to be healthy when performing
+  scaling operations (due to a missing await).
+
+* Refactored some of the tests, specifically reusing repetitive operations.
+
+* Removed handling of master & cold replicas from integration tests as these are not
+  used in practice.
+
 1.2.0 (2021-03-22)
 ------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -92,6 +92,9 @@ class Config:
     #: HTTP Basic Auth username for web requests made to :attr:`WEBHOOK_URL`.
     WEBHOOK_USERNAME: Optional[str] = None
 
+    #: Which table are the running jobs stored in. This is only changed in tests.
+    JOBS_TABLE: str = "sys.jobs"
+
     def __init__(self, *, prefix: str):
         self._prefix = prefix
 
@@ -213,6 +216,7 @@ class Config:
         self.WEBHOOK_USERNAME = self.env(
             "WEBHOOK_USERNAME", default=self.WEBHOOK_USERNAME
         )
+        self.JOBS_TABLE = self.env("JOBS_TABLE", default=self.JOBS_TABLE)
 
     def env(self, name: str, *, default=UNDEFINED) -> str:
         """

--- a/crate/operator/cratedb.py
+++ b/crate/operator/cratedb.py
@@ -171,6 +171,17 @@ async def is_cluster_healthy(
 async def are_snapshots_in_progress(
     conn_factory, logger: logging.Logger
 ) -> Tuple[bool, Optional[str]]:
+    """
+    Check if there are any snapshots in progress by querying sys.jobs
+    (or the configured table for testing purposes).
+
+    Since sys.jobs will also contain the current query (i.e. us selecting from sys.jobs)
+    we also need to exclude our statement.
+
+    :param conn_factory the connection factory to connect to CrateDB
+    :param logger the logger on which we're logging
+    :return A Tuple of the result (Bool) and the statement that is progress (if any).
+    """
     async with conn_factory() as conn:
         async with conn.cursor() as cursor:
             logger.info("Checking if there are running snapshots ...")

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -162,7 +162,8 @@ async def restart_cluster(
         # of the Pod.
         await core.delete_namespaced_pod(namespace=namespace, name=next_pod_name)
         raise kopf.TemporaryError(
-            f"Waiting for pod {next_pod_name} ({next_pod_uid}) to be terminated."
+            f"Waiting for pod {next_pod_name} ({next_pod_uid}) to be terminated.",
+            delay=15,
         )
     elif next_pod_name in all_pod_names:
         total_nodes = get_total_nodes_count(old["spec"]["nodes"])
@@ -186,10 +187,10 @@ async def restart_cluster(
                 patch.status["pendingPods"] = None  # Remove attribute from `.status`
                 return
         else:
-            raise kopf.TemporaryError("Cluster is not healthy yet.")
+            raise kopf.TemporaryError("Cluster is not healthy yet.", delay=30)
     else:
         raise kopf.TemporaryError(
-            "Scheduling rerun because there are pods to be restarted"
+            "Scheduling rerun because there are pods to be restarted", delay=15
         )
 
 

--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -78,7 +78,8 @@ class StateBasedSubHandler(abc.ABC):
         else:
             raise kopf.TemporaryError(
                 f"Waiting to reach state '{self.state}'. "
-                f"Current state '{self._context.state_machine.current}'."
+                f"Current state '{self._context.state_machine.current}'.",
+                delay=30,
             )
 
     @abc.abstractmethod

--- a/crate/operator/utils/state.py
+++ b/crate/operator/utils/state.py
@@ -5,6 +5,7 @@ from crate.operator.webhooks import WebhookEvent, WebhookStatus, WebhookSubPaylo
 
 
 class State(str, Enum):
+    ENSURE_NO_BACKUPS = "ensure_no_backups"
     RESTART = "restart"
     SCALE = "scale"
     UPGRADE = "upgrade"

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -53,6 +53,7 @@ rules:
   resources:
   - configmaps
   - cronjobs
+  - jobs
   - deployments
   - namespaces
   - persistentvolumeclaims

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,7 @@ def load_config():
         "CRATEDB_OPERATOR_JMX_EXPORTER_VERSION": "1.0.0",
         "CRATEDB_OPERATOR_LOG_LEVEL": "DEBUG",
         "CRATEDB_OPERATOR_TESTING": "true",
+        "CRATEDB_OPERATOR_JOBS_TABLE": "test.test_sys_jobs",
     }
     with mock.patch.dict(os.environ, env):
         config.load()


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Before performing scaling/upgrading/restarts, check that:
1. There are any `CREATE SNAPSHOT ...` jobs in CrateDB. If so, waits for them to finish.
2. There is a running k8s job to perform the backup. If so, waits for it to finish. <- Note that this has to be done in addition to the `CREATE SNAPSHOT` check because there is a real possibility of a race condition - it might take up to 30s for the `CREATE SNAPSHOT` to appear once the backup job starts.

This is implemented as an additional state in the cluster update state machine - basically we block in the `ensure_no_backups` state until there are no backups running any more.

Also refactored the ITs somewhat to better reuse code (especially cluster creation).

Also fixed a bug that meant we're not waiting for a cluster to become GREEN before performing scaling (caused by a missing `await`).


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
