### PR TITLE
Use topologyspread instead of AntiAffinity Rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Replace AntiAffinity Rule with topologySpreadConstraints
+
 * Fixed a problem with reporting the load balancer ip (hostname) for AWS EKS.
   EKS gives load balancers hostnames and not IPs. We treat these as one and the same.
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This enforces the distribution of the pods over the availability zones. By setting `when_unsatisfiable="DoNotSchedule", the pods will trigger the kubernetes autoscaler to add nodes to the cluster.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
