### PR TITLE
Add notifications for exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,21 @@ Changelog
 Unreleased
 ----------
 
+* Replaced kopf timeout handling with a decorator ``@crate.timeout()`` to be
+  able to run code when a timeout happens.
+
+* Added a decorator ``@crate.on.error()`` which catches timeouts as well as
+  other permanent handler errors and performs actions passed in an error
+  handler, like sending a notification.
+
+* Fixed the issue that notifications of successful upgrades pile up in the
+  status of the CrateDB resource if an upgrade succeeds but the subsequent
+  restart fails or times out. These notifications were erroneously sent in the
+  next run of the handler.
+
+* Changed the registration of all kopf subhandlers in the creation process
+  to use StateBasedSubhandler.
+
 2.7.1 (2021-11-12)
 ------------------
 

--- a/crate/operator/backup.py
+++ b/crate/operator/backup.py
@@ -43,6 +43,8 @@ from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import LABEL_COMPONENT, LABEL_NAME, SYSTEM_USERNAME
+from crate.operator.utils import crate
+from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import call_kubeapi
 from crate.operator.utils.typing import LabelType
 
@@ -304,3 +306,34 @@ async def create_backups(
                     has_ssl,
                 ),
             )
+
+
+class CreateBackupsSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_create_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        owner_references: Optional[List[V1OwnerReference]],
+        backup_metrics_labels: LabelType,
+        http_port: int,
+        prometheus_port: int,
+        backups: Dict[str, Any],
+        image_pull_secrets: Optional[List[V1LocalObjectReference]],
+        has_ssl: bool,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+
+        await create_backups(
+            owner_references,
+            namespace,
+            name,
+            backup_metrics_labels,
+            http_port,
+            prometheus_port,
+            backups,
+            image_pull_secrets,
+            has_ssl,
+            logger,
+        )

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -26,6 +26,8 @@ from psycopg2.extensions import QuotedString
 from crate.operator.config import config
 from crate.operator.constants import CONNECT_TIMEOUT, SYSTEM_USERNAME
 from crate.operator.cratedb import create_user, get_connection
