### PR TITLE
Prepare release 2.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+2.0.0 (2021-04-15)
+------------------
+
 * Removed the deprecated ``zalando...`` annotations. This will require a 2.0 release.
 
 * Added PodDisruptionBudget to keep a cratedb statefulset up during kubernetes upgrades.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

it's 2.0.0 because we've removed some backwards-compatible kopf annotations we no longer use since 1.0.0.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
