### PR TITLE
Restructure main.py

### DIFF
--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -32,6 +32,8 @@ CONNECT_TIMEOUT = 10.0
 
 KOPF_STATE_STORE_PREFIX = f"operator.{API_GROUP}"
 
+CLUSTER_UPDATE_ID = "cluster_update"
+
 
 class CloudProvider(str, enum.Enum):
     AWS = "aws"

--- a/crate/operator/handlers/__init__.py
+++ b/crate/operator/handlers/__init__.py
@@ -1,0 +1,15 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -1,0 +1,245 @@
+import logging
+
+import kopf
+from kubernetes_asyncio.client import V1LocalObjectReference, V1OwnerReference
+
+from crate.operator.backup import create_backups
+from crate.operator.bootstrap import bootstrap_cluster
+from crate.operator.config import config
+from crate.operator.constants import (
+    API_GROUP,
+    LABEL_COMPONENT,
+    LABEL_MANAGED_BY,
+    LABEL_NAME,
+    LABEL_PART_OF,
+    Port,
+)
+from crate.operator.create import (
+    create_debug_volume,
+    create_services,
+    create_sql_exporter_config,
+    create_statefulset,
+    create_system_user,
+)
+from crate.operator.operations import get_master_nodes_names, get_total_nodes_count
+from crate.operator.utils.kopf import subhandler_partial
+
+
+async def create_cratedb(
+    namespace: str, meta: kopf.Meta, spec: kopf.Spec, logger: logging.Logger
+):
+    name = meta["name"]
+    base_labels = {
+        LABEL_MANAGED_BY: "crate-operator",
+        LABEL_NAME: name,
+        LABEL_PART_OF: "cratedb",
+    }
+    cratedb_labels = base_labels.copy()
+    cratedb_labels[LABEL_COMPONENT] = "cratedb"
+    cratedb_labels.update(meta.get("labels", {}))
+
+    owner_references = [
+        V1OwnerReference(
+            api_version=f"{API_GROUP}/v1",
+            block_owner_deletion=True,
+            controller=True,
+            kind="CrateDB",
+            name=name,
+            uid=meta["uid"],
+        )
+    ]
+
+    image_pull_secrets = (
+        [V1LocalObjectReference(name=secret) for secret in config.IMAGE_PULL_SECRETS]
+        if config.IMAGE_PULL_SECRETS
+        else None
+    )
+
+    ports_spec = spec.get("ports", {})
+    http_port = ports_spec.get("http", Port.HTTP.value)
+    jmx_port = ports_spec.get("jmx", Port.JMX.value)
+    postgres_port = ports_spec.get("postgres", Port.POSTGRES.value)
+    prometheus_port = ports_spec.get("prometheus", Port.PROMETHEUS.value)
+    transport_port = ports_spec.get("transport", Port.TRANSPORT.value)
+
+    master_nodes = get_master_nodes_names(spec["nodes"])
+    total_nodes_count = get_total_nodes_count(spec["nodes"], "all")
+    data_nodes_count = get_total_nodes_count(spec["nodes"], "data")
+    crate_image = spec["cluster"]["imageRegistry"] + ":" + spec["cluster"]["version"]
+    has_master_nodes = "master" in spec["nodes"]
+    # The first StatefulSet we create references a set of master nodes. These
+    # can either be explicit CrateDB master nodes, or implicit ones, which
+    # would be the first set of nodes from the data nodes list.
+    #
+    # After the first StatefulSet was created, we set `treat_as_master` to
+    # `False` to indicate that all remaining StatefulSets are neither explicit
+    # nor implicit master nodes.
+    treat_as_master = True
+    cluster_name = spec["cluster"]["name"]
+    source_ranges = spec["cluster"].get("allowedCIDRs", None)
+
+    kopf.register(
+        fn=subhandler_partial(
+            create_sql_exporter_config,
+            owner_references,
+            namespace,
+            name,
+            cratedb_labels,
+            logger,
+        ),
+        id="sql_exporter_config",
+    )
+
+    kopf.register(
+        fn=subhandler_partial(
+            create_debug_volume,
+            owner_references,
+            namespace,
+            name,
+            cratedb_labels,
+            logger,
+        ),
+        id="debug_volume",
+    )
+
+    kopf.register(
+        fn=subhandler_partial(
+            create_system_user,
+            owner_references,
+            namespace,
+            name,
+            cratedb_labels,
+            logger,
+        ),
+        id="system_user",
+    )
+
+    kopf.register(
+        fn=subhandler_partial(
+            create_services,
+            owner_references,
+            namespace,
+            name,
+            cratedb_labels,
+            http_port,
+            postgres_port,
+            transport_port,
+            spec.get("cluster", {}).get("externalDNS"),
+            logger,
+            source_ranges,
+        ),
+        id="services",
+    )
+
+    if has_master_nodes:
+        kopf.register(
+            fn=subhandler_partial(
+                create_statefulset,
+                owner_references,
+                namespace,
+                name,
+                cratedb_labels,
+                treat_as_master,
+                False,
+                cluster_name,
+                "master",
+                "master-",
+                spec["nodes"]["master"],
+                master_nodes,
+                total_nodes_count,
+                data_nodes_count,
+                http_port,
+                jmx_port,
+                postgres_port,
+                prometheus_port,
+                transport_port,
+                crate_image,
+                spec["cluster"].get("ssl"),
+                spec["cluster"].get("settings"),
+                image_pull_secrets,
+                logger,
+            ),
+            id="statefulset_master",
+        )
+        treat_as_master = False
+
+    for node_spec in spec["nodes"]["data"]:
+        node_name = node_spec["name"]
+        kopf.register(
+            fn=subhandler_partial(
+                create_statefulset,
+                owner_references,
+                namespace,
+                name,
+                cratedb_labels,
+                treat_as_master,
+                True,
+                cluster_name,
+                node_name,
+                f"data-{node_name}-",
+                node_spec,
+                master_nodes,
+                total_nodes_count,
+                data_nodes_count,
+                http_port,
+                jmx_port,
+                postgres_port,
+                prometheus_port,
+                transport_port,
+                crate_image,
+                spec["cluster"].get("ssl"),
+                spec["cluster"].get("settings"),
+                image_pull_secrets,
+                logger,
+            ),
+            id=f"statefulset_data_{node_name}",
+        )
+        treat_as_master = False
+
+    if has_master_nodes:
+        master_node_pod = f"crate-master-{name}-0"
+    else:
+        node_name = spec["nodes"]["data"][0]["name"]
+        master_node_pod = f"crate-data-{node_name}-{name}-0"
+
+    kopf.register(
+        fn=subhandler_partial(
+            bootstrap_cluster,
+            namespace,
+            name,
+            master_node_pod,
+            spec["cluster"].get("license"),
+            "ssl" in spec["cluster"],
+            spec.get("users"),
+            logger,
+        ),
+        id="bootstrap",
+        timeout=config.BOOTSTRAP_TIMEOUT,
+        backoff=config.BOOTSTRAP_RETRY_DELAY,
+    )
+
+    if "backups" in spec:
+        if config.CLUSTER_BACKUP_IMAGE is None:
+            logger.info(
+                "Not deploying backup tools because no backup image is defined."
+            )
+        else:
+            backup_metrics_labels = base_labels.copy()
+            backup_metrics_labels[LABEL_COMPONENT] = "backup"
+            backup_metrics_labels.update(meta.get("labels", {}))
+            kopf.register(
+                fn=subhandler_partial(
+                    create_backups,
+                    owner_references,
+                    namespace,
+                    name,
+                    backup_metrics_labels,
+                    http_port,
+                    prometheus_port,
+                    spec["backups"],
+                    image_pull_secrets,
+                    "ssl" in spec["cluster"],
+                    logger,
+                ),
+                id="backup",
+            )

