### PR TITLE
Allow returning a status from handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Unreleased
 * Removed handling of master & cold replicas from integration tests as these are not
   used in practice.
 
+* Changed how (sub)handlers are treated to allow returning statuses, which get persisted
+  against the CrateDB resource in k8s.
+
 1.2.0 (2021-03-22)
 ------------------
 

--- a/crate/operator/backup.py
+++ b/crate/operator/backup.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional
 
 import kopf
 from kubernetes_asyncio.client import (
@@ -263,13 +263,13 @@ async def create_backups(
     image_pull_secrets: Optional[List[V1LocalObjectReference]],
     has_ssl: bool,
     logger: logging.Logger,
-) -> Union[Tuple[V1beta1CronJob, V1Deployment], Tuple]:
+) -> None:
     backup_aws = backups.get("aws")
     async with ApiClient() as api_client:
         apps = AppsV1Api(api_client)
         batchv1_beta1 = BatchV1beta1Api(api_client)
         if backup_aws:
-            cron = await call_kubeapi(
+            await call_kubeapi(
                 batchv1_beta1.create_namespaced_cron_job,
                 logger,
                 continue_on_conflict=True,
@@ -284,7 +284,7 @@ async def create_backups(
                     has_ssl,
                 ),
             )
-            deployment = await call_kubeapi(
+            await call_kubeapi(
                 apps.create_namespaced_deployment,
                 logger,
                 continue_on_conflict=True,
@@ -300,8 +300,6 @@ async def create_backups(
                     has_ssl,
                 ),
             )
-            return (cron, deployment)
-    return ()
 
 
 class EnsureNoBackupsSubHandler(StateBasedSubHandler):

--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -37,7 +37,7 @@ def subhandler_partial(awaitable: Callable, *args, **kwargs):
 
     @wraps(awaitable)
     async def _wrapper(**_):
-        await awaitable(*args, **kwargs)
+        return await awaitable(*args, **kwargs)
 
     return _wrapper
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -104,8 +104,10 @@ class TestBackup:
 
     async def test_not_enabled(self, faker, namespace, api_client):
         name = faker.domain_word()
+        apps = AppsV1Api(api_client)
+        batchv1_beta1 = BatchV1beta1Api(api_client)
 
-        ret = await create_backups(
+        await create_backups(
             None,
             namespace.metadata.name,
             name,
@@ -117,4 +119,15 @@ class TestBackup:
             True,
             logging.getLogger(__name__),
         )
-        assert ret == ()
+        assert (
+            await self.does_cronjob_exist(
+                batchv1_beta1, namespace.metadata.name, f"create-snapshot-{name}"
+            )
+            is False
+        )
+        assert (
+            await self.does_deployment_exist(
+                apps, namespace.metadata.name, f"backup-metrics-{name}"
+            )
+            is False
+        )

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -768,7 +768,7 @@ class TestSystemUser:
         name = faker.domain_word()
         password = faker.password(length=12)
         with mock.patch("crate.operator.create.gen_password", return_value=password):
-            secret = await create_system_user(
+            await create_system_user(
                 None, namespace.metadata.name, name, {}, logging.getLogger(__name__)
             )
         await assert_wait_for(
@@ -777,6 +777,10 @@ class TestSystemUser:
             core,
             namespace.metadata.name,
             f"user-system-{name}",
+        )
+        secrets = (await core.list_namespaced_secret(namespace.metadata.name)).items
+        secret = next(
+            filter(lambda x: x.metadata.name == f"user-system-{name}", secrets)
         )
         assert b64decode(secret.data["password"]) == password
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -178,6 +178,7 @@ async def insert_test_snapshot_job(conn_factory):
             await cursor.execute(
                 f"INSERT INTO {table_name} (id, stmt) VALUES (1, 'CREATE SNAPSHOT ...')"
             )
+            await cursor.execute(f"REFRESH TABLE {table_name}")
 
 
 async def clear_test_snapshot_jobs(conn_factory):
@@ -186,6 +187,7 @@ async def clear_test_snapshot_jobs(conn_factory):
             table_name = config.JOBS_TABLE
             logger.info(f"Creating {table_name}")
             await cursor.execute(f"DELETE FROM {table_name}")
+            await cursor.execute(f"REFRESH TABLE {table_name}")
 
 
 async def create_fake_snapshot_job(api_client, name, namespace):


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Handlers have a facility to store their status. That is stored in the "status" attribute of the resource that is being handled (CrateDB in our case). This was not working before, but is quite useful.

As a result of this change, some handlers had to be adapter to not return large representations (i.e. entire K8s resource objects), because these need to be serialiased and stored against the CrateDB resource (which obviously doesn't work).

The usage of these statuses allows some control of handler execution sequencing, because it is possible to check if a previous handler has succeeded or not, as described [here](https://kopf.readthedocs.io/en/latest/results/).

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
