### PR TITLE
Rework cluster health metric gathering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Changed how the metrics are reported so that they disappear if a cluster is deleted.
+
 2.7.0 (2021-11-09)
 ------------------
 

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -1,3 +1,19 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import logging
 
 import kopf

--- a/crate/operator/handlers/handle_migrate_discovery_service.py
+++ b/crate/operator/handlers/handle_migrate_discovery_service.py
@@ -1,3 +1,19 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import logging
 
 from kubernetes_asyncio.client import CoreV1Api

--- a/crate/operator/handlers/handle_migrate_user_password_label.py
+++ b/crate/operator/handlers/handle_migrate_user_password_label.py
@@ -1,3 +1,19 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import kopf
 from kubernetes_asyncio.client import CoreV1Api
 from kubernetes_asyncio.client.api_client import ApiClient

--- a/crate/operator/handlers/handle_notify_external_ip_changed.py
+++ b/crate/operator/handlers/handle_notify_external_ip_changed.py
@@ -1,3 +1,19 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import logging
 
 import kopf

--- a/crate/operator/handlers/handle_update_allowed_cidrs.py
+++ b/crate/operator/handlers/handle_update_allowed_cidrs.py
@@ -1,3 +1,19 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import logging
 
 import kopf

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -1,3 +1,19 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import hashlib
 
 import kopf

--- a/crate/operator/handlers/handle_update_user_password_secret.py
+++ b/crate/operator/handlers/handle_update_user_password_secret.py
@@ -1,3 +1,19 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import logging
 
 import kopf

--- a/crate/operator/prometheus.py
+++ b/crate/operator/prometheus.py
@@ -1,6 +1,26 @@
-from datetime import datetime
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from prometheus_client import Gauge, Info
+import enum
+import time
+from datetime import datetime
+from typing import Optional
+
+from prometheus_client import REGISTRY, Info
+from prometheus_client.core import GaugeMetricFamily
 
 from crate.operator import __version__
 
@@ -13,14 +33,51 @@ i.info(
     }
 )
 
-cluster_status_gauge = Gauge(
-    "cloud_clusters_health",
-    documentation="0->GREEN, 1->YELLOW, 2->RED, 3->UNREACHABLE",
-    labelnames=["cluster_id"],
-)
+CLUSTER_METRICS = {}
+LAST_SEEN_THRESHOLD = 300
 
-cluster_last_seen_gauge = Gauge(
-    "cloud_clusters_last_seen",
-    documentation="Unix timestamp of when a cluster was last seen (not unreachable)",
-    labelnames=["cluster_id"],
-)
+
+class PrometheusClusterStatus(enum.Enum):
+    GREEN = 0
+    YELLOW = 1
+    RED = 2
+    UNREACHABLE = 3
+
+
+def report_cluster_status(
+    cluster_id: str,
+    status: PrometheusClusterStatus,
+    last_reported: Optional[int] = None,
+):
+    CLUSTER_METRICS[cluster_id] = {
+        "status": status,
+        "last_reported": last_reported if last_reported else int(time.time()),
+    }
+
+
+class ClusterCollector:
+    def collect(self):
+        now = time.time()
+        cloud_clusters_health = GaugeMetricFamily(
+            "cloud_clusters_health",
+            "0->GREEN, 1->YELLOW, 2->RED, 3->UNREACHABLE",
+            labels=["cluster_id"],
+        )
+        cloud_clusters_last_seen = GaugeMetricFamily(
+            "cloud_clusters_last_seen",
+            "Unix timestamp of when a cluster was last seen (not unreachable).",
+            labels=["cluster_id"],
+        )
+        for cluster_id, metrics in CLUSTER_METRICS.items():
+            if now - metrics["last_reported"] < LAST_SEEN_THRESHOLD:
+                cloud_clusters_health.add_metric([cluster_id], metrics["status"].value)
+                if metrics["status"] != PrometheusClusterStatus.UNREACHABLE:
+                    cloud_clusters_last_seen.add_metric(
+                        [cluster_id], metrics["last_reported"]
+                    )
+
+        yield cloud_clusters_health
+        yield cloud_clusters_last_seen
+
+
+REGISTRY.register(ClusterCollector())

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,65 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2020 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import time
+
+from prometheus_client import REGISTRY
+
+from crate.operator.prometheus import PrometheusClusterStatus, report_cluster_status
+
+
+def test_will_report_metrics_for_clusters():
+    last_reported = int(time.time())
+    report_cluster_status("id", PrometheusClusterStatus.GREEN, last_reported)
+    metrics = list(REGISTRY.collect())
+    cloud_clusters_health = next(
+        filter(lambda metric: metric.name == "cloud_clusters_health", metrics), None
+    )
+    cloud_clusters_last_seen = next(
+        filter(lambda metric: metric.name == "cloud_clusters_last_seen", metrics), None
+    )
+    assert cloud_clusters_health.samples[0].value == 0
+    assert cloud_clusters_last_seen.samples[0].value == last_reported
+
+
+def test_will_expire_clusters_that_have_not_reported_for_a_while():
+    last_reported = int(time.time()) - 100000
+    report_cluster_status("id", PrometheusClusterStatus.GREEN, last_reported)
+    metrics = list(REGISTRY.collect())
+    cloud_clusters_health = next(
+        filter(lambda metric: metric.name == "cloud_clusters_health", metrics), None
+    )
+    cloud_clusters_last_seen = next(
+        filter(lambda metric: metric.name == "cloud_clusters_last_seen", metrics), None
+    )
+    assert cloud_clusters_health.samples == []
+    assert cloud_clusters_last_seen.samples == []
+
+
+def test_will_not_report_last_seen_for_unreachable_clusters():
+    report_cluster_status("id", PrometheusClusterStatus.UNREACHABLE)
+    metrics = list(REGISTRY.collect())
+    cloud_clusters_health = next(
+        filter(lambda metric: metric.name == "cloud_clusters_health", metrics), None
+    )
+    cloud_clusters_last_seen = next(
+        filter(lambda metric: metric.name == "cloud_clusters_last_seen", metrics), None
+    )
+    assert (
+        cloud_clusters_health.samples[0].value
+        == PrometheusClusterStatus.UNREACHABLE.value
+    )
+    assert cloud_clusters_last_seen.samples == []


### PR DESCRIPTION
## Summary of changes

Prior to this change, metrics would "hang around" even if a cluster is deleted. This created a problem as deleted clusters would then trigger the LastSeenTooOld alert and 24x7.

The new method instead has a metric gatherer, which only reports metrics for clusters that exist. If a cluster is deleted, it's metrics will disappear in a few minutes and we won't get alerted.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