--- a/crate/operator/handlers/handle_migrate_discovery_service.py
+++ b/crate/operator/handlers/handle_migrate_discovery_service.py
@@ -1,0 +1,43 @@
+import logging
+
+from kubernetes_asyncio.client import CoreV1Api
+from kubernetes_asyncio.client.api_client import ApiClient
+
+from crate.operator.constants import Port
+
+
+async def migrate_discovery_service(
+    namespace: str,
+    name: str,
+    logger: logging.Logger,
+):
+    if not name.startswith("crate-discovery-"):
+        return
+
+    async with ApiClient() as api_client:
+        core = CoreV1Api(api_client)
+
+        service = await core.read_namespaced_service(name, namespace)
+
+        http_port = next(
+            (port for port in service.spec.ports if port.name == "http"), None
+        )
+
+        if http_port:
+            return
+
+        logger.info("Found old discovery service w/o HTTP port, patching: %s", name)
+
+        await core.patch_namespaced_service(
+            name,
+            namespace,
+            body={
+                "spec": {
+                    "ports": [
+                        {"name": "cluster", "port": Port.TRANSPORT.value},
+                        {"name": "http", "port": Port.HTTP.value},
+                        {"name": "psql", "port": Port.POSTGRES.value},
+                    ]
+                }
+            },
+        )

--- a/crate/operator/handlers/handle_migrate_user_password_label.py
+++ b/crate/operator/handlers/handle_migrate_user_password_label.py
@@ -1,0 +1,28 @@
+import kopf
+from kubernetes_asyncio.client import CoreV1Api
+from kubernetes_asyncio.client.api_client import ApiClient
+
+from crate.operator.constants import LABEL_USER_PASSWORD
+from crate.operator.utils.kubeapi import ensure_user_password_label
+
+
+async def migrate_user_password_label(
+    namespace: str,
+    spec: kopf.Spec,
+):
+    if "users" in spec:
+        async with ApiClient() as api_client:
+            for user_spec in spec["users"]:
+                core = CoreV1Api(api_client)
+
+                secret_name = user_spec["password"]["secretKeyRef"]["name"]
+                secret = await core.read_namespaced_secret(
+                    namespace=namespace, name=secret_name
+                )
+                if (
+                    secret.metadata.labels is None
+                    or LABEL_USER_PASSWORD not in secret.metadata.labels
+                ):
+                    await ensure_user_password_label(
+                        core, namespace, user_spec["password"]["secretKeyRef"]["name"]
+                    )

