### PR TITLE
Added service IP Whitelist to create.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,9 @@ Unreleased
   connection timeout to 1 hour. Without this, connections with long-running queries
   were being killed by the ELB.
 
-* Changed the operator CRD to be able add allowed IPs (CIDR notation) to the
-  CrateDB clusters.
+* Changed the operator CRD to be able add allowed IPs (CIDR notation) to the CrateDB clusters.
+
+* Added loadBalancerSourceIPRanges for crate service to allow IP Whitelisting.
 
 2.4.0 (2021-08-26)
 ------------------

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -813,6 +813,7 @@ def get_data_service(
     http_port: int,
     postgres_port: int,
     dns_record: Optional[str],
+    source_ranges: Optional[List[str]] = None,
 ) -> V1Service:
     annotations = {}
     if config.CLOUD_PROVIDER == CloudProvider.AWS:
@@ -853,6 +854,7 @@ def get_data_service(
             selector={LABEL_COMPONENT: "cratedb", LABEL_NAME: name},
             type="LoadBalancer",
             external_traffic_policy="Local",
+            load_balancer_source_ranges=source_ranges if source_ranges else None,
         ),
     )
 
@@ -886,6 +888,7 @@ async def create_services(
     transport_port: int,
     dns_record: Optional[str],
     logger: logging.Logger,
+    source_ranges: Optional[List[str]] = None,
 ) -> None:
     async with ApiClient() as api_client:
         core = CoreV1Api(api_client)
@@ -895,7 +898,13 @@ async def create_services(
             continue_on_conflict=True,
             namespace=namespace,
             body=get_data_service(
-                owner_references, name, labels, http_port, postgres_port, dns_record
+                owner_references,
+                name,
+                labels,
+                http_port,
+                postgres_port,
+                dns_record,
+                source_ranges,
             ),
         )
         await call_kubeapi(

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -201,6 +201,7 @@ async def cluster_create(
     # nor implicit master nodes.
     treat_as_master = True
     cluster_name = spec["cluster"]["name"]
+    source_ranges = spec["cluster"].get("allowedCIDRs", None)
 
     kopf.register(
         fn=subhandler_partial(
@@ -250,6 +251,7 @@ async def cluster_create(
             transport_port,
             spec.get("cluster", {}).get("externalDNS"),
             logger,
+            source_ranges,
         ),
         id="services",
     )


### PR DESCRIPTION
This allows to add IP addresses in CIDR notation to the crate service. Once defined, it allows connection to cratedb only from the specified IP ranges. 

cloud-234
