### PR TITLE
Up the idle connection timeout to 1 hour

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Unreleased
 * Changed the operator CRD to print additional information about the running CrateDBs:
   the cluster name, version and number of data nodes.
 
+* Added an annotation for AWS ELB load balancers running on EKS to up the idle
+  connection timeout to 1 hour. Without this, connections with long-running queries
+  were being killed by the ELB.
+
 2.4.0 (2021-08-26)
 ------------------
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -816,11 +816,13 @@ def get_data_service(
 ) -> V1Service:
     annotations = {}
     if config.CLOUD_PROVIDER == CloudProvider.AWS:
-        # https://kubernetes.io/docs/concepts/services-networking/service/#connection-draining-on-aws
         annotations.update(
             {
+                # https://kubernetes.io/docs/concepts/services-networking/service/#connection-draining-on-aws
                 "service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled": "true",  # noqa
                 "service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout": "1800",  # noqa
+                # Default idle timeout is 60s, which kills the connection on long-running queries # noqa
+                "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",  # noqa
             }
         )
     elif config.CLOUD_PROVIDER == CloudProvider.AZURE:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -700,6 +700,10 @@ class TestServiceModels:
                 "service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout"  # noqa
                 in annotation_keys
             )
+            assert (
+                "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"  # noqa
+                in annotation_keys
+            )
         if provider == "azure":
             assert (
                 "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The default of 60s is killing connections on long-running queries, which is not cool.

Fixes crate/cloud#312

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
