### PR TITLE
CrateDB status ping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 
 Unreleased
 ----------
+* Added a kopf timer function that retrieves the cluster health for all CrateDB clusters
+  the operator knows off and sends the corresponding notification.
 
 * Changed the operator to use the internal ``discovery`` service for all operations
   on the cluster, because the public ``crate`` service might be IP-restricted.

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -110,6 +110,10 @@ class Config:
     #: and `recover_after_nodes`
     GATEWAY_SETTINGS_DATA_NODES_VERSION: str = "4.7.0"
 
+    #: Interval in seconds for which the operator will ping CrateDBs for their
+    #: current health.
+    CRATEDB_STATUS_CHECK_INTERVAL: Optional[int] = 60
+
     def __init__(self, *, prefix: str):
         self._prefix = prefix
 
@@ -254,6 +258,19 @@ class Config:
             "WEBHOOK_USERNAME", default=self.WEBHOOK_USERNAME
         )
         self.JOBS_TABLE = self.env("JOBS_TABLE", default=self.JOBS_TABLE)
+        cratedb_status_interval = int(
+            self.env(
+                "CRATEDB_STATUS_CHECK_INTERVAL",
+                default=self.CRATEDB_STATUS_CHECK_INTERVAL,
+            )
+        )
+        try:
+            self.CRATEDB_STATUS_CHECK_INTERVAL = cratedb_status_interval
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}CRATEDB_STATUS_CHECK_INTERVAL="
+                f"'{cratedb_status_interval}'. Needs to be a positive integer or 0."
+            )
 
     def env(self, name: str, *, default=UNDEFINED) -> str:
         """

--- a/crate/operator/handlers/handle_ping_cratedb_status.py
+++ b/crate/operator/handlers/handle_ping_cratedb_status.py
@@ -1,0 +1,46 @@
+import logging
+
+from kubernetes_asyncio.client import CoreV1Api
+from kubernetes_asyncio.client.api_client import ApiClient
+
+from crate.operator.cratedb import HEALTHINESS, connection_factory, get_healthiness
+from crate.operator.utils.kubeapi import get_host, get_system_user_password
+from crate.operator.webhooks import (
+    WebhookClusterHealthPayload,
+    WebhookEvent,
+    WebhookStatus,
+    webhook_client,
+)
+
+
+async def ping_cratedb_status(
+    namespace: str,
+    name: str,
+    logger: logging.Logger,
+) -> None:
+    async with ApiClient() as api_client:
+        core = CoreV1Api(api_client)
+        host = await get_host(core, namespace, name)
+        password = await get_system_user_password(core, namespace, name)
+        conn_factory = connection_factory(host, password)
+
+        async with conn_factory() as conn:
+            async with conn.cursor() as cursor:
+                try:
+                    healthiness = await get_healthiness(cursor)
+                    # If there are no tables in the cluster, get_healthiness returns
+                    # none: default to `Green`, as cluster is reachable
+                    status = HEALTHINESS.get(healthiness, "GREEN")
+                except Exception as e:
+                    logger.warning("Failed to ping cluster.", exc_info=e)
+                    status = "UNREACHABLE"
+
+        await webhook_client.send_notification(
+            namespace,
+            name,
+            WebhookEvent.HEALTH,
+            WebhookClusterHealthPayload(status=status),
+            WebhookStatus.SUCCESS,
+            logger,
+            unsafe=False,
+        )

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -38,6 +38,7 @@ from crate.operator.handlers.handle_migrate_user_password_label import (
 from crate.operator.handlers.handle_notify_external_ip_changed import (
     external_ip_changed,
 )
+from crate.operator.handlers.handle_ping_cratedb_status import ping_cratedb_status
 from crate.operator.handlers.handle_update_allowed_cidrs import (
     update_service_allowed_cidrs,
 )
@@ -203,3 +204,10 @@ async def service_external_ip_update(
     (if webhooks are enabled).
     """
     await external_ip_changed(name, namespace, diff, meta, logger)
+
+
+@kopf.timer(
+    API_GROUP, "v1", RESOURCE_CRATEDB, interval=config.CRATEDB_STATUS_CHECK_INTERVAL
+)
+async def ping_cratedb(namespace: str, name: str, logger: logging.Logger, **kwargs):
+    await ping_cratedb_status(namespace, name, logger)

--- a/crate/operator/webhooks.py
+++ b/crate/operator/webhooks.py
@@ -28,6 +28,7 @@ class WebhookEvent(str, enum.Enum):
     SNAPSHOT = "snapshot"
     DELAY = "delay"
     INFO_CHANGED = "info_changed"
+    HEALTH = "health"
 
 
 class WebhookStatus(str, enum.Enum):
@@ -67,6 +68,10 @@ class WebhookInfoChangedPayload(WebhookSubPayload):
     external_ip: str
 
 
+class WebhookClusterHealthPayload(WebhookSubPayload):
+    status: str
+
+
 class WebhookPayload(TypedDict):
     event: WebhookEvent
     status: WebhookStatus
@@ -76,6 +81,7 @@ class WebhookPayload(TypedDict):
     upgrade_data: Optional[WebhookUpgradePayload]
     temporary_failure_data: Optional[WebhookTemporaryFailurePayload]
     info_data: Optional[WebhookInfoChangedPayload]
+    health_data: Optional[WebhookClusterHealthPayload]
 
 
 class WebhookClient:
@@ -139,6 +145,7 @@ class WebhookClient:
         upgrade_data: Optional[WebhookUpgradePayload] = None,
         temporary_failure_data: Optional[WebhookTemporaryFailurePayload] = None,
         info_data: Optional[WebhookInfoChangedPayload] = None,
+        health_data: Optional[WebhookClusterHealthPayload] = None,
         unsafe: Optional[bool] = False,
         logger: logging.Logger,
     ) -> Optional[aiohttp.ClientResponse]:
@@ -176,6 +183,7 @@ class WebhookClient:
             upgrade_data=upgrade_data,
             temporary_failure_data=temporary_failure_data,
             info_data=info_data,
+            health_data=health_data,
         )
 
         logger.info(
@@ -246,6 +254,8 @@ class WebhookClient:
             kwargs = {"temporary_failure_data": sub_payload}
         elif event == WebhookEvent.INFO_CHANGED:
             kwargs = {"info_data": sub_payload}
+        elif event == WebhookEvent.HEALTH:
+            kwargs = {"health_data": sub_payload}
         else:
             raise ValueError(f"Unknown event '{event}'")
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Added a kopf timer function that retrieves the cluster health for all CrateDB clusters
the operator knows off and sends the corresponding notification to the Cloud-API.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
