### PR TITLE
Send a webhook when an external IP is obtained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.python-version
 build/
 develop-eggs/
 dist/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Added a new kopf handler that watches for services getting external IPs
+  (i.e. Load Balancers) and sending a webhook back with that info.
+
 * Fix tests that did not catch the async TimeoutError that aiopg started using
   following a dependabot-triggered update.
 

--- a/crate/operator/edge.py
+++ b/crate/operator/edge.py
@@ -1,0 +1,41 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2020 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from .webhooks import (
+    WebhookEvent,
+    WebhookInfoChangedPayload,
+    WebhookStatus,
+    webhook_client,
+)
+
+
+async def notify_service_ip(
+    namespace: str, cluster_id: str, new_ip: str, logger: logging.Logger
+):
+    """
+    Notify the configured webhooks URL about a service obtaining an IP address.
+    """
+    payload = WebhookInfoChangedPayload(external_ip=new_ip)
+    await webhook_client.send_notification(
+        namespace,
+        cluster_id,
+        WebhookEvent.INFO_CHANGED,
+        payload,
+        WebhookStatus.SUCCESS,
+        logger,
+    )

--- a/crate/operator/webhooks.py
+++ b/crate/operator/webhooks.py
@@ -27,6 +27,7 @@ class WebhookEvent(str, enum.Enum):
     UPGRADE = "upgrade"
     SNAPSHOT = "snapshot"
     DELAY = "delay"
+    INFO_CHANGED = "info_changed"
 
 
 class WebhookStatus(str, enum.Enum):
@@ -62,6 +63,10 @@ class WebhookUpgradePayload(WebhookSubPayload):
     new_version: str
 
 
+class WebhookInfoChangedPayload(WebhookSubPayload):
+    external_ip: str
+
+
 class WebhookPayload(TypedDict):
     event: WebhookEvent
     status: WebhookStatus
@@ -70,6 +75,7 @@ class WebhookPayload(TypedDict):
     scale_data: Optional[WebhookScalePayload]
     upgrade_data: Optional[WebhookUpgradePayload]
     temporary_failure_data: Optional[WebhookTemporaryFailurePayload]
+    info_data: Optional[WebhookInfoChangedPayload]
 
 
 class WebhookClient:
@@ -132,6 +138,7 @@ class WebhookClient:
         scale_data: Optional[WebhookScalePayload] = None,
         upgrade_data: Optional[WebhookUpgradePayload] = None,
         temporary_failure_data: Optional[WebhookTemporaryFailurePayload] = None,
+        info_data: Optional[WebhookInfoChangedPayload] = None,
         logger: logging.Logger,
     ) -> Optional[aiohttp.ClientResponse]:
         """
@@ -166,6 +173,7 @@ class WebhookClient:
             scale_data=scale_data,
             upgrade_data=upgrade_data,
             temporary_failure_data=temporary_failure_data,
+            info_data=info_data,
         )
 
         logger.info(
@@ -231,6 +239,8 @@ class WebhookClient:
             kwargs = {"upgrade_data": sub_payload}
         elif event == WebhookEvent.DELAY:
             kwargs = {"temporary_failure_data": sub_payload}
+        elif event == WebhookEvent.INFO_CHANGED:
+            kwargs = {"info_data": sub_payload}
         else:
             raise ValueError(f"Unknown event '{event}'")
 

--- a/tests/test_load_balancer_updates.py
+++ b/tests/test_load_balancer_updates.py
@@ -1,0 +1,57 @@
+from unittest import mock
+
+import pytest
+from kubernetes_asyncio.client import CoreV1Api, CustomObjectsApi
+
+from crate.operator.webhooks import (
+    WebhookEvent,
+    WebhookInfoChangedPayload,
+    WebhookStatus,
+)
+from tests.utils import DEFAULT_TIMEOUT, assert_wait_for, start_cluster
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+@mock.patch("crate.operator.webhooks.webhook_client.send_notification")
+async def test_get_external_ip(
+    mock_send_notification: mock.AsyncMock,
+    faker,
+    namespace,
+    cleanup_handler,
+    kopf_runner,
+    api_client,
+):
+    """
+    Please note that this test requires having a Load Balancer implementation.
+
+    This will work fine on Azure, however needs MetalLB enabled if running on microk8s.
+    """
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+
+    external_ip, _ = await start_cluster(
+        name, namespace, cleanup_handler, core, coapi, 1, wait_for_healthy=False
+    )
+
+    await assert_wait_for(
+        True,
+        _notification_sent,
+        mock_send_notification,
+        err_msg="Did not notify external IP being added to the service.",
+        timeout=DEFAULT_TIMEOUT * 5,  # can take a while to obtain external IP
+    )
+
+    mock_send_notification.assert_called_once_with(
+        namespace.metadata.name,
+        name,
+        WebhookEvent.INFO_CHANGED,
+        WebhookInfoChangedPayload(external_ip=external_ip),
+        WebhookStatus.SUCCESS,
+        mock.ANY,
+    )
+
+
+async def _notification_sent(mock_send_notification: mock.AsyncMock):
+    return mock_send_notification.call_count > 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,6 +71,7 @@ async def start_cluster(
     coapi: CustomObjectsApi,
     hot_nodes: int = 0,
     crate_version: str = CRATE_VERSION,
+    wait_for_healthy: bool = True,
 ) -> Tuple[str, str]:
     # Clean up persistent volume after the test
     cleanup_handler.append(
@@ -121,14 +122,15 @@ async def start_cluster(
     )
     password = await get_system_user_password(core, namespace.metadata.name, name)
 
-    await assert_wait_for(
-        True,
-        is_cluster_healthy,
-        connection_factory(host, password),
-        hot_nodes,
-        err_msg="Cluster wasn't healthy after 5 minutes.",
-        timeout=DEFAULT_TIMEOUT * 5,
-    )
+    if wait_for_healthy:
+        await assert_wait_for(
+            True,
+            is_cluster_healthy,
+            connection_factory(host, password),
+            hot_nodes,
+            err_msg="Cluster wasn't healthy after 5 minutes.",
+            timeout=DEFAULT_TIMEOUT * 5,
+        )
 
     return host, password
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This is required in the cloud to update DNS for Edge regions which do not run external-dns.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
