### PR TITLE
Change cluster.routing.allocation.enable setting during upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Added update of ``cluster.routing.allocation.enable`` setting to ``new_primaries``
+  before performing scaling/upgrades/restarts in order to disable shard allocations
+  during that time. Once the update is finished the setting is reset.
+
 * Replace AntiAffinity Rule with topologySpreadConstraints
 
 * Fixed a problem with reporting the load balancer ip (hostname) for AWS EKS.

--- a/crate/operator/backup.py
+++ b/crate/operator/backup.py
@@ -17,14 +17,10 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-import kopf
 from kubernetes_asyncio.client import (
     AppsV1Api,
-    BatchV1Api,
     BatchV1beta1Api,
-    CoreV1Api,
     V1beta1CronJob,
-    V1beta1CronJobList,
     V1beta1CronJobSpec,
     V1beta1JobTemplateSpec,
     V1Container,
@@ -33,9 +29,7 @@ from kubernetes_asyncio.client import (
     V1DeploymentSpec,
     V1EnvVar,
     V1EnvVarSource,
-    V1JobList,
     V1JobSpec,
-    V1JobStatus,
     V1LabelSelector,
     V1LocalObjectReference,
     V1ObjectFieldSelector,
@@ -49,19 +43,8 @@ from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import LABEL_COMPONENT, LABEL_NAME, SYSTEM_USERNAME
-from crate.operator.cratedb import are_snapshots_in_progress, connection_factory
-from crate.operator.utils.kopf import StateBasedSubHandler, subhandler_partial
-from crate.operator.utils.kubeapi import (
-    call_kubeapi,
-    get_host,
-    get_system_user_password,
-)
+from crate.operator.utils.kubeapi import call_kubeapi
 from crate.operator.utils.typing import LabelType
-from crate.operator.webhooks import (
-    WebhookEvent,
-    WebhookStatus,
-    WebhookTemporaryFailurePayload,
-)
 
 
 def get_backup_env(
@@ -306,172 +289,3 @@ async def create_backups(
                     has_ssl,
                 ),
             )
-
-
-DISABLE_CRONJOB_HANDLER_ID = "disable_cronjob"
-IGNORE_CRONJOB = "ignore_cronjob"
-CRONJOB_SUSPENDED = "cronjob_suspended"
-CRONJOB_NAME = "cronjob_name"
-
-
-class EnsureNoBackupsSubHandler(StateBasedSubHandler):
-    async def handle(  # type: ignore
-        self,
-        namespace: str,
-        name: str,
-        body: kopf.Body,
-        old: kopf.Body,
-        logger: logging.Logger,
-        **kwargs: Any,
-    ):
-        kopf.register(
-            fn=subhandler_partial(
-                self._ensure_cronjob_suspended, namespace, name, logger
-            ),
-            id=DISABLE_CRONJOB_HANDLER_ID,
-        )
-        kopf.register(
-            fn=subhandler_partial(
-                self._ensure_no_snapshots_in_progress, namespace, name, logger
-            ),
-            id="ensure_no_snapshots_in_progress",
-        )
-        kopf.register(
-            fn=subhandler_partial(
-                self._ensure_no_backup_cronjobs_running, namespace, name, logger
-            ),
-            id="ensure_no_cronjobs_running",
-        )
-
-    @staticmethod
-    async def _ensure_cronjob_suspended(
-        namespace: str, name: str, logger: logging.Logger
-    ) -> Optional[Dict]:
-        async with ApiClient() as api_client:
-            batch = BatchV1beta1Api(api_client)
-
-            jobs: V1beta1CronJobList = await batch.list_namespaced_cron_job(namespace)
-
-            for job in jobs.items:
-                job_name = job.metadata.name
-                labels = job.metadata.labels
-                if (
-                    labels.get("app.kubernetes.io/component") == "backup"
-                    and labels.get("app.kubernetes.io/name") == name
-                ):
-                    current_suspend_status = job.spec.suspend
-                    if current_suspend_status:
-                        logger.warn(
-                            f"Found job {job_name} that is already suspended, ignoring"
-                        )
-                        return {
-                            CRONJOB_NAME: job_name,
-                            CRONJOB_SUSPENDED: True,
-                            IGNORE_CRONJOB: True,
-                        }
-
-                    logger.info(
-                        f"Temporarily suspending CronJob {job_name} "
-                        f"while cluster update in progress"
-                    )
-                    update = {"spec": {"suspend": True}}
-                    await batch.patch_namespaced_cron_job(job_name, namespace, update)
-                    return {CRONJOB_NAME: job_name, CRONJOB_SUSPENDED: True}
-
-        return None
-
-    async def _ensure_no_snapshots_in_progress(self, namespace, name, logger):
-        async with ApiClient() as api_client:
-            core = CoreV1Api(api_client)
-
-            host = await get_host(core, namespace, name)
-            password = await get_system_user_password(core, namespace, name)
-            conn_factory = connection_factory(host, password)
-
-            snapshots_in_progress, statement = await are_snapshots_in_progress(
-                conn_factory, logger
-            )
-            if snapshots_in_progress:
-                raise kopf.TemporaryError(
-                    "A snapshot is currently in progress, "
-                    f"waiting for it to finish: {statement}",
-                    delay=30,
-                )
-
-    async def _ensure_no_backup_cronjobs_running(
-        self, namespace: str, name: str, logger: logging.Logger
-    ):
-        async with ApiClient() as api_client:
-            batch = BatchV1Api(api_client)
-
-            jobs: V1JobList = await call_kubeapi(
-                batch.list_namespaced_job, logger, namespace=namespace
-            )
-            for job in jobs.items:
-                job_name = job.metadata.name
-                labels = job.metadata.labels
-                job_status: V1JobStatus = job.status
-                if (
-                    labels.get("app.kubernetes.io/component") == "backup"
-                    and labels.get("app.kubernetes.io/name") == name
-                    and job_status.active is not None
-                ):
-                    await kopf.execute(
-                        fns={
-                            "notify_backup_running": subhandler_partial(
-                                self._notify_backup_running, logger
-                            )
-                        }
-                    )
-                    raise kopf.TemporaryError(
-                        "A snapshot k8s job is currently running, "
-                        f"waiting for it to finish: {job_name}",
-                        delay=30,
-                    )
-
-    async def _notify_backup_running(self, logger):
-        self.schedule_notification(
-            WebhookEvent.DELAY,
-            WebhookTemporaryFailurePayload(reason="A snapshot is in progress"),
-            WebhookStatus.TEMPORARY_FAILURE,
-        )
-        await self.send_notifications(logger)
-
-
-class EnsureCronjobReenabled(StateBasedSubHandler):
-    async def handle(  # type: ignore
-        self,
-        namespace: str,
-        name: str,
-        body: kopf.Body,
-        old: kopf.Body,
-        logger: logging.Logger,
-        status: kopf.Status,
-        **kwargs: Any,
-    ):
-        disabler_job_status = None
-        for key in status.keys():
-            if key.endswith(DISABLE_CRONJOB_HANDLER_ID):
-                disabler_job_status = status.get(key)
-                break
-
-        if disabler_job_status is None:
-            logger.info("No cronjob was disabled, so can't re-enable anything.")
-            return
-
-        if disabler_job_status.get(IGNORE_CRONJOB, False):
-            logger.warning("Will not attempt to re-enable any CronJobs")
-            return
-
-        async with ApiClient() as api_client:
-            job_name = disabler_job_status[CRONJOB_NAME]
-
-            batch = BatchV1beta1Api(api_client)
-
-            jobs: V1beta1CronJobList = await batch.list_namespaced_cron_job(namespace)
-
-            for job in jobs.items:
-                if job.metadata.name == job_name:
-                    update = {"spec": {"suspend": False}}
-                    await batch.patch_namespaced_cron_job(job_name, namespace, update)
-                    logger.info(f"Re-enabled cronjob {job_name}")

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -16,10 +16,18 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import kopf
-from kubernetes_asyncio.client import CoreV1Api, V1PodList
+from kubernetes_asyncio.client import (
+    BatchV1Api,
+    BatchV1beta1Api,
+    CoreV1Api,
+    V1beta1CronJobList,
+    V1JobList,
+    V1JobStatus,
+    V1PodList,
+)
 from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.constants import (
@@ -29,9 +37,24 @@ from crate.operator.constants import (
     LABEL_NODE_NAME,
     LABEL_PART_OF,
 )
-from crate.operator.cratedb import connection_factory, is_cluster_healthy
-from crate.operator.utils.kopf import StateBasedSubHandler
-from crate.operator.utils.kubeapi import get_host, get_system_user_password
+from crate.operator.cratedb import (
+    are_snapshots_in_progress,
+    connection_factory,
+    is_cluster_healthy,
+    reset_cluster_setting,
+    set_cluster_setting,
+)
+from crate.operator.utils.kopf import StateBasedSubHandler, subhandler_partial
+from crate.operator.utils.kubeapi import (
+    call_kubeapi,
+    get_host,
+    get_system_user_password,
+)
+from crate.operator.webhooks import (
+    WebhookEvent,
+    WebhookStatus,
+    WebhookTemporaryFailurePayload,
+)
 
 
 def get_total_nodes_count(nodes: Dict[str, Any]) -> int:
@@ -209,3 +232,228 @@ class RestartSubHandler(StateBasedSubHandler):
             await restart_cluster(core, namespace, name, old, logger, patch, status)
 
         await self.send_notifications(logger)
+
+
+DISABLE_CRONJOB_HANDLER_ID = "disable_cronjob"
+IGNORE_CRONJOB = "ignore_cronjob"
+CRONJOB_SUSPENDED = "cronjob_suspended"
+CRONJOB_NAME = "cronjob_name"
+
+
+class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        body: kopf.Body,
+        old: kopf.Body,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        kopf.register(
+            fn=subhandler_partial(
+                self._ensure_cronjob_suspended, namespace, name, logger
+            ),
+            id=DISABLE_CRONJOB_HANDLER_ID,
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._ensure_no_snapshots_in_progress, namespace, name, logger
+            ),
+            id="ensure_no_snapshots_in_progress",
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._ensure_no_backup_cronjobs_running, namespace, name, logger
+            ),
+            id="ensure_no_cronjobs_running",
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._set_cluster_routing_allocation_setting, namespace, name, logger
+            ),
+            id="set_cluster_routing_allocation_setting",
+        )
+
+    @staticmethod
+    async def _ensure_cronjob_suspended(
+        namespace: str, name: str, logger: logging.Logger
+    ) -> Optional[Dict]:
+        async with ApiClient() as api_client:
+            batch = BatchV1beta1Api(api_client)
+
+            jobs: V1beta1CronJobList = await batch.list_namespaced_cron_job(namespace)
+
+            for job in jobs.items:
+                job_name = job.metadata.name
+                labels = job.metadata.labels
+                if (
+                    labels.get("app.kubernetes.io/component") == "backup"
+                    and labels.get("app.kubernetes.io/name") == name
+                ):
+                    current_suspend_status = job.spec.suspend
+                    if current_suspend_status:
+                        logger.warn(
+                            f"Found job {job_name} that is already suspended, ignoring"
+                        )
+                        return {
+                            CRONJOB_NAME: job_name,
+                            CRONJOB_SUSPENDED: True,
+                            IGNORE_CRONJOB: True,
+                        }
+
+                    logger.info(
+                        f"Temporarily suspending CronJob {job_name} "
+                        f"while cluster update in progress"
+                    )
+                    update = {"spec": {"suspend": True}}
+                    await batch.patch_namespaced_cron_job(job_name, namespace, update)
+                    return {CRONJOB_NAME: job_name, CRONJOB_SUSPENDED: True}
+
+        return None
+
+    async def _ensure_no_snapshots_in_progress(self, namespace, name, logger):
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+
+            host = await get_host(core, namespace, name)
+            password = await get_system_user_password(core, namespace, name)
+            conn_factory = connection_factory(host, password)
+
+            snapshots_in_progress, statement = await are_snapshots_in_progress(
+                conn_factory, logger
+            )
+            if snapshots_in_progress:
+                raise kopf.TemporaryError(
+                    "A snapshot is currently in progress, "
+                    f"waiting for it to finish: {statement}",
+                    delay=30,
+                )
+
+    async def _ensure_no_backup_cronjobs_running(
+        self, namespace: str, name: str, logger: logging.Logger
+    ):
+        async with ApiClient() as api_client:
+            batch = BatchV1Api(api_client)
+
+            jobs: V1JobList = await call_kubeapi(
+                batch.list_namespaced_job, logger, namespace=namespace
+            )
+            for job in jobs.items:
+                job_name = job.metadata.name
+                labels = job.metadata.labels
+                job_status: V1JobStatus = job.status
+                if (
+                    labels.get("app.kubernetes.io/component") == "backup"
+                    and labels.get("app.kubernetes.io/name") == name
+                    and job_status.active is not None
+                ):
+                    await kopf.execute(
+                        fns={
+                            "notify_backup_running": subhandler_partial(
+                                self._notify_backup_running, logger
+                            )
+                        }
+                    )
+                    raise kopf.TemporaryError(
+                        "A snapshot k8s job is currently running, "
+                        f"waiting for it to finish: {job_name}",
+                        delay=30,
+                    )
+
+    async def _notify_backup_running(self, logger):
+        self.schedule_notification(
+            WebhookEvent.DELAY,
+            WebhookTemporaryFailurePayload(reason="A snapshot is in progress"),
+            WebhookStatus.TEMPORARY_FAILURE,
+        )
+        await self.send_notifications(logger)
+
+    async def _set_cluster_routing_allocation_setting(
+        self, namespace: str, name: str, logger: logging.Logger
+    ):
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+
+            host = await get_host(core, namespace, name)
+            password = await get_system_user_password(core, namespace, name)
+            conn_factory = connection_factory(host, password)
+
+            await set_cluster_setting(
+                conn_factory,
+                logger,
+                setting="cluster.routing.allocation.enable",
+                value="new_primaries",
+                mode="PERSISTENT",
+            )
+
+
+class AfterClusterUpdateSubHandler(StateBasedSubHandler):
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        body: kopf.Body,
+        old: kopf.Body,
+        logger: logging.Logger,
+        status: kopf.Status,
+        **kwargs: Any,
+    ):
+        kopf.register(
+            fn=subhandler_partial(
+                self._ensure_cronjob_reenabled, namespace, name, logger, status
+            ),
+            id="ensure_cronjob_reenabled",
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._reset_cluster_routing_allocation_setting, namespace, name, logger
+            ),
+            id="reset_cluster_routing_allocation_setting",
+        )
+
+    async def _ensure_cronjob_reenabled(
+        self, namespace: str, name: str, logger: logging.Logger, status: kopf.Status
+    ):
+        disabler_job_status = None
+        for key in status.keys():
+            if key.endswith(DISABLE_CRONJOB_HANDLER_ID):
+                disabler_job_status = status.get(key)
+                break
+
+        if disabler_job_status is None:
+            logger.info("No cronjob was disabled, so can't re-enable anything.")
+            return
+
+        if disabler_job_status.get(IGNORE_CRONJOB, False):
+            logger.warning("Will not attempt to re-enable any CronJobs")
+            return
+
+        async with ApiClient() as api_client:
+            job_name = disabler_job_status[CRONJOB_NAME]
+
+            batch = BatchV1beta1Api(api_client)
+
+            jobs: V1beta1CronJobList = await batch.list_namespaced_cron_job(namespace)
+
+            for job in jobs.items:
+                if job.metadata.name == job_name:
+                    update = {"spec": {"suspend": False}}
+                    await batch.patch_namespaced_cron_job(job_name, namespace, update)
+                    logger.info(f"Re-enabled cronjob {job_name}")
+
+    async def _reset_cluster_routing_allocation_setting(
+        self, namespace: str, name: str, logger: logging.Logger
+    ):
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+
+            host = await get_host(core, namespace, name)
+            password = await get_system_user_password(core, namespace, name)
+            conn_factory = connection_factory(host, password)
+
+            await reset_cluster_setting(
+                conn_factory,
+                logger,
+                setting="cluster.routing.allocation.enable",
+            )

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -263,10 +263,10 @@ async def _is_blocked_on_running_snapshot(
         name=name,
     )
 
-    ensure_no_backups = cratedb["metadata"]["annotations"].get(
-        f"{KOPF_STATE_STORE_PREFIX}/cluster_update.ensure_no_backups", None
+    before_cluster_update = cratedb["metadata"]["annotations"].get(
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update.before_cluster_update", None
     )
-    if not ensure_no_backups:
+    if not before_cluster_update:
         return False
 
     for v in cratedb["metadata"]["annotations"].values():


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Added a new kopf subhandler which updates the ``cluster.routing.allocation.enable`` setting to ``new_primaries`` before a cluster is upgraded, scaled up/down or restarted. This should disable shard allocations during this time. Once the process is finished the setting is reset to its default value by another subhandler.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
