### PR TITLE
Allow overriding the storage class used in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,10 @@ def load_config():
         "CRATEDB_OPERATOR_HEALTH_CHECK_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_CRATEDB_STATUS_CHECK_INTERVAL": "5",
     }
+    # If the environment already has any of these keys defined, leave them be
+    for k in env.keys():
+        if k in os.environ:
+            env[k] = os.environ[k]
     with mock.patch.dict(os.environ, env):
         config.load()
         yield

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -105,7 +105,7 @@ async def start_cluster(
                             "memory": "4Gi",
                             "heapRatio": 0.25,
                             "disk": {
-                                "storageClass": "default",
+                                "storageClass": config.DEBUG_VOLUME_STORAGE_CLASS,
                                 "size": "16GiB",
                                 "count": 1,
                             },


### PR DESCRIPTION
## Summary of changes

This allows us to use non-default storage classes when running tests. 


## Checklist

- [x] Test-only change, will not update `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
