### PR TITLE
New aiopg is actually raising a TimeoutError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fix tests that did not catch the async TimeoutError that aiopg started using
+  following a dependabot-triggered update.
+
 2.1.0 (2021-04-28)
 ------------------
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -49,7 +49,7 @@ async def does_user_exist(host: str, password: str, username: str) -> bool:
                 await cursor.execute("SELECT 1")
                 row = await cursor.fetchone()
                 return bool(row and row[0] == 1)
-    except (DatabaseError, OperationalError):
+    except (DatabaseError, OperationalError, asyncio.exceptions.TimeoutError):
         return False
 
 

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -42,7 +42,7 @@ async def is_password_set(host: str, system_password: str, user: str) -> bool:
                 await cursor.execute("SELECT 1")
                 row = await cursor.fetchone()
                 return bool(row and row[0] == 1)
-    except (DatabaseError, OperationalError):
+    except (DatabaseError, OperationalError, asyncio.exceptions.TimeoutError):
         return False
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -142,7 +142,7 @@ async def is_cluster_healthy(
                 num_nodes = await get_number_of_nodes(cursor)
                 healthines = await get_healthiness(cursor)
                 return expected_num_nodes == num_nodes and healthines in {1, None}
-    except psycopg2.DatabaseError:
+    except (psycopg2.DatabaseError, asyncio.exceptions.TimeoutError):
         return False
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

And we don't handle it.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
