### PR TITLE
Add additional env variable to cronjobs for custom s3 backup endpointUrl

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Add additional environment variable to use a custom S3 backup ``endpointUrl``.
+
 2.3.0 (2021-07-26)
 ------------------
 

--- a/crate/operator/backup.py
+++ b/crate/operator/backup.py
@@ -146,6 +146,21 @@ def get_backup_cronjob(
         + get_backup_env(name, http_port, backup_aws, has_ssl)
         + get_webhook_env()
     )
+
+    if "endpointUrl" in backup_aws:
+        env.append(
+            V1EnvVar(
+                name="S3_ENDPOINT_URL",
+                value_from=V1EnvVarSource(
+                    secret_key_ref=V1SecretKeySelector(
+                        key=backup_aws["endpointUrl"]["secretKeyRef"]["key"],
+                        name=backup_aws["endpointUrl"]["secretKeyRef"]["name"],
+                        optional=True,
+                    ),
+                ),
+            )
+        )
+
     return V1beta1CronJob(
         metadata=V1ObjectMeta(
             name=f"create-snapshot-{name}",

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -78,6 +78,23 @@ spec:
                       description: A crontab formatted string indicating when and how often to perform backups.
                       pattern: ^(((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ){4}(((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*))$
                       type: string
+                    endpointUrl:
+                      properties:
+                        secretKeyRef:
+                          properties:
+                            key:
+                              description: The key within the Kubernetes Secret that holds the S3 endpoint.
+                              type: string
+                            name:
+                              description: Name of a Kubernetes Secret that contains the S3 endpoint-url to be used for backups.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secretKeyRef
+                      type: object
                     region:
                       properties:
                         secretKeyRef:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This adds additional environment variables to the backup cronjob to be able to write to a custom S3 bucket.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
