### PR TITLE
Prepare 2.2.0 of the operator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,11 +5,16 @@ Changelog
 Unreleased
 ----------
 
+2.2.0 (2021-06-23)
+------------------
+
 * Added a new kopf handler that watches for services getting external IPs
   (i.e. Load Balancers) and sending a webhook back with that info.
 
 * Fix tests that did not catch the async TimeoutError that aiopg started using
   following a dependabot-triggered update.
+
+* Added an ability to throw exceptions from webhooks, for handlers that require it.
 
 2.1.0 (2021-04-28)
 ------------------

--- a/tests/test_load_balancer_updates.py
+++ b/tests/test_load_balancer_updates.py
@@ -50,6 +50,7 @@ async def test_get_external_ip(
         WebhookInfoChangedPayload(external_ip=external_ip),
         WebhookStatus.SUCCESS,
         mock.ANY,
+        unsafe=True,
     )
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
