### PR TITLE
Fix version of aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         "click==7.1.2",
         "kubernetes-asyncio==18.20.0",
         "PyYAML<7.0",
+        # Versions 3.8+ incompatible with pytest-aiohttp.
+        "aiohttp<3.8",
     ],
     extras_require={
         "docs": [


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

A new one was released (3.8.0) that is incompatible with pytest-aiohttp. There is no newer version of pytest-aiohttp.


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