+from crate.operator.utils import crate
+from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import (
     ensure_user_password_label,
     get_host,
@@ -297,6 +299,7 @@ async def bootstrap_users(
 
 
 async def bootstrap_cluster(
+    core: CoreV1Api,
     namespace: str,
     name: str,
     master_node_pod: str,
@@ -309,6 +312,7 @@ async def bootstrap_cluster(
     Bootstrap an entire cluster, including license, system user, and additional
     users.
 
+    :param core: An instance of the Kubernetes Core V1 API.
     :param namespace: The Kubernetes namespace for the CrateDB cluster.
     :param name: The name for the ``CrateDB`` custom resource. Used to lookup
         the password for the system user created during deployment.
@@ -327,18 +331,36 @@ async def bootstrap_cluster(
     """
     # We first need to set the license, in case the CrateDB cluster
     # contains more nodes than available in the free license.
-    async with ApiClient() as api_client:
-        core = CoreV1Api(api_client)
-        if license:
-            await bootstrap_license(
-                core, namespace, master_node_pod, has_ssl, license, logger
-            )
-        await bootstrap_system_user(
-            core, namespace, name, master_node_pod, has_ssl, logger
+
+    if license:
+        await bootstrap_license(
+            core, namespace, master_node_pod, has_ssl, license, logger
         )
-        if users:
-            await bootstrap_users(core, namespace, name, users)
+    await bootstrap_system_user(core, namespace, name, master_node_pod, has_ssl, logger)
+    if users:
+        await bootstrap_users(core, namespace, name, users)
 
 
 def _temporary_error():
     return TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)
+
+
+class BootstrapClusterSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_create_failed_notification)
+    @crate.timeout(timeout=float(config.BOOTSTRAP_TIMEOUT))
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        master_node_pod: str,
+        license: Optional[SecretKeyRefContainer],
+        has_ssl: bool,
+        users: Optional[List[Dict[str, Any]]],
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+            await bootstrap_cluster(
+                core, namespace, name, master_node_pod, license, has_ssl, users, logger
+            )

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -38,7 +38,7 @@ class Config:
     #: Time in seconds for which the operator will continue and wait to
     #: bootstrap a cluster. Once this threshold has passed, a bootstrapping is
     #: considered failed
-    BOOTSTRAP_TIMEOUT: Optional[int] = 1800
+    BOOTSTRAP_TIMEOUT: int = 1800
 
     #: Time in seconds between the retries when bootstrapping the cluster.
     #: This can be safely lowered if the k8s environment is quick to act and

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -33,6 +33,7 @@ CONNECT_TIMEOUT = 10.0
 KOPF_STATE_STORE_PREFIX = f"operator.{API_GROUP}"
 
 CLUSTER_UPDATE_ID = "cluster_update"
+CLUSTER_CREATE_ID = "cluster_create"
 
 
 class CloudProvider(str, enum.Enum):

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -48,6 +48,7 @@ from crate.operator.handlers.handle_update_user_password_secret import (
     update_user_password_secret,
 )
 from crate.operator.kube_auth import login_via_kubernetes_asyncio
+from crate.operator.utils import crate
 from crate.operator.webhooks import webhook_client
 
 NO_VALUE = object()
@@ -95,16 +96,24 @@ async def login(**kwargs):
 
 
 @kopf.on.create(API_GROUP, "v1", RESOURCE_CRATEDB)
+@crate.on.error(error_handler=crate.send_create_failed_notification)
 async def cluster_create(
-    namespace: str, meta: kopf.Meta, spec: kopf.Spec, logger: logging.Logger, **_kwargs
+    namespace: str,
+    meta: kopf.Meta,
+    spec: kopf.Spec,
+    patch: kopf.Patch,
+    status: kopf.Status,
+    logger: logging.Logger,
+    **_kwargs,
 ):
     """
     Handles creation of CrateDB Clusters.
     """
-    await create_cratedb(namespace, meta, spec, logger)
+    await create_cratedb(namespace, meta, spec, patch, status, logger)
 
 
 @kopf.on.update(API_GROUP, "v1", RESOURCE_CRATEDB, id=CLUSTER_UPDATE_ID)
+@crate.on.error(error_handler=crate.send_update_failed_notification)
 async def cluster_update(
     namespace: str,
     name: str,

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -45,6 +45,7 @@ from crate.operator.cratedb import (
     reset_cluster_setting,
     set_cluster_setting,
 )
+from crate.operator.utils import crate
 from crate.operator.utils.kopf import StateBasedSubHandler, subhandler_partial
 from crate.operator.utils.kubeapi import (
     call_kubeapi,
@@ -245,6 +246,8 @@ async def restart_cluster(
 
 
 class RestartSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(config.ROLLING_RESTART_TIMEOUT))
     async def handle(  # type: ignore
         self,
         namespace: str,
@@ -269,6 +272,8 @@ CRONJOB_NAME = "cronjob_name"
 
 
 class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(config.SCALING_TIMEOUT))
     async def handle(  # type: ignore
         self,
         namespace: str,
@@ -417,6 +422,7 @@ class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
 
 
 class AfterClusterUpdateSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
     async def handle(  # type: ignore
         self,
         namespace: str,

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -35,7 +35,7 @@ from kubernetes_asyncio.stream import WsApiClient
 from crate.operator.config import config
 from crate.operator.cratedb import connection_factory, is_cluster_healthy
 from crate.operator.operations import get_total_nodes_count
-from crate.operator.utils import quorum
+from crate.operator.utils import crate, quorum
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import get_host, get_system_user_password
 from crate.operator.utils.version import CrateVersion
@@ -585,6 +585,8 @@ async def scale_cluster(
 
 
 class ScaleSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(config.SCALING_TIMEOUT))
     async def handle(  # type: ignore
         self,
         namespace: str,

--- a/crate/operator/utils/crate/__init__.py
+++ b/crate/operator/utils/crate/__init__.py
@@ -1,5 +1,5 @@
 # CrateDB Kubernetes Operator
-# Copyright (C) 2020 Crate.IO GmbH
+# Copyright (C) 2021 Crate.IO GmbH
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -14,16 +14,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from kopf import PermanentError
+from crate.operator.utils.crate import on
+from crate.operator.utils.crate.on import (
+    send_create_failed_notification,
+    send_update_failed_notification,
+    timeout,
+)
 
-
-class ConfigurationError(ValueError):
-    """
-    Exception raised when there are configuration issues with the operator.
-    """
-
-    pass
-
-
-class SubHandlerFailedDependencyError(PermanentError):
-    """An error for the subhandler's failed ependencies."""
+__all__ = [
+    "on",
+    "send_create_failed_notification",
+    "send_update_failed_notification",
+    "timeout",
+]

--- a/crate/operator/utils/crate/on.py
+++ b/crate/operator/utils/crate/on.py
@@ -1,0 +1,130 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from typing import Callable
+
+import kopf
+import wrapt
+
+from crate.operator.webhooks import (
+    WebhookEvent,
+    WebhookOperation,
+    WebhookPermanentErrorPayload,
+    WebhookStatus,
+    webhook_client,
+)
+
+
+async def _send_error_notification(
+    *,
+    namespace: str,
+    name: str,
+    reason: str,
+    operation: WebhookOperation,
+    logger: logging.Logger,
+    **kwargs,
+) -> None:
+    await webhook_client.send_notification(
+        namespace,
+        name,
+        WebhookEvent.ERROR,
+        WebhookPermanentErrorPayload(reason=reason, operation=operation),
+        WebhookStatus.FAILURE,
+        logger,
+    )
+
+
+async def send_update_failed_notification(*args, **kwargs):
+    await _send_error_notification(
+        *args, **{**kwargs, "operation": WebhookOperation.UPDATE}
+    )
+
+
+async def send_create_failed_notification(*args, **kwargs):
+    await _send_error_notification(
+        *args, **{**kwargs, "operation": WebhookOperation.CREATE}
+    )
+
+
+def timeout(*, timeout: float) -> Callable:
+    """
+    The ``@crate.timeout()`` decorator for kopf handlers or StateBasedSubHandler.
+    It checks if the runtime passed as kwarg to all handlers exceeded the given
+    timeout and raises a kopf.HandlerTimeoutError accordingly.
+
+    :param timeout: the overall runtime of the decorated handler
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        @wrapt.decorator
+        async def _async_timeout(wrapped, instance, args, kwargs):
+            if kwargs["runtime"].total_seconds() >= timeout:
+                _handler = (
+                    f"{instance.__class__.__name__}.{wrapped.__name__}"
+                    if instance
+                    else f"{wrapped.__name__}"
+                )
+
+                raise kopf.HandlerTimeoutError(
+                    f'{_handler} has timed out after {kwargs["runtime"]}.'
+                )
+            return await wrapped(*args, **kwargs)
+
+        return _async_timeout(fn)
+
+    return decorator
+
+
+def error(*, error_handler: Callable) -> Callable:
+    """
+    The ``@crate.on.error()`` decorator for kopf handlers or StateBasedSubHandler.
+    It catches permanent errors in handlers and runs a given coroutine. It re-raises
+    the exception for further processing by kopf.
+
+    :param error_handler: a coroutine which is run on fatal errors
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        @wrapt.decorator
+        async def _async_error(wrapped, instance, args, kwargs):
+            try:
+                return await wrapped(*args, **kwargs)
+            except kopf.PermanentError as e:
+                _namespace = getattr(instance, "namespace", None) or kwargs.get(
+                    "namespace", None
+                )
+                _name = getattr(instance, "name", None) or kwargs.get("name", None)
+                if (
+                    type(e) in [kopf.PermanentError, kopf.HandlerTimeoutError]
+                    and callable(error_handler)
+                    and _namespace
+                    and _name
+                ):
+                    try:
+                        await error_handler(
+                            namespace=_namespace,
+                            name=_name,
+                            reason=str(e),
+                            logger=kwargs["logger"],
+                        )
+                    except Exception:
+                        pass
+                raise
+
+        return _async_error(fn)
+
+    return decorator

--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Optional, TypedDict
 
 import kopf
 
+from crate.operator.exceptions import SubHandlerFailedDependencyError
 from crate.operator.webhooks import (
     WebhookEvent,
     WebhookStatus,
@@ -192,7 +193,7 @@ class StateBasedSubHandler(abc.ABC):
                 )
                 return True
             else:
-                raise kopf.PermanentError(
+                raise SubHandlerFailedDependencyError(
                     f"A dependency ({handler_name}) has failed. Giving up."
                 )
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "prometheus_client==0.12.0",
         # Versions 3.8+ incompatible with pytest-aiohttp.
         "aiohttp<=3.7.4",
+        "wrapt==1.13.3",
     ],
     extras_require={
         "docs": [

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,104 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2021 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import datetime
+import logging
+from typing import Any
+from unittest import mock
+
+import kopf
+import pytest
+
+from crate.operator.operations import StateBasedSubHandler
+from crate.operator.utils import crate
+from crate.operator.webhooks import (
+    WebhookEvent,
+    WebhookOperation,
+    WebhookPermanentErrorPayload,
+    WebhookStatus,
+)
+
+from .utils import DEFAULT_TIMEOUT, assert_wait_for, was_notification_sent
+
+
+class ActionSubhandler(StateBasedSubHandler):
+    """A subhandler for testing timeout and error decorators"""
+
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(20))
+    async def handle(self, **kwargs: Any):
+        return {"success": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "runtime, timeout",
+    [(15, 20), (20, 20), (30, 20)],
+)
+@mock.patch("crate.operator.webhooks.webhook_client.send_notification")
+async def test_upgrade_cluster_timeout(
+    mock_send_notification: mock.AsyncMock,
+    runtime,
+    timeout,
+    faker,
+):
+    name = faker.domain_word()
+    hash = faker.md5()
+    namespace = faker.uuid4()
+
+    handler = ActionSubhandler(
+        namespace,
+        name,
+        hash,
+        {},
+    )
+    if runtime >= timeout:
+        with pytest.raises(kopf.HandlerTimeoutError):
+            await handler._subhandler(
+                logger=logging.getLogger(__name__),
+                runtime=datetime.timedelta(seconds=runtime),
+                status={},
+                annotations={},
+            )
+        await assert_wait_for(
+            True,
+            was_notification_sent,
+            mock_send_notification,
+            mock.call(
+                namespace,
+                name,
+                WebhookEvent.ERROR,
+                WebhookPermanentErrorPayload(
+                    reason=(
+                        "ActionSubhandler.handle has timed out"
+                        f" after {datetime.timedelta(seconds=runtime)}."
+                    ),
+                    operation=WebhookOperation.UPDATE,
+                ),
+                WebhookStatus.FAILURE,
+                mock.ANY,
+            ),
+            err_msg="Exception notification was not sent.",
+            timeout=DEFAULT_TIMEOUT,
+        )
+    else:
+        res = await handler._subhandler(
+            logger=logging.getLogger(__name__),
+            runtime=datetime.timedelta(seconds=runtime),
+            status={},
+            annotations={},
+        )
+        assert res["result"] == {"success": True}

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -51,6 +51,7 @@ def test_payload_serialization_scale():
         temporary_failure_data=None,
         info_data=None,
         health_data=None,
+        error_data=None,
     )
     assert json.loads(json.dumps(p)) == {
         "event": "scale",
@@ -67,6 +68,7 @@ def test_payload_serialization_scale():
         "temporary_failure_data": None,
         "info_data": None,
         "health_data": None,
+        "error_data": None,
     }
 
 
@@ -83,6 +85,7 @@ def test_payload_serialization_upgrade():
         temporary_failure_data=None,
         info_data=None,
         health_data=None,
+        error_data=None,
     )
     assert json.loads(json.dumps(p)) == {
         "event": "upgrade",
@@ -99,6 +102,7 @@ def test_payload_serialization_upgrade():
         "temporary_failure_data": None,
         "info_data": None,
         "health_data": None,
+        "error_data": None,
     }
 
 
@@ -179,6 +183,7 @@ class TestWebhookClientSending(AioHTTPTestCase):
                 "temporary_failure_data": None,
                 "info_data": None,
                 "health_data": None,
+                "error_data": None,
             },
         }
 
@@ -214,6 +219,7 @@ class TestWebhookClientSending(AioHTTPTestCase):
                 "temporary_failure_data": None,
                 "info_data": None,
                 "health_data": None,
+                "error_data": None,
             },
         }
 
