### PR TITLE
Expose a Prometheus metrics endpoint

### DIFF
--- a/crate/operator/__init__.py
+++ b/crate/operator/__init__.py
@@ -13,3 +13,10 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from pkg_resources import DistributionNotFound, get_distribution
+
+try:
+    __version__ = get_distribution("crate-operator").version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -114,6 +114,9 @@ class Config:
     #: current health.
     CRATEDB_STATUS_CHECK_INTERVAL: Optional[int] = 60
 
+    #: The port on which prometheus exposes metrics
+    PROMETHEUS_PORT: int = 8080
+
     def __init__(self, *, prefix: str):
         self._prefix = prefix
 
@@ -265,11 +268,25 @@ class Config:
             )
         )
         try:
-            self.CRATEDB_STATUS_CHECK_INTERVAL = cratedb_status_interval
+            self.CRATEDB_STATUS_CHECK_INTERVAL = int(cratedb_status_interval)
         except ValueError:
             raise ConfigurationError(
                 f"Invalid {self._prefix}CRATEDB_STATUS_CHECK_INTERVAL="
                 f"'{cratedb_status_interval}'. Needs to be a positive integer or 0."
+            )
+
+        prometheus_port = int(
+            self.env(
+                "PROMETHEUS_PORT",
+                default=self.PROMETHEUS_PORT,
+            )
+        )
+        try:
+            self.PROMETHEUS_PORT = int(prometheus_port)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}PROMETHEUS_PORT="
+                f"'{cratedb_status_interval}'. Needs to be a positive integer."
             )
 
     def env(self, name: str, *, default=UNDEFINED) -> str:

--- a/crate/operator/handlers/handle_ping_cratedb_status.py
+++ b/crate/operator/handlers/handle_ping_cratedb_status.py
@@ -1,9 +1,12 @@
+import enum
 import logging
+import time
 
 from kubernetes_asyncio.client import CoreV1Api
 from kubernetes_asyncio.client.api_client import ApiClient
 
-from crate.operator.cratedb import HEALTHINESS, connection_factory, get_healthiness
+from crate.operator.cratedb import connection_factory, get_healthiness
+from crate.operator.prometheus import cluster_last_seen_gauge, cluster_status_gauge
 from crate.operator.utils.kubeapi import get_host, get_system_user_password
 from crate.operator.webhooks import (
     WebhookClusterHealthPayload,
@@ -11,6 +14,20 @@ from crate.operator.webhooks import (
     WebhookStatus,
     webhook_client,
 )
+
+
+class PrometheusStatus(enum.Enum):
+    GREEN = 0
+    YELLOW = 1
+    RED = 2
+    UNREACHABLE = 3
+
+
+HEALTHINESS_TO_STATUS = {
+    1: PrometheusStatus.GREEN,
+    2: PrometheusStatus.YELLOW,
+    3: PrometheusStatus.RED,
+}
 
 
 async def ping_cratedb_status(
@@ -24,22 +41,28 @@ async def ping_cratedb_status(
         password = await get_system_user_password(core, namespace, name)
         conn_factory = connection_factory(host, password)
 
-        async with conn_factory() as conn:
-            async with conn.cursor() as cursor:
-                try:
+        try:
+            async with conn_factory() as conn:
+                async with conn.cursor() as cursor:
                     healthiness = await get_healthiness(cursor)
                     # If there are no tables in the cluster, get_healthiness returns
                     # none: default to `Green`, as cluster is reachable
-                    status = HEALTHINESS.get(healthiness, "GREEN")
-                except Exception as e:
-                    logger.warning("Failed to ping cluster.", exc_info=e)
-                    status = "UNREACHABLE"
+                    status = HEALTHINESS_TO_STATUS.get(
+                        healthiness, PrometheusStatus.GREEN
+                    )
+        except Exception as e:
+            logger.warning("Failed to ping cluster.", exc_info=e)
+            status = PrometheusStatus.UNREACHABLE
+
+        cluster_status_gauge.labels(cluster_id=name).set(status.value)
+        if status != PrometheusStatus.UNREACHABLE:
+            cluster_last_seen_gauge.labels(cluster_id=name).set(int(time.time()))
 
         await webhook_client.send_notification(
             namespace,
             name,
             WebhookEvent.HEALTH,
-            WebhookClusterHealthPayload(status=status),
+            WebhookClusterHealthPayload(status=status.name),
             WebhookStatus.SUCCESS,
             logger,
         )

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -17,6 +17,7 @@
 import logging
 
 import kopf
+from prometheus_client import start_http_server
 
 from crate.operator.config import config
 from crate.operator.constants import (
@@ -82,6 +83,10 @@ async def startup(settings: kopf.OperatorSettings, **_kwargs):
     settings.watching.connect_timeout = 30
     # Wait for that many seconds between watching events
     settings.watching.reconnect_backoff = 1
+
+    # Only start the prometheus server in non-testing mode.
+    if not config.TESTING:
+        start_http_server(config.PROMETHEUS_PORT)
 
 
 @kopf.on.login()

--- a/crate/operator/prometheus.py
+++ b/crate/operator/prometheus.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from prometheus_client import Gauge, Info
+
+from crate.operator import __version__
+
+i = Info("svc", "Service Info")
+i.info(
+    {
+        "name": "crate-operator",
+        "version": __version__,
+        "started": datetime.utcnow().isoformat(),
+    }
+)
+
+cluster_status_gauge = Gauge(
+    "cloud_clusters_health",
+    documentation="0->GREEN, 1->YELLOW, 2->RED, 3->UNREACHABLE",
+    labelnames=["cluster_id"],
+)
+
+cluster_last_seen_gauge = Gauge(
+    "cloud_clusters_last_seen",
+    documentation="Unix timestamp of when a cluster was last seen (not unreachable)",
+    labelnames=["cluster_id"],
+)

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "click==7.1.2",
         "kubernetes-asyncio==18.20.0",
         "PyYAML<7.0",
+        "prometheus_client==0.12.0",
         # Versions 3.8+ incompatible with pytest-aiohttp.
         "aiohttp<=3.7.4",
     ],


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

By default, on port 8080.

This also exposes cluster health metrics for each running cluster.

Once deployed, we can use this for the `CloudClusterHealthStatusError` and `CloudClusterLastSeenTooOld` alerts instead of using the API metrics.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
