### PR TITLE
Use the hostname if ip is not available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fixed a problem with reporting the load balancer ip (hostname) for AWS EKS.
+  EKS gives load balancers hostnames and not IPs. We treat these as one and the same.
+
 2.2.0 (2021-06-23)
 ------------------
 

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -595,6 +595,12 @@ async def service_external_ip_update(
         logger.warning(f"No IP received for LoadBalancer {diff}")
         return
 
+    # Most k8s clusters give out IP addresses to LoadBalancer services, however some
+    # (i.e. EKS) give hostnames instead. As far as Crate is concerned, these are
+    # treated the same.
     # TODO: Multiple IPs?
-    ip = op.new[0]["ip"]
+    ip = op.new[0].get("ip") or op.new[0].get("hostname")
+    if not ip:
+        logger.warning(f"Load balancer got neither IP nor hostname {op}")
+        return
     await notify_service_ip(namespace, cluster_id, ip, logger)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

EKS does not use IP addresses and gives out hostnames to load balancers instead. The rest of our stack is prepared to deal with this, but not this handler.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