--- a/crate/operator/handlers/handle_notify_external_ip_changed.py
+++ b/crate/operator/handlers/handle_notify_external_ip_changed.py
@@ -1,0 +1,50 @@
+import logging
+
+import kopf
+from kopf import DiffItem, DiffOperation
+
+from crate.operator.config import config
+from crate.operator.constants import LABEL_NAME
+from crate.operator.edge import notify_service_ip
+
+
+async def external_ip_changed(
+    name: str,
+    namespace: str,
+    diff: kopf.Diff,
+    meta: dict,
+    logger: logging.Logger,
+):
+    # Ignore the testing service
+    if config.TESTING and name.startswith("crate-testing"):
+        return
+
+    if len(diff) == 0:
+        return
+
+    op: DiffItem = diff[0]
+
+    # Don't care about IPs being removed (also does not happen)
+    if op.operation == DiffOperation.REMOVE:
+        return
+
+    # Sometimes when a service is just created, we get an _empty_ IP added,
+    # also ignore these.
+    if not op.new:
+        return
+
+    cluster_id = meta["labels"][LABEL_NAME]
+
+    if len(op.new) == 0:
+        logger.warning(f"No IP received for LoadBalancer {diff}")
+        return
+
+    # Most k8s clusters give out IP addresses to LoadBalancer services, however some
+    # (i.e. EKS) give hostnames instead. As far as Crate is concerned, these are
+    # treated the same.
+    # TODO: Multiple IPs?
+    ip = op.new[0].get("ip") or op.new[0].get("hostname")
+    if not ip:
+        logger.warning(f"Load balancer got neither IP nor hostname {op}")
+        return
+    await notify_service_ip(namespace, cluster_id, ip, logger)

--- a/crate/operator/handlers/handle_update_allowed_cidrs.py
+++ b/crate/operator/handlers/handle_update_allowed_cidrs.py
@@ -1,0 +1,34 @@
+import logging
+
+import kopf
+from kopf import DiffItem
+from kubernetes_asyncio.client import CoreV1Api
+from kubernetes_asyncio.client.api_client import ApiClient
+
+
+async def update_service_allowed_cidrs(
+    namespace: str,
+    name: str,
+    diff: kopf.Diff,
+    logger: logging.Logger,
+):
+    change: DiffItem = diff[0]
+    logger.info(f"Updating load balancer source ranges to {change.new}")
+
+    async with ApiClient() as api_client:
+        core = CoreV1Api(api_client)
+        # This also runs on creation events, so we want to double check that the service
+        # exists before attempting to do anything.
+        services = await core.list_namespaced_service(namespace=namespace)
+        service = next(
+            (svc for svc in services.items if svc.metadata.name == f"crate-{name}"),
+            None,
+        )
+        if not service:
+            return
+
+        await core.patch_namespaced_service(
+            name=f"crate-{name}",
+            namespace=namespace,
+            body={"spec": {"loadBalancerSourceRanges": change.new}},
+        )

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -1,0 +1,125 @@
+import hashlib
+
+import kopf
+
+from crate.operator.config import config
+from crate.operator.constants import CLUSTER_UPDATE_ID
+from crate.operator.operations import (
+    AfterClusterUpdateSubHandler,
+    BeforeClusterUpdateSubHandler,
+    RestartSubHandler,
+)
+from crate.operator.scale import ScaleSubHandler
+from crate.operator.upgrade import UpgradeSubHandler
+
+
+async def update_cratedb(
+    namespace: str,
+    name: str,
+    patch: kopf.Patch,
+    status: kopf.Status,
+    diff: kopf.Diff,
+):
+    """
+    Handle cluster updates.
+
+    This is done as a chain of sub-handlers that depend on the previous ones completing.
+    The state of each handler is stored in the status field of the CrateDB
+    custom resource. Since the status field persists between runs of this handler
+    (even for unrelated runs), we calculate and store a hash of what changed as well.
+    This hash is then used by the sub-handlers to work out which run they are part of.
+
+    i.e., consider this status:
+
+    ::
+
+        status:
+          cluster_update:
+            ref: 24b527bf0eada363bf548f19b98dd9cb
+          cluster_update/after_cluster_update:
+            ref: 24b527bf0eada363bf548f19b98dd9cb
+            success: true
+          cluster_update/before_cluster_update:
+            ref: 24b527bf0eada363bf548f19b98dd9cb
+            success: true
+          cluster_update/scale:
+            ref: 24b527bf0eada363bf548f19b98dd9cb
+            success: true
+
+
+    here ``status.cluster_update.ref`` is the hash of the last diff that was being acted
+    upon. Since kopf *does not clean up statuses*, when we start a new run we check if
+    the hash matches - if not, it means we can disregard any refs that are not for this
+    run.
+    """
+    context = status.get(CLUSTER_UPDATE_ID)
+    hash = hashlib.md5(str(diff).encode("utf-8")).hexdigest()
+    if not context:
+        context = {"ref": hash}
+    elif context.get("ref", "") != hash:
+        context["ref"] = hash
+
+    do_upgrade = False
+    do_restart = False
+    do_scale = False
+    for _, field_path, *_ in diff:
+        if field_path in {
+            ("spec", "cluster", "imageRegistry"),
+            ("spec", "cluster", "version"),
+        }:
+            do_upgrade = True
+            do_restart = True
+        elif field_path == ("spec", "nodes", "master", "replicas"):
+            do_scale = True
+        elif field_path == ("spec", "nodes", "data"):
+            do_scale = True
+
+    if not do_upgrade and not do_restart and not do_scale:
+        return
+
+    depends_on = [f"{CLUSTER_UPDATE_ID}/before_cluster_update"]
+    kopf.register(
+        fn=BeforeClusterUpdateSubHandler(namespace, name, hash, context)(),
+        id="before_cluster_update",
+        timeout=config.SCALING_TIMEOUT,
+    )
+    if do_upgrade:
+        kopf.register(
+            fn=UpgradeSubHandler(
+                namespace, name, hash, context, depends_on=depends_on.copy()
+            )(),
+            id="upgrade",
+        )
+        depends_on.append(f"{CLUSTER_UPDATE_ID}/upgrade")
+    if do_restart:
+        kopf.register(
+            fn=RestartSubHandler(
+                namespace, name, hash, context, depends_on=depends_on.copy()
+            )(),
+            id="restart",
+            timeout=config.ROLLING_RESTART_TIMEOUT,
+        )
+        depends_on.append(f"{CLUSTER_UPDATE_ID}/restart")
+
+    if do_scale:
+        kopf.register(
+            fn=ScaleSubHandler(
+                namespace, name, hash, context, depends_on=depends_on.copy()
+            )(),
+            id="scale",
+            timeout=config.SCALING_TIMEOUT,
+        )
+        depends_on.append(f"{CLUSTER_UPDATE_ID}/scale")
+    kopf.register(
+        fn=AfterClusterUpdateSubHandler(
+            namespace,
+            name,
+            hash,
+            context,
+            depends_on=depends_on.copy(),
+            run_on_dep_failures=True,
+        )(),
+        id="after_cluster_update",
+    )
+
+    patch.status[CLUSTER_UPDATE_ID] = context

