### PR TITLE
Add timeouts to update and create handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Unreleased
 * Renamed webhook event ``error`` to ``feedback`` and added more status updates
   during a cluster upgrade.
 
+* Added timeouts to ``create`` and ``update`` handlers.
+
 2.7.2 (2021-12-10)
 ------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -91,6 +91,12 @@ class Config:
     #: failed.
     SCALING_TIMEOUT = 3600
 
+    #: Time in seconds for which the operator will continue and wait to perform
+    #: an update of a cluster, either scaling a cluster up or down or upgrading
+    #: a cluster. Once this threshold has passed, an update is considered
+    #: failed.
+    CLUSTER_UPDATE_TIMEOUT = 7200
+
     #: Enable several testing behaviors, such as relaxed pod anti-affinity to
     #: allow for easier testing in smaller Kubernetes clusters.
     TESTING: bool = False
@@ -290,6 +296,22 @@ class Config:
             raise ConfigurationError(
                 f"Invalid {self._prefix}PROMETHEUS_PORT="
                 f"'{cratedb_status_interval}'. Needs to be a positive integer."
+            )
+
+        update_timeout = self.env(
+            "CLUSTER_UPDATE_TIMEOUT", default=str(self.CLUSTER_UPDATE_TIMEOUT)
+        )
+        try:
+            self.CLUSTER_UPDATE_TIMEOUT = int(update_timeout)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}CLUSTER_UPDATE_TIMEOUT="
+                f"'{update_timeout}'. Needs to be a positive integer or 0."
+            )
+        if self.CLUSTER_UPDATE_TIMEOUT < 0:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}CLUSTER_UPDATE_TIMEOUT="
+                f"'{update_timeout}'. Needs to be a positive integer or 0."
             )
 
     def env(self, name: str, *, default=UNDEFINED) -> str:

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -97,6 +97,7 @@ async def login(**kwargs):
 
 @kopf.on.create(API_GROUP, "v1", RESOURCE_CRATEDB)
 @crate.on.error(error_handler=crate.send_create_failed_notification)
+@crate.timeout(timeout=float(config.BOOTSTRAP_TIMEOUT))
 async def cluster_create(
     namespace: str,
     meta: kopf.Meta,
@@ -114,6 +115,7 @@ async def cluster_create(
 
 @kopf.on.update(API_GROUP, "v1", RESOURCE_CRATEDB, id=CLUSTER_UPDATE_ID)
 @crate.on.error(error_handler=crate.send_update_failed_notification)
+@crate.timeout(timeout=float(config.CLUSTER_UPDATE_TIMEOUT))
 async def cluster_update(
     namespace: str,
     name: str,


### PR DESCRIPTION
## Summary of changes
https://github.com/crate/cloud/issues/429 - Add timeouts to the main `update` and `create` handlers to make sure operations are not blocked forever by a subhandler which does not have an individual timeout.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