@@ -244,6 +250,7 @@ class TestWebhookClientSending(AioHTTPTestCase):
                     "reason": "A snapshot is in progress",
                 },
                 "health_data": None,
+                "error_data": None,
             },
         }
 
@@ -272,6 +279,7 @@ class TestWebhookClientSending(AioHTTPTestCase):
                 "info_data": {"external_ip": "192.168.1.10"},
                 "temporary_failure_data": None,
                 "health_data": None,
+                "error_data": None,
             },
         }
 
@@ -299,6 +307,7 @@ class TestWebhookClientSending(AioHTTPTestCase):
                 "upgrade_data": None,
                 "info_data": None,
                 "temporary_failure_data": None,
+                "error_data": None,
                 "health_data": {"status": "GREEN"},
             },
         }


### PR DESCRIPTION
## Summary of changes
This is a proposal how we could handle notifications to the API in case of exceptions or timeouts during an upgrade (or all other operations in the future). 

Added two `wrapt` universal decorators which can be applied to plain functions (for regular kopf handlers) or class methods (for subhandlers using StateBasedSubHandler). `@crate.timeout(timeout={seconds})` checks if the (sub)handler's runtime exceeded the given timeout seconds on each run and raises a `kopf.HandlerTimeoutError` in case it has timed out. This exception as well as all other `kopf.PermanentError`s are caught in `@crate.on.error(error_handler={my_error_handler})` and an error handler coroutine can be run sending notifications to the API. After that it re-raises the exception so it can be further processed by kopf.

This PR also fixes the issue that notifications of successful upgrades pile up in the status of the CrateDB resource if an upgrade succeeds but the subsequent restart fails or times out. These notifications were erroneously sent in the next run of the handler, because on permanent errors or timeouts there is no traditional return value and kopf does not update the status in such cases. After two failed restarts it looks sth like this

```yml
[...]
status:
  cluster_update:
    notifications:
    - event: upgrade
      payload:
        new_registry: crate
        new_version: 4.6.3
        old_registry: crate
        old_version: 4.6.1
      status: success
    - event: upgrade
      payload:
        new_registry: crate
        new_version: 4.6.4
        old_registry: crate
        old_version: 4.6.3
      status: success
    ref: 20681de22617dfdd8ef03effd25b8014
  cluster_update/after_cluster_update:
    ref: 20681de22617dfdd8ef03effd25b8014
    success: true
[...]
```
I added a new subhandler which only creates the success notification if both `upgrade` and `restart` subhandlers have finished successfully, not sure if there would be a more elegant way of solving this issue..

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
