### PR TITLE
Add ability to re-throw errors for webhooks

### DIFF
--- a/crate/operator/edge.py
+++ b/crate/operator/edge.py
@@ -38,4 +38,5 @@ async def notify_service_ip(
         payload,
         WebhookStatus.SUCCESS,
         logger,
+        unsafe=True,
     )

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -560,6 +560,7 @@ async def secret_update(
     "services",
     labels={LABEL_PART_OF: "cratedb", LABEL_MANAGED_BY: "crate-operator"},
     field="status.loadBalancer.ingress",
+    timeout=3600,
 )
 async def service_external_ip_update(
     namespace: str,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

For most webhooks we don't care about them failing - they are simply FYIs about something working or not. Some others, OTOH, are important - i.e. an IP being obtained. These we want to be retried, so re-throw any exceptions that happen.
    
Also clarified some of the logging messages - namely do not need to log the name/namespace as these are always prepended by kopf.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
