### PR TITLE
Update the CRD to print some additional info about the CrateDBs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Changed the operator CRD to print additional information about the running CrateDBs:
+  the cluster name, version and number of data nodes.
+
 2.4.0 (2021-08-26)
 ------------------
 

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -20,6 +20,22 @@ kind: CustomResourceDefinition
 metadata:
   name: cratedbs.cloud.crate.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.cluster.name
+    description: The CrateDB Cluster name
+    name: ClusterName
+    type: string
+  - JSONPath: .spec.cluster.version
+    description: The CrateDB Cluster version
+    name: Version
+    type: string
+  - JSONPath: .spec.nodes.data[?(@.name == "hot")].replicas
+    description: Number of data nodes in this cluster
+    name: Nodes
+    type: number
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: cloud.crate.io
   names:
     kind: CrateDB


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Name, version number and number of nodes.

```
❯ k get cratedbs -A
NAMESPACE                              NAME                                   CLUSTERNAME          VERSION   NODES   AGE
ee397dc2-1678-4b4e-865f-390b9bfd348e   7a9b09de-82ad-4ee0-8797-d21e59fa410f   loose-ivory-ermine   4.6.3     3       18m
```

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
