### PR TITLE
Fixing the version of click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ setup(
         "aiopg==1.2.1",
         "bitmath==1.3.3.1",
         "kopf==0.28.3",
+        # kopf depends on an undefined click version, and the latest (8.0.0) has broken
+        # backwards-compatibility. Fixing the version here instead.
+        "click==7.1.2",
         "kubernetes-asyncio==12.1.0",
     ],
     extras_require={


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

kopf depends on the latest, and 8.0.0 broke something that made kopf break in an un-expected way.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