--- a/crate/operator/handlers/handle_update_user_password_secret.py
+++ b/crate/operator/handlers/handle_update_user_password_secret.py
@@ -1,0 +1,57 @@
+import logging
+
+import kopf
+from kubernetes_asyncio.client import CoreV1Api, CustomObjectsApi
+from kubernetes_asyncio.client.api_client import ApiClient
+
+from crate.operator.config import config
+from crate.operator.constants import API_GROUP, RESOURCE_CRATEDB
+from crate.operator.update_user_password import update_user_password
+from crate.operator.utils.kopf import subhandler_partial
+from crate.operator.utils.kubeapi import get_host
+
+
+async def update_user_password_secret(
+    namespace: str,
+    name: str,
+    diff: kopf.Diff,
+    logger: logging.Logger,
+):
+    async with ApiClient() as api_client:
+        coapi = CustomObjectsApi(api_client)
+        core = CoreV1Api(api_client)
+
+        for operation, field_path, old_value, new_value in diff:
+            custom_objects = await coapi.list_namespaced_custom_object(
+                namespace=namespace,
+                group=API_GROUP,
+                version="v1",
+                plural=RESOURCE_CRATEDB,
+            )
+
+            for crate_custom_object in custom_objects["items"]:
+                host = await get_host(
+                    core, namespace, crate_custom_object["metadata"]["name"]
+                )
+
+                for user_spec in crate_custom_object["spec"]["users"]:
+                    expected_field_path = (
+                        "data",
+                        user_spec["password"]["secretKeyRef"]["key"],
+                    )
+                    if (
+                        user_spec["password"]["secretKeyRef"]["name"] == name
+                        and field_path == expected_field_path
+                    ):
+                        kopf.register(
+                            fn=subhandler_partial(
+                                update_user_password,
+                                host,
+                                user_spec["name"],
+                                old_value,
+                                new_value,
+                                logger,
+                            ),
+                            id=f"update-{crate_custom_object['metadata']['name']}-{user_spec['name']}",  # noqa
+                            timeout=config.BOOTSTRAP_TIMEOUT,
+                        )

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -14,99 +14,45 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import asyncio
-import hashlib
 import logging
-from typing import Any, Awaitable, Dict, List
 
 import kopf
-from kopf.structs.diffs import DiffItem, DiffOperation
-from kubernetes_asyncio.client import (
-    CoreV1Api,
-    CustomObjectsApi,
-    V1LocalObjectReference,
-    V1OwnerReference,
-)
-from kubernetes_asyncio.client.api_client import ApiClient
 
-from crate.operator.backup import create_backups
-from crate.operator.bootstrap import bootstrap_cluster
 from crate.operator.config import config
 from crate.operator.constants import (
     API_GROUP,
+    CLUSTER_UPDATE_ID,
     KOPF_STATE_STORE_PREFIX,
-    LABEL_COMPONENT,
     LABEL_MANAGED_BY,
-    LABEL_NAME,
     LABEL_PART_OF,
     LABEL_USER_PASSWORD,
     RESOURCE_CRATEDB,
-    Port,
 )
