### PR TITLE
Update source IPs when the CRD changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,11 +14,16 @@ Unreleased
 
 * Changed the operator CRD to be able add allowed IPs (CIDR notation) to the CrateDB clusters.
 
-* Added loadBalancerSourceIPRanges for crate service to allow IP Whitelisting.
+* Added ``loadBalancerSourceIPRanges`` for crate service to allow IP Whitelisting.
 
 * Use settings names ``gateway.recover_after_data_nodes`` and
   ``gateway.expected_data_nodes`` instead of ``gateway.recover_after_nodes`` and
   ``gateway.expected_nodes`` from CrateDB version 4.7 onwards.
+
+* Implemented a handler allowing changing ``allowedCIDRs`` on CrateDB resources.
+
+* Added ``BOOTSTRAP_RETRY_DELAY`` and ``HEALTH_CHECK_RETRY_DELAY`` settings that allow
+  adjusting the respective delays in the bootstrap process.
 
 2.4.0 (2021-08-26)
 ------------------

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -95,19 +95,19 @@ async def bootstrap_license(
             # license key in the log messages which might be part of the string
             # representation of the exception.
             exception_logger("... failed. Status: %s Reason: %s", e.status, e.reason)
-            raise TemporaryError()
+            raise _temporary_error()
         except WSServerHandshakeError as e:
             # We don't use `logger.exception()` to not accidentally include the
             # license key in the log messages which might be part of the string
             # representation of the exception.
             exception_logger("... failed. Status: %s Message: %s", e.status, e.message)
-            raise TemporaryError()
+            raise _temporary_error()
         else:
             if "SET OK" in result:
                 logger.info("... success")
             else:
                 logger.info("... error. %s", result)
-                raise TemporaryError()
+                raise _temporary_error()
 
 
 async def bootstrap_system_user(
@@ -188,13 +188,13 @@ async def bootstrap_system_user(
             # password in the log messages which might be part of the string
             # representation of the exception.
             exception_logger("... failed. Status: %s Reason: %s", e.status, e.reason)
-            raise TemporaryError()
+            raise _temporary_error()
         except WSServerHandshakeError as e:
             # We don't use `logger.exception()` to not accidentally include the
             # password in the log messages which might be part of the string
             # representation of the exception.
             exception_logger("... failed. Status: %s Message: %s", e.status, e.message)
-            raise TemporaryError()
+            raise _temporary_error()
         else:
             if "CREATE OK" in result:
                 logger.info("... success")
@@ -203,7 +203,7 @@ async def bootstrap_system_user(
                 logger.info("... success. Already present")
             else:
                 logger.info("... error. %s", result)
-                raise TemporaryError()
+                raise _temporary_error()
 
         if needs_update:
             try:
@@ -225,7 +225,7 @@ async def bootstrap_system_user(
                 exception_logger(
                     "... failed. Status: %s Reason: %s", e.status, e.reason
                 )
-                raise TemporaryError()
+                raise _temporary_error()
             except WSServerHandshakeError as e:
                 # We don't use `logger.exception()` to not accidentally include the
                 # password in the log messages which might be part of the string
@@ -233,13 +233,13 @@ async def bootstrap_system_user(
                 exception_logger(
                     "... failed. Status: %s Message: %s", e.status, e.message
                 )
-                raise TemporaryError()
+                raise _temporary_error()
             else:
                 if "ALTER OK" in result:
                     logger.info("... success")
                 else:
                     logger.info("... error. %s", result)
-                    raise TemporaryError()
+                    raise _temporary_error()
 
         try:
             logger.info("Trying to grant system user all privileges ...")
@@ -255,13 +255,13 @@ async def bootstrap_system_user(
             )
         except (ApiException, WSServerHandshakeError):
             logger.exception("... failed")
-            raise TemporaryError()
+            raise _temporary_error()
         else:
             if "GRANT OK" in result:
                 logger.info("... success")
             else:
                 logger.info("... error. %s", result)
-                raise TemporaryError()
+                raise _temporary_error()
 
 
 async def bootstrap_users(
@@ -338,3 +338,7 @@ async def bootstrap_cluster(
         )
         if users:
             await bootstrap_users(core, namespace, name, users)
+
+
+def _temporary_error():
+    return TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -40,6 +40,16 @@ class Config:
     #: considered failed
     BOOTSTRAP_TIMEOUT: Optional[int] = 1800
 
+    #: Time in seconds between the retries when bootstrapping the cluster.
+    #: This can be safely lowered if the k8s environment is quick to act and
+    #: the pods are quick to start up.
+    BOOTSTRAP_RETRY_DELAY: Optional[int] = 60
+
+    #: Delay between health checks when waiting for a cluster to become ready.
+    #: This can be safely lowered if the k8s environment is quick to act and
+    #: the pods are quick to start up.
+    HEALTH_CHECK_RETRY_DELAY: Optional[int] = 30
+
     #: When set, enable special handling for the defind cloud provider, e.g. on
     #: AWS pass the availability zone as a CrateDB node attribute.
     CLOUD_PROVIDER: Optional[CloudProvider] = None
@@ -121,6 +131,28 @@ class Config:
             )
         if self.BOOTSTRAP_TIMEOUT == 0:
             self.BOOTSTRAP_TIMEOUT = None
+
+        bootstrap_delay = self.env(
+            "BOOTSTRAP_RETRY_DELAY", default=str(self.BOOTSTRAP_RETRY_DELAY)
+        )
+        try:
+            self.BOOTSTRAP_RETRY_DELAY = int(bootstrap_delay)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}BOOTSTRAP_RETRY_DELAY="
+                f"'{bootstrap_timeout}'. Needs to be a positive integer."
+            )
+
+        healthcheck_delay = self.env(
+            "HEALTH_CHECK_RETRY_DELAY", default=str(self.HEALTH_CHECK_RETRY_DELAY)
+        )
+        try:
+            self.HEALTH_CHECK_RETRY_DELAY = int(healthcheck_delay)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}HEALTH_CHECK_RETRY_DELAY="
+                f"'{bootstrap_timeout}'. Needs to be a positive integer."
+            )
 
         cloud_provider = self.env("CLOUD_PROVIDER", default=self.CLOUD_PROVIDER)
         if cloud_provider is not None:

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -326,8 +326,8 @@ def get_statefulset_containers(
             ],
             readiness_probe=V1Probe(
                 http_get=V1HTTPGetAction(path="/ready", port=prometheus_port),
-                initial_delay_seconds=30,
-                period_seconds=10,
+                initial_delay_seconds=10 if config.TESTING else 30,
+                period_seconds=5 if config.TESTING else 10,
             ),
             resources=V1ResourceRequirements(
                 limits={

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -242,7 +242,7 @@ async def check_for_deallocation(
     if rows:
         allocations = ", ".join(f"{row[0]}={row[1]}" for row in rows) or "None"
         logger.info("Current pending allocation %s", allocations)
-        raise kopf.TemporaryError("Pending allocation")
+        raise kopf.TemporaryError("Pending allocation", delay=15)
 
 
 async def deallocate_nodes(
@@ -696,4 +696,6 @@ async def _ensure_cluster_healthy(
             expected_number_of_nodes += sts.spec.replicas
 
     if not await is_cluster_healthy(conn_factory, expected_number_of_nodes, logger):
-        raise kopf.TemporaryError("Waiting for cluster to be healthy.", delay=15)
+        raise kopf.TemporaryError(
+            "Waiting for cluster to be healthy.", delay=config.HEALTH_CHECK_RETRY_DELAY
+        )

--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -14,6 +14,7 @@ from crate.operator.webhooks import (
     webhook_client,
 )
 
+from ..config import config
 from ..constants import KOPF_STATE_STORE_PREFIX
 
 
@@ -109,7 +110,11 @@ class StateBasedSubHandler(abc.ABC):
 
         if len(waiting_for) > 0:
             wt = ",".join(waiting_for)
-            raise kopf.TemporaryError(f"Waiting for '{wt}'.", delay=30)
+            # If running in testing mode (i.e. running ITs) we can reduce the delay
+            # significantly as things generally move fast.
+            raise kopf.TemporaryError(
+                f"Waiting for '{wt}'.", delay=5 if config.TESTING else 30
+            )
 
         res = await self.handle(**kwargs)
         return {"success": True, "ref": self.ref, "result": res}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,8 @@ def load_config():
         "CRATEDB_OPERATOR_LOG_LEVEL": "DEBUG",
         "CRATEDB_OPERATOR_TESTING": "true",
         "CRATEDB_OPERATOR_JOBS_TABLE": "test.test_sys_jobs",
+        "CRATEDB_OPERATOR_BOOTSTRAP_RETRY_DELAY": "5",
+        "CRATEDB_OPERATOR_HEALTH_CHECK_RETRY_DELAY": "5",
     }
     with mock.patch.dict(os.environ, env):
         config.load()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -48,8 +48,8 @@ async def do_pod_ids_exist(core: CoreV1Api, namespace: str, pod_ids: Set[str]) -
 async def test_upgrade_cluster(
     faker, namespace, cleanup_handler, kopf_runner, api_client
 ):
-    version_from = "4.4.1"
-    version_to = "4.4.2"
+    version_from = "4.6.1"
+    version_to = "4.6.4"
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)
     name = faker.domain_word()

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -93,8 +93,8 @@ async def test_update_cluster_password(
                             "name": "data",
                             "replicas": 1,
                             "resources": {
-                                "cpus": 0.5,
-                                "memory": "1Gi",
+                                "cpus": 2,
+                                "memory": "4Gi",
                                 "heapRatio": 0.25,
                                 "disk": {
                                     "storageClass": "default",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This change is twofold:
- Firstly we've implemented a `@kopf.on.field` handler to handle `allowedCIDRs` changes and updating the relevant service
- Secondly, this also does a significant refactor of some of our delays/timings, making the tests run much faster. This is achieved primarily by lowering some timeouts (bootstrap, health checks) when in test mode, so we don't wait around for 60s doing nothing in the ITs.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
