### PR TITLE
Upgrading to the latest stable version of kopf

### DIFF
--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 
 import kopf
 from aiopg import Cursor
-from kopf.structs.diffs import diff as calc_diff
+from kopf._cogs.structs.diffs import diff as calc_diff
 from kubernetes_asyncio.client import (
     AppsV1Api,
     CoreV1Api,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,18 +54,7 @@ exclude_patterns: List[str] = []
 nitpick_ignore = [
     # undoc'd; https://docs.python.org/3/distutils/apiref.html#module-distutils.version
     ("py:class", "distutils.version.Version"),
-    # kopf has moved on - the intersphinx documentation is broken because we're using
-    # an older version of kopf that is no longer documented on readthedocs.
-    # FIXME: Remove these once we upgrade to a recent version of kopf.
-    ("py:class", "kopf.structs.bodies.Body"),
-    ("py:class", "kopf.structs.bodies.Status"),
-    ("py:class", "kopf.structs.bodies.Meta"),
-    ("py:class", "kopf.structs.bodies.Spec"),
-    ("py:class", "kopf.structs.diffs.Diff"),
-    ("py:class", "kopf.structs.diffs.DiffItem"),
-    ("py:class", "kopf.structs.patches.Patch"),
-    ("py:class", "kopf.structs.credentials.ConnectionInfo"),
-    ("py:class", "kopf.structs.configuration.OperatorSettings"),
+    # FIXME: fix kopf here
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,6 @@ exclude_patterns: List[str] = []
 nitpick_ignore = [
     # undoc'd; https://docs.python.org/3/distutils/apiref.html#module-distutils.version
     ("py:class", "distutils.version.Version"),
-    # FIXME: fix kopf here
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,7 @@ setup(
     install_requires=[
         "aiopg==1.3.3",
         "bitmath==1.3.3.1",
-        "kopf==0.28.3",
-        # kopf depends on an undefined click version, and the latest (8.0.0) has broken
-        # backwards-compatibility. Fixing the version here instead.
-        "click==7.1.2",
+        "kopf==1.35.1",
         "kubernetes-asyncio==18.20.0",
         "PyYAML<7.0",
         "prometheus_client==0.12.0",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This is a WIP PR upgrading to the latest kopf. So far it seems that everything is compatible, but will need to be thoroughly tested. We are using one interface that is now protected (`from kopf._cogs.structs.diffs`).

References #217 


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