-from crate.operator.create import (
-    create_debug_volume,
-    create_services,
-    create_sql_exporter_config,
-    create_statefulset,
-    create_system_user,
+from crate.operator.handlers.handle_create_cratedb import create_cratedb
+from crate.operator.handlers.handle_migrate_discovery_service import (
+    migrate_discovery_service,
 )
-from crate.operator.edge import notify_service_ip
+from crate.operator.handlers.handle_migrate_user_password_label import (
+    migrate_user_password_label,
+)
+from crate.operator.handlers.handle_notify_external_ip_changed import (
+    external_ip_changed,
+)
+from crate.operator.handlers.handle_update_allowed_cidrs import (
+    update_service_allowed_cidrs,
+)
+from crate.operator.handlers.handle_update_cratedb import update_cratedb
+from crate.operator.handlers.handle_update_user_password_secret import (
+    update_user_password_secret,
+)
 from crate.operator.kube_auth import login_via_kubernetes_asyncio
-from crate.operator.operations import (
-    AfterClusterUpdateSubHandler,
-    BeforeClusterUpdateSubHandler,
-    RestartSubHandler,
-    get_total_nodes_count,
-)
-from crate.operator.scale import ScaleSubHandler
-from crate.operator.update_user_password import update_user_password
-from crate.operator.upgrade import UpgradeSubHandler
-from crate.operator.utils.kopf import subhandler_partial
-from crate.operator.utils.kubeapi import ensure_user_password_label, get_host
 from crate.operator.webhooks import webhook_client
 
 NO_VALUE = object()
 
 
-def get_master_nodes_names(nodes: Dict[str, Any]) -> List[str]:
-    """
-    Return the list of nodes service as master nodes in a CrateDB cluster.
-
-    The function takes the ``spec.nodes`` from a CrateDB custom resource
-    and checks if it defines explicit master nodes or not. Based on that, it
-    will return the list of node names.
-
-    :param nodes: The ``spec.nodes`` from a CrateDB custom resource.
-    """
-    if "master" in nodes:
-        # We have dedicated master nodes. They are going to form the cluster
-        # state.
-        return [f"master-{i}" for i in range(nodes["master"]["replicas"])]
-    else:
-        node = nodes["data"][0]
-        node_name = node["name"]
-        return [f"data-{node_name}-{i}" for i in range(node["replicas"])]
-
-
-async def with_timeout(awaitable: Awaitable, timeout: int, error: str) -> None:
-    """
-    Wait up to ``timeout`` seconds for ``awaitable`` to finish before failing.
-
-    When ``timeout`` is ``<= 0``, no timeout will be applied.
-
-    :raises kopf.PermanentError: When the timeout is reached, raises an error
-        with message ``errorr``.
-    """
-    try:
-        if timeout > 0:
-            awaitable = asyncio.wait_for(awaitable, timeout=timeout)  # type: ignore
-        await awaitable
-    except asyncio.TimeoutError:
-        raise kopf.PermanentError(error) from None
-
-
 @kopf.on.startup()
-async def startup(settings: kopf.OperatorSettings, **kwargs):
+async def startup(settings: kopf.OperatorSettings, **_kwargs):
     config.load()
     if (
         config.WEBHOOK_PASSWORD is not None
@@ -146,224 +92,10 @@ async def login(**kwargs):
 async def cluster_create(
     namespace: str, meta: kopf.Meta, spec: kopf.Spec, logger: logging.Logger, **_kwargs
 ):
-    name = meta["name"]
-    base_labels = {
-        LABEL_MANAGED_BY: "crate-operator",
-        LABEL_NAME: name,
-        LABEL_PART_OF: "cratedb",
-    }
-    cratedb_labels = base_labels.copy()
-    cratedb_labels[LABEL_COMPONENT] = "cratedb"
-    cratedb_labels.update(meta.get("labels", {}))
-
-    owner_references = [
-        V1OwnerReference(
-            api_version=f"{API_GROUP}/v1",
-            block_owner_deletion=True,
-            controller=True,
-            kind="CrateDB",
-            name=name,
-            uid=meta["uid"],
-        )
-    ]
-
-    image_pull_secrets = (
-        [V1LocalObjectReference(name=secret) for secret in config.IMAGE_PULL_SECRETS]
-        if config.IMAGE_PULL_SECRETS
-        else None
-    )
-
-    ports_spec = spec.get("ports", {})
-    http_port = ports_spec.get("http", Port.HTTP.value)
-    jmx_port = ports_spec.get("jmx", Port.JMX.value)
-    postgres_port = ports_spec.get("postgres", Port.POSTGRES.value)
-    prometheus_port = ports_spec.get("prometheus", Port.PROMETHEUS.value)
-    transport_port = ports_spec.get("transport", Port.TRANSPORT.value)
-
-    master_nodes = get_master_nodes_names(spec["nodes"])
-    total_nodes_count = get_total_nodes_count(spec["nodes"], "all")
-    data_nodes_count = get_total_nodes_count(spec["nodes"], "data")
-    crate_image = spec["cluster"]["imageRegistry"] + ":" + spec["cluster"]["version"]
-    has_master_nodes = "master" in spec["nodes"]
-    # The first StatefulSet we create references a set of master nodes. These
-    # can either be explicit CrateDB master nodes, or implicit ones, which
-    # would be the first set of nodes from the data nodes list.
-    #
-    # After the first StatefulSet was created, we set `treat_as_master` to
-    # `False` to indicate that all remaining StatefulSets are neither explicit
-    # nor implicit master nodes.
-    treat_as_master = True
-    cluster_name = spec["cluster"]["name"]
-    source_ranges = spec["cluster"].get("allowedCIDRs", None)
-
-    kopf.register(
-        fn=subhandler_partial(
-            create_sql_exporter_config,
-            owner_references,
-            namespace,
-            name,
-            cratedb_labels,
-            logger,
-        ),
-        id="sql_exporter_config",
-    )
-
-    kopf.register(
-        fn=subhandler_partial(
-            create_debug_volume,
-            owner_references,
-            namespace,
-            name,
-            cratedb_labels,
-            logger,
-        ),
-        id="debug_volume",
-    )
-
-    kopf.register(
-        fn=subhandler_partial(
-            create_system_user,
-            owner_references,
-            namespace,
-            name,
-            cratedb_labels,
-            logger,
-        ),
-        id="system_user",
-    )
-
-    kopf.register(
-        fn=subhandler_partial(
-            create_services,
-            owner_references,
-            namespace,
-            name,
-            cratedb_labels,
-            http_port,
-            postgres_port,
-            transport_port,
-            spec.get("cluster", {}).get("externalDNS"),
-            logger,
-            source_ranges,
-        ),
-        id="services",
-    )
-
-    if has_master_nodes:
-        kopf.register(
-            fn=subhandler_partial(
-                create_statefulset,
-                owner_references,
-                namespace,
-                name,
-                cratedb_labels,
-                treat_as_master,
-                False,
-                cluster_name,
-                "master",
-                "master-",
-                spec["nodes"]["master"],
-                master_nodes,
-                total_nodes_count,
-                data_nodes_count,
-                http_port,
-                jmx_port,
-                postgres_port,
-                prometheus_port,
-                transport_port,
-                crate_image,
-                spec["cluster"].get("ssl"),
-                spec["cluster"].get("settings"),
-                image_pull_secrets,
-                logger,
-            ),
-            id="statefulset_master",
-        )
-        treat_as_master = False
-
-    for node_spec in spec["nodes"]["data"]:
-        node_name = node_spec["name"]
-        kopf.register(
-            fn=subhandler_partial(
-                create_statefulset,
-                owner_references,
-                namespace,
-                name,
-                cratedb_labels,
-                treat_as_master,
-                True,
-                cluster_name,
-                node_name,
-                f"data-{node_name}-",
-                node_spec,
-                master_nodes,
-                total_nodes_count,
-                data_nodes_count,
-                http_port,
-                jmx_port,
-                postgres_port,
-                prometheus_port,
-                transport_port,
-                crate_image,
-                spec["cluster"].get("ssl"),
-                spec["cluster"].get("settings"),
-                image_pull_secrets,
-                logger,
-            ),
-            id=f"statefulset_data_{node_name}",
-        )
-        treat_as_master = False
-
-    if has_master_nodes:
-        master_node_pod = f"crate-master-{name}-0"
-    else:
-        node_name = spec["nodes"]["data"][0]["name"]
-        master_node_pod = f"crate-data-{node_name}-{name}-0"
-
-    kopf.register(
-        fn=subhandler_partial(
-            bootstrap_cluster,
-            namespace,
-            name,
-            master_node_pod,
-            spec["cluster"].get("license"),
-            "ssl" in spec["cluster"],
-            spec.get("users"),
-            logger,
-        ),
-        id="bootstrap",
-        timeout=config.BOOTSTRAP_TIMEOUT,
-        backoff=config.BOOTSTRAP_RETRY_DELAY,
-    )
-
-    if "backups" in spec:
-        if config.CLUSTER_BACKUP_IMAGE is None:
-            logger.info(
-                "Not deploying backup tools because no backup image is defined."
-            )
-        else:
-            backup_metrics_labels = base_labels.copy()
-            backup_metrics_labels[LABEL_COMPONENT] = "backup"
-            backup_metrics_labels.update(meta.get("labels", {}))
-            kopf.register(
-                fn=subhandler_partial(
-                    create_backups,
-                    owner_references,
-                    namespace,
-                    name,
-                    backup_metrics_labels,
-                    http_port,
-                    prometheus_port,
-                    spec["backups"],
-                    image_pull_secrets,
-                    "ssl" in spec["cluster"],
-                    logger,
-                ),
-                id="backup",
-            )
-
-
-CLUSTER_UPDATE_ID = "cluster_update"
+    """
+    Handles creation of CrateDB Clusters.
+    """
+    await create_cratedb(namespace, meta, spec, logger)
 
 
 @kopf.on.update(API_GROUP, "v1", RESOURCE_CRATEDB, id=CLUSTER_UPDATE_ID)
@@ -373,136 +105,27 @@ async def cluster_update(
     patch: kopf.Patch,
     status: kopf.Status,
     diff: kopf.Diff,
-    **kwargs,
+    **_kwargs,
 ):
     """
-    Handle cluster updates.
-
-    This is done as a chain of sub-handlers that depend on the previous ones completing.
-    The state of each handler is stored in the status field of the CrateDB
-    custom resource. Since the status field persists between runs of this handler
-    (even for unrelated runs), we calculate and store a hash of what changed as well.
-    This hash is then used by the sub-handlers to work out which run they are part of.
-
-    i.e., consider this status:
-
-    ::
-
-        status:
-          cluster_update:
-            ref: 24b527bf0eada363bf548f19b98dd9cb
-          cluster_update/after_cluster_update:
-            ref: 24b527bf0eada363bf548f19b98dd9cb
-            success: true
-          cluster_update/before_cluster_update:
-            ref: 24b527bf0eada363bf548f19b98dd9cb
-            success: true
-          cluster_update/scale:
-            ref: 24b527bf0eada363bf548f19b98dd9cb
-            success: true
-
-
-    here ``status.cluster_update.ref`` is the hash of the last diff that was being acted
-    upon. Since kopf *does not clean up statuses*, when we start a new run we check if
-    the hash matches - if not, it means we can disregard any refs that are not for this
-    run.
+    Handles updates to the CrateDB resource.
     """
-    context = status.get(CLUSTER_UPDATE_ID)
-    hash = hashlib.md5(str(diff).encode("utf-8")).hexdigest()
-    if not context:
-        context = {"ref": hash}
-    elif context.get("ref", "") != hash:
-        context["ref"] = hash
-
-    do_upgrade = False
-    do_restart = False
-    do_scale = False
-    for _, field_path, *_ in diff:
-        if field_path in {
-            ("spec", "cluster", "imageRegistry"),
-            ("spec", "cluster", "version"),
-        }:
-            do_upgrade = True
-            do_restart = True
-        elif field_path == ("spec", "nodes", "master", "replicas"):
-            do_scale = True
-        elif field_path == ("spec", "nodes", "data"):
-            do_scale = True
-
-    if not do_upgrade and not do_restart and not do_scale:
-        return
-
-    depends_on = [f"{CLUSTER_UPDATE_ID}/before_cluster_update"]
-    kopf.register(
-        fn=BeforeClusterUpdateSubHandler(namespace, name, hash, context)(),
-        id="before_cluster_update",
-        timeout=config.SCALING_TIMEOUT,
-    )
-    if do_upgrade:
-        kopf.register(
-            fn=UpgradeSubHandler(
-                namespace, name, hash, context, depends_on=depends_on.copy()
-            )(),
-            id="upgrade",
-        )
-        depends_on.append(f"{CLUSTER_UPDATE_ID}/upgrade")
-    if do_restart:
-        kopf.register(
-            fn=RestartSubHandler(
-                namespace, name, hash, context, depends_on=depends_on.copy()
-            )(),
-            id="restart",
-            timeout=config.ROLLING_RESTART_TIMEOUT,
-        )
-        depends_on.append(f"{CLUSTER_UPDATE_ID}/restart")
-
-    if do_scale:
-        kopf.register(
-            fn=ScaleSubHandler(
-                namespace, name, hash, context, depends_on=depends_on.copy()
-            )(),
-            id="scale",
-            timeout=config.SCALING_TIMEOUT,
-        )
-        depends_on.append(f"{CLUSTER_UPDATE_ID}/scale")
-    kopf.register(
-        fn=AfterClusterUpdateSubHandler(
-            namespace,
-            name,
-            hash,
-            context,
-            depends_on=depends_on.copy(),
-            run_on_dep_failures=True,
-        )(),
-        id="after_cluster_update",
-    )
-
-    patch.status[CLUSTER_UPDATE_ID] = context
+    await update_cratedb(namespace, name, patch, status, diff)
 
 
 @kopf.on.resume(API_GROUP, "v1", RESOURCE_CRATEDB)
 async def update_cratedb_resource(
     namespace: str,
-    name: str,
     spec: kopf.Spec,
-    **kwargs,
+    **_kwargs,
 ):
-    if "users" in spec:
-        async with ApiClient() as api_client:
-            for user_spec in spec["users"]:
-                core = CoreV1Api(api_client)
+    """
+    Migrates CrateDB secrets that do not have the LABEL_USER_PASSWORD label on them.
 
-                secret_name = user_spec["password"]["secretKeyRef"]["name"]
-                secret = await core.read_namespaced_secret(
-                    namespace=namespace, name=secret_name
-                )
-                if (
-                    secret.metadata.labels is None
-                    or LABEL_USER_PASSWORD not in secret.metadata.labels
-                ):
-                    await ensure_user_password_label(
-                        core, namespace, user_spec["password"]["secretKeyRef"]["name"]
-                    )
+    This handler here is for backwards-compatibility and will be removed in the next
+    major operator release.
+    """
+    await migrate_user_password_label(namespace, spec)
 
 
 @kopf.on.update("", "v1", "secrets", labels={LABEL_USER_PASSWORD: "true"})
@@ -511,46 +134,12 @@ async def secret_update(
     name: str,
     diff: kopf.Diff,
     logger: logging.Logger,
-    **kwargs,
+    **_kwargs,
 ):
-    async with ApiClient() as api_client:
-        coapi = CustomObjectsApi(api_client)
-        core = CoreV1Api(api_client)
-
-        for operation, field_path, old_value, new_value in diff:
-            custom_objects = await coapi.list_namespaced_custom_object(
-                namespace=namespace,
-                group=API_GROUP,
-                version="v1",
-                plural=RESOURCE_CRATEDB,
-            )
-
-            for crate_custom_object in custom_objects["items"]:
-                host = await get_host(
-                    core, namespace, crate_custom_object["metadata"]["name"]
-                )
-
-                for user_spec in crate_custom_object["spec"]["users"]:
-                    expected_field_path = (
-                        "data",
-                        user_spec["password"]["secretKeyRef"]["key"],
-                    )
-                    if (
-                        user_spec["password"]["secretKeyRef"]["name"] == name
-                        and field_path == expected_field_path
-                    ):
-                        kopf.register(
-                            fn=subhandler_partial(
-                                update_user_password,
-                                host,
-                                user_spec["name"],
-                                old_value,
-                                new_value,
-                                logger,
-                            ),
-                            id=f"update-{crate_custom_object['metadata']['name']}-{user_spec['name']}",  # noqa
-                            timeout=config.BOOTSTRAP_TIMEOUT,
-                        )
+    """
+    Handles changes to the password for a CrateDB cluster.
+    """
+    await update_user_password_secret(namespace, name, diff, logger)
 
 
 @kopf.on.field(API_GROUP, "v1", RESOURCE_CRATEDB, field="spec.cluster.allowedCIDRs")
@@ -561,26 +150,10 @@ async def service_cidr_changes(
     logger: logging.Logger,
     **_kwargs,
 ):
-    change: DiffItem = diff[0]
-    logger.info(f"Updating load balancer source ranges to {change.new}")
-
-    async with ApiClient() as api_client:
-        core = CoreV1Api(api_client)
-        # This also runs on creation events, so we want to double check that the service
-        # exists before attempting to do anything.
-        services = await core.list_namespaced_service(namespace=namespace)
-        service = next(
-            (svc for svc in services.items if svc.metadata.name == f"crate-{name}"),
-            None,
-        )
-        if not service:
-            return
-
-        await core.patch_namespaced_service(
-            name=f"crate-{name}",
-            namespace=namespace,
-            body={"spec": {"loadBalancerSourceRanges": change.new}},
-        )
+    """
+    Handles updates to the list of allowed CIDRs, and updates the relevant k8s Service.
+    """
+    await update_service_allowed_cidrs(namespace, name, diff, logger)
 
 
 @kopf.on.resume(
@@ -604,36 +177,7 @@ async def update_discovery_service_handler(
     This handler here is for backwards-compatibility and will be removed in the next
     major operator release.
     """
-    if not name.startswith("crate-discovery-"):
-        return
-
-    async with ApiClient() as api_client:
-        core = CoreV1Api(api_client)
-
-        service = await core.read_namespaced_service(name, namespace)
-
-        http_port = next(
-            (port for port in service.spec.ports if port.name == "http"), None
-        )
-
-        if http_port:
-            return
-
-        logger.info("Found old discovery service w/o HTTP port, patching: %s", name)
-
-        await core.patch_namespaced_service(
-            name,
-            namespace,
-            body={
-                "spec": {
-                    "ports": [
-                        {"name": "cluster", "port": Port.TRANSPORT.value},
-                        {"name": "http", "port": Port.HTTP.value},
-                        {"name": "psql", "port": Port.POSTGRES.value},
-                    ]
-                }
-            },
-        )
+    await migrate_discovery_service(namespace, name, logger)
 
 
 @kopf.on.field(
@@ -658,36 +202,4 @@ async def service_external_ip_update(
     This gets posted to the backend for further handling as a webhook
     (if webhooks are enabled).
     """
-    # Ignore the testing service
-    if config.TESTING and name.startswith("crate-testing"):
-        return
-
-    if len(diff) == 0:
-        return
-
-    op: DiffItem = diff[0]
-
-    # Don't care about IPs being removed (also does not happen)
-    if op.operation == DiffOperation.REMOVE:
-        return
-
-    # Sometimes when a service is just created, we get an _empty_ IP added,
-    # also ignore these.
-    if not op.new:
-        return
-
-    cluster_id = meta["labels"][LABEL_NAME]
-
-    if len(op.new) == 0:
-        logger.warning(f"No IP received for LoadBalancer {diff}")
-        return
-
-    # Most k8s clusters give out IP addresses to LoadBalancer services, however some
-    # (i.e. EKS) give hostnames instead. As far as Crate is concerned, these are
-    # treated the same.
-    # TODO: Multiple IPs?
-    ip = op.new[0].get("ip") or op.new[0].get("hostname")
-    if not ip:
-        logger.warning(f"Load balancer got neither IP nor hostname {op}")
-        return
-    await notify_service_ip(namespace, cluster_id, ip, logger)
+    await external_ip_changed(name, namespace, diff, meta, logger)

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -81,6 +81,26 @@ def get_total_nodes_count(nodes: Dict[str, Any], type: str = "all") -> int:
     return total.get(type, 0)
 
 
+def get_master_nodes_names(nodes: Dict[str, Any]) -> List[str]:
+    """
+    Return the list of nodes service as master nodes in a CrateDB cluster.
+
+    The function takes the ``spec.nodes`` from a CrateDB custom resource
+    and checks if it defines explicit master nodes or not. Based on that, it
+    will return the list of node names.
+
+    :param nodes: The ``spec.nodes`` from a CrateDB custom resource.
+    """
+    if "master" in nodes:
+        # We have dedicated master nodes. They are going to form the cluster
+        # state.
+        return [f"master-{i}" for i in range(nodes["master"]["replicas"])]
+    else:
+        node = nodes["data"][0]
+        node_name = node["name"]
+        return [f"data-{node_name}-{i}" for i in range(node["replicas"])]
+
+
 async def get_pods_in_cluster(
     core: CoreV1Api, namespace: str, name: str
 ) -> Tuple[Tuple[str], Tuple[str]]:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

`main.py`, at several hundred lines long, was getting ridiculous and out of hands. This introduces a new pattern of only declaring the `@kopf.on.*` handlers in `main.py` itself, and implementing the handling in a separate package, which is cleaner.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
