### PR TITLE
Add notifications during cluster operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Added status update notifications for cluster creation and updates of the
+  allowed CIDRs and user password secrets.
+
 2.9.0 (2022-01-27)
 ------------------
 

--- a/crate/operator/utils/notifications.py
+++ b/crate/operator/utils/notifications.py
@@ -21,14 +21,20 @@ from crate.operator.utils import crate
 from crate.operator.webhooks import WebhookOperation, WebhookStatus
 
 
-async def send_update_progress_notification(
-    *, namespace: str, name: str, message: str, logger: logging.Logger
+async def send_operation_progress_notification(
+    *,
+    namespace: str,
+    name: str,
+    message: str,
+    logger: logging.Logger,
+    status: WebhookStatus,
+    operation: WebhookOperation,
 ):
     await crate.send_feedback_notification(
         namespace=namespace,
         name=name,
         message=message,
-        operation=WebhookOperation.UPDATE,
-        status=WebhookStatus.IN_PROGRESS,
+        operation=operation,
+        status=status,
         logger=logger,
     )

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
+from typing import Any, List, Mapping
+from unittest import mock
 
 import pytest
 from kubernetes_asyncio.client import (
@@ -28,8 +30,19 @@ from psycopg2 import DatabaseError, OperationalError
 from crate.operator.constants import LABEL_USER_PASSWORD
 from crate.operator.cratedb import get_connection
 from crate.operator.utils.formatting import b64encode
+from crate.operator.webhooks import (
+    WebhookEvent,
+    WebhookFeedbackPayload,
+    WebhookOperation,
+    WebhookStatus,
+)
 
-from .utils import DEFAULT_TIMEOUT, assert_wait_for, start_cluster
+from .utils import (
+    DEFAULT_TIMEOUT,
+    assert_wait_for,
+    start_cluster,
+    was_notification_sent,
+)
 
 pytestmark = [pytest.mark.k8s, pytest.mark.asyncio]
 
@@ -45,7 +58,10 @@ async def is_password_set(host: str, system_password: str, user: str) -> bool:
         return False
 
 
-async def test_update_cluster_password(faker, namespace, kopf_runner, api_client):
+@mock.patch("crate.operator.webhooks.webhook_client.send_notification")
+async def test_update_cluster_password(
+    mock_send_notification: mock.AsyncMock, faker, namespace, kopf_runner, api_client
+):
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)
     name = faker.domain_word()
@@ -59,20 +75,20 @@ async def test_update_cluster_password(faker, namespace, kopf_runner, api_client
             body=V1Secret(
                 data={"password": b64encode(password)},
                 metadata=V1ObjectMeta(
-                    name=f"user-{name}", labels={LABEL_USER_PASSWORD: "true"}
+                    name=f"user-password-{name}-0", labels={LABEL_USER_PASSWORD: "true"}
                 ),
                 type="Opaque",
             ),
         ),
     )
 
-    users = [
+    users: List[Mapping[str, Any]] = [
         {
             "name": username,
             "password": {
                 "secretKeyRef": {
                     "key": "password",
-                    "name": f"user-{name}",
+                    "name": f"user-password-{name}-0",
                 }
             },
         },
@@ -80,12 +96,50 @@ async def test_update_cluster_password(faker, namespace, kopf_runner, api_client
 
     host, password = await start_cluster(name, namespace, core, coapi, 1, users=users)
 
+    await assert_wait_for(
+        True,
+        was_notification_sent,
+        mock_send_notification,
+        mock.call(
+            namespace.metadata.name,
+            name,
+            WebhookEvent.FEEDBACK,
+            WebhookFeedbackPayload(
+                message="The cluster has been created successfully.",
+                operation=WebhookOperation.CREATE,
+            ),
+            WebhookStatus.SUCCESS,
+            mock.ANY,
+        ),
+        err_msg="Did not notify cluster creation status update.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+
     await core.patch_namespaced_secret(
         namespace=namespace.metadata.name,
-        name=f"user-{name}",
+        name=f"user-password-{name}-0",
         body=V1Secret(
             data={"password": b64encode(new_password)},
         ),
+    )
+
+    await assert_wait_for(
+        True,
+        was_notification_sent,
+        mock_send_notification,
+        mock.call(
+            namespace.metadata.name,
+            name,
+            WebhookEvent.FEEDBACK,
+            WebhookFeedbackPayload(
+                message="Updating password.",
+                operation=WebhookOperation.UPDATE,
+            ),
+            WebhookStatus.IN_PROGRESS,
+            mock.ANY,
+        ),
+        err_msg="Did not notify user password status start.",
+        timeout=DEFAULT_TIMEOUT,
     )
 
     await assert_wait_for(
@@ -95,4 +149,23 @@ async def test_update_cluster_password(faker, namespace, kopf_runner, api_client
         new_password,
         username,
         timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+    await assert_wait_for(
+        True,
+        was_notification_sent,
+        mock_send_notification,
+        mock.call(
+            namespace.metadata.name,
+            name,
+            WebhookEvent.FEEDBACK,
+            WebhookFeedbackPayload(
+                message="Password updated successfully.",
+                operation=WebhookOperation.UPDATE,
+            ),
+            WebhookStatus.SUCCESS,
+            mock.ANY,
+        ),
+        err_msg="Did not notify user password status success.",
+        timeout=DEFAULT_TIMEOUT,
     )


### PR DESCRIPTION
## Summary of changes
Send notifications about the progress for cluster creation and updates of the allowed CIDRs and user password secrets to the API.

https://github.com/crate/cloud/issues/439

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
