### PR TITLE
Add PDB for statefulset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Unreleased
 
 * Removed the Context class in favour of simple storing the context as a dictionary.
 
+* Added PodDisruptionBudget to keep a cratedb statefulset up during k8s upgrades.
 
 1.2.0 (2021-03-22)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Added PodDisruptionBudget to keep a cratedb statefulset up during kubernetes upgrades.
+
 * Added a check for any running snapshots (either k8s jobs or CREATE SNAPSHOT stmts.)
   before performing scaling/upgrades/restarts. This ensures we don't inadvertently
   interfere with an existing snapshot operation
@@ -29,7 +31,6 @@ Unreleased
 
 * Removed the Context class in favour of simple storing the context as a dictionary.
 
-* Added PodDisruptionBudget to keep a cratedb statefulset up during k8s upgrades.
 
 1.2.0 (2021-03-22)
 ------------------

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -789,9 +789,9 @@ async def create_statefulset(
             ),
         )
         """
-           A Pod Distruption Budget ensures that when performing Kubernetes cluster maintenance
-           (i.e. upgrades), we make sure to not disrupt more than 1 pod in a StatefulSet 
-           at a time. 
+           A Pod Distruption Budget ensures that when performing Kubernetes cluster
+           maintenance (i.e. upgrades), we make sure to not disrupt more than
+           1 pod in a StatefulSet at a time.
         """
         await call_kubeapi(
             policy.create_namespaced_pod_disruption_budget,

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -788,6 +788,11 @@ async def create_statefulset(
                 ),
             ),
         )
+        """
+           A Pod Distruption Budget ensures that when performing Kubernetes cluster maintenance
+           (i.e. upgrades), we make sure to not disrupt more than 1 pod in a StatefulSet 
+           at a time. 
+        """
         await call_kubeapi(
             policy.create_namespaced_pod_disruption_budget,
             logger,

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -50,6 +50,7 @@ rules:
   - ""
   - apps
   - batch
+  - policy
   resources:
   - configmaps
   - cronjobs
@@ -62,6 +63,7 @@ rules:
   - secrets
   - services
   - statefulsets
+  - poddisruptionbudgets
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Why this is an improvement
A Pod Distruption Budget ensures that when performing Kubernetes cluster maintenance (i.e. upgrades), we make sure to not disrupt more than 1 pod in a StatefulSet at a time. 

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
