### PR TITLE
Changed ``imagePullPolicy`` on container init scripts to not always pull

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Unreleased
 * Added status update notifications for cluster creation and updates of the
   allowed CIDRs and user password secrets.
 
+* Changed ``imagePullPolicy`` on container init scripts to not always pull busybox
+  and similar images. This is wasteful in light of the new docker hub limits.
+
 2.9.0 (2022-01-27)
 ------------------
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -487,6 +487,7 @@ def get_statefulset_init_containers(crate_image: str) -> List[V1Container]:
             # thus doing it before.
             command=["sysctl", "-w", "vm.max_map_count=262144"],
             image="busybox",
+            image_pull_policy="IfNotPresent",
             name="init-sysctl",
             security_context=V1SecurityContext(privileged=True),
         ),
@@ -498,6 +499,7 @@ def get_statefulset_init_containers(crate_image: str) -> List[V1Container]:
                 f"https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/{config.JMX_EXPORTER_VERSION}/crate-jmx-exporter-{config.JMX_EXPORTER_VERSION}.jar",  # noqa
             ],
             image="busybox",
+            image_pull_policy="IfNotPresent",
             name="fetch-jmx-exporter",
             volume_mounts=[V1VolumeMount(name="jmxdir", mount_path="/jmxdir")],
         ),
@@ -508,6 +510,7 @@ def get_statefulset_init_containers(crate_image: str) -> List[V1Container]:
                 "mkdir -pv /resource/heapdump ; chown -R crate:crate /resource",
             ],
             image=crate_image,
+            image_pull_policy="IfNotPresent",
             name="mkdir-heapdump",
             volume_mounts=[V1VolumeMount(name="debug", mount_path="/resource")],
         ),


### PR DESCRIPTION
## Summary of changes

... busybox and similar images. This is wasteful in light of the new docker hub limits.


## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
