### PR TITLE
Partially revert how we use setuptools_scm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     packages=find_namespace_packages(include=["crate.*"]),
     include_package_data=True,
     package_data={"crate.operator": ["data/*"]},
+    setup_requires=["setuptools>=58", "setuptools_scm>=6.2"],
     install_requires=[
         "aiopg==1.3.2",
         "bitmath==1.3.3.1",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

To maintain backwards-compatibility with the tagging script.

To be fair, I'm not entirely sure how this is supposed to work. If I simply have the build dependencies in `pyproject.toml`, they are not installed when we do a `pip install -e .`.

Reverting this now, as the tagging script stopped working as a result of this, but looking forward to some ideas.

CC @amotl @tomach 

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
