### PR TITLE
Expand volumes of existing clusters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 * Changed the ``crate-discovery`` internal service to be headless - there is no reason
   at all for it to be load balanced by k8s.
 
+* Added subhandlers allowing to expand volume size on existing CrateDB clusters.
+
 2.10.0 (2022-02-17)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -97,6 +97,12 @@ class Config:
     #: failed.
     CLUSTER_UPDATE_TIMEOUT = 7200
 
+    #: Time in seconds for which the operator will continue and wait to perform
+    #: a check if volume expansion has finshed successfully. Once this threshold
+    # has passed, a volume expansion is considered failed or not supported by the
+    # StorageClass.
+    EXPAND_VOLUME_TIMEOUT = 1800
+
     #: Enable several testing behaviors, such as relaxed pod anti-affinity to
     #: allow for easier testing in smaller Kubernetes clusters.
     TESTING: bool = False
@@ -312,6 +318,22 @@ class Config:
             raise ConfigurationError(
                 f"Invalid {self._prefix}CLUSTER_UPDATE_TIMEOUT="
                 f"'{update_timeout}'. Needs to be a positive integer or 0."
+            )
+
+        expand_volume_timeout = self.env(
+            "EXPAND_VOLUME_TIMEOUT", default=str(self.EXPAND_VOLUME_TIMEOUT)
+        )
+        try:
+            self.EXPAND_VOLUME_TIMEOUT = int(expand_volume_timeout)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}EXPAND_VOLUME_TIMEOUT="
+                f"'{expand_volume_timeout}'. Needs to be a positive integer or 0."
+            )
+        if self.EXPAND_VOLUME_TIMEOUT < 0:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}EXPAND_VOLUME_TIMEOUT="
+                f"'{expand_volume_timeout}'. Needs to be a positive integer or 0."
             )
 
     def env(self, name: str, *, default=UNDEFINED) -> str:

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -35,6 +35,9 @@ KOPF_STATE_STORE_PREFIX = f"operator.{API_GROUP}"
 CLUSTER_UPDATE_ID = "cluster_update"
 CLUSTER_CREATE_ID = "cluster_create"
 
+DATA_NODE_NAME = "hot"
+DATA_PVC_NAME_PREFIX = "data"
+
 
 class CloudProvider(str, enum.Enum):
     AWS = "aws"

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -69,6 +69,7 @@ from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import (
+    DATA_PVC_NAME_PREFIX,
     LABEL_COMPONENT,
     LABEL_NAME,
     LABEL_NODE_NAME,
@@ -460,7 +461,9 @@ def get_statefulset_crate_volume_mounts(
     ]
     volume_mounts.extend(
         [
-            V1VolumeMount(mount_path=f"/data/data{i}", name=f"data{i}")
+            V1VolumeMount(
+                mount_path=f"/data/data{i}", name=f"{DATA_PVC_NAME_PREFIX}{i}"
+            )
             for i in range(node_spec["resources"]["disk"]["count"])
         ]
     )
@@ -527,7 +530,9 @@ def get_statefulset_pvc(
 
     pvcs = [
         V1PersistentVolumeClaim(
-            metadata=V1ObjectMeta(name=f"data{i}", owner_references=owner_references),
+            metadata=V1ObjectMeta(
+                name=f"{DATA_PVC_NAME_PREFIX}{i}", owner_references=owner_references
+            ),
             spec=V1PersistentVolumeClaimSpec(
                 access_modes=["ReadWriteOnce"],
                 resources=V1ResourceRequirements(requests={"storage": size}),

--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -1,0 +1,186 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2022 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import kopf
+from kubernetes_asyncio.client import CoreV1Api
+from kubernetes_asyncio.client.api_client import ApiClient
+
+from crate.operator.config import config
+from crate.operator.constants import DATA_NODE_NAME, DATA_PVC_NAME_PREFIX
+from crate.operator.operations import get_pvcs_in_namespace
+from crate.operator.utils import crate
+from crate.operator.utils.formatting import convert_to_bytes
+from crate.operator.utils.kopf import StateBasedSubHandler
+from crate.operator.utils.notifications import send_operation_progress_notification
+from crate.operator.webhooks import (
+    WebhookEvent,
+    WebhookFeedbackPayload,
+    WebhookOperation,
+    WebhookStatus,
+)
+
+
+async def expand_volume(
+    core: CoreV1Api,
+    namespace: str,
+    name: str,
+    data_diff_items: kopf.Diff,
+    logger: logging.Logger,
+):
+    """
+    Expand a cluster's disk size according to the given ``data_diff_items``.
+
+    :param core: An instance of the Kubernetes Core V1 API.
+    :param namespace: The Kubernetes namespace for the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param old: The old resource body.
+    :param data_diff_items: A list of changes made to the individual
+        data node specifications.
+    """
+    all_pvcs = await get_pvcs_in_namespace(core, namespace, name, DATA_NODE_NAME)
+    pvc_storage = {}
+
+    await send_operation_progress_notification(
+        namespace=namespace,
+        name=name,
+        message="Suspending cluster and waiting for Persistent "
+        "Volume Claim(s) to be resized.",
+        logger=logger,
+        status=WebhookStatus.IN_PROGRESS,
+        operation=WebhookOperation.UPDATE,
+    )
+
+    for pvc in all_pvcs:
+        if not pvc["name"].startswith(DATA_PVC_NAME_PREFIX):
+            continue
+        current_pvc = await core.read_namespaced_persistent_volume_claim(
+            name=pvc["name"],
+            namespace=namespace,
+        )
+        if data_diff_items:
+            for _, field_path, old_storage, new_storage in data_diff_items:
+                current_storage = convert_to_bytes(
+                    current_pvc.spec.resources.requests["storage"]
+                )
+                new_storage = convert_to_bytes(new_storage)
+                if current_storage != new_storage:
+                    body: Dict[str, Any] = {
+                        "spec": {
+                            "resources": {
+                                "requests": {"storage": str(int(new_storage))}
+                            },
+                        }
+                    }
+                    logger.info(f"Patch PVC {pvc['name']} with body {body}")
+                    await core.patch_namespaced_persistent_volume_claim(
+                        name=pvc["name"],
+                        namespace=namespace,
+                        body=body,
+                    )
+                storage_status = convert_to_bytes(
+                    current_pvc.status.capacity["storage"]
+                )
+                logger.info(
+                    f"PVC {pvc['name']} storage current/new "
+                    f"{int(storage_status)}/{int(new_storage)}"
+                )
+                conditions = current_pvc.status.conditions or []
+                if int(storage_status) == int(new_storage) or any(
+                    cond.type == "FileSystemResizePending" for cond in conditions
+                ):
+                    pvc_storage[pvc["name"]] = {
+                        "in_progress": False,
+                    }
+                else:
+                    pvc_storage[pvc["name"]] = {
+                        "in_progress": True,
+                    }
+    # If resizing for at least one of the PVCs is not finished, we try again.
+    # Or assume that the StorageClass does not support expansion and fail
+    # after the timeout is reached.
+    if pending_pvc := next(
+        (
+            name
+            for name, value in pvc_storage.items()
+            if value.get("in_progress") is True
+        ),
+        None,
+    ):
+        raise kopf.TemporaryError(
+            f"Resizing is still in progress for PVC {pending_pvc}. Retrying... ",
+            delay=15,
+        )
+
+
+class ExpandVolumeSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=90 if config.TESTING else config.EXPAND_VOLUME_TIMEOUT)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        spec: kopf.Spec,
+        old: kopf.Body,
+        new: kopf.Body,
+        diff: kopf.Diff,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        expand_data_diff_items: Optional[List[kopf.DiffItem]] = None
+
+        for operation, field_path, old_value, new_value in diff:
+            if field_path == ("spec", "nodes", "data"):
+                expand_data_diff_items = []
+                for node_spec_idx in range(len(old_value)):
+                    old_spec = old_value[node_spec_idx]
+                    new_spec = new_value[node_spec_idx]
+
+                    expand_data_diff_items.append(
+                        kopf.DiffItem(
+                            kopf.DiffOperation.CHANGE,
+                            (str(node_spec_idx), "resources", "disk", "size"),
+                            old_spec["resources"]["disk"]["size"],
+                            new_spec["resources"]["disk"]["size"],
+                        )
+                    )
+            else:
+                logger.info("Ignoring operation %s on field %s", operation, field_path)
+
+        if expand_data_diff_items:
+            async with ApiClient() as api_client:
+                core = CoreV1Api(api_client)
+
+                await expand_volume(
+                    core,
+                    namespace,
+                    name,
+                    kopf.Diff(expand_data_diff_items),
+                    logger,
+                )
+
+        # schedule success notification and send it after the cluster
+        # has been restarted successfully.
+        self.schedule_notification(
+            WebhookEvent.FEEDBACK,
+            WebhookFeedbackPayload(
+                message="The cluster storage has been resized successfully.",
+                operation=WebhookOperation.UPDATE,
+            ),
+            WebhookStatus.SUCCESS,
+        )

--- a/crate/operator/utils/formatting.py
+++ b/crate/operator/utils/formatting.py
@@ -16,7 +16,7 @@
 
 import base64
 import functools
-from typing import Callable
+from typing import Callable, Union
 
 import bitmath
 
@@ -55,3 +55,14 @@ def format_bitmath(value: bitmath.Byte) -> str:
     # trailing "b" or "B", we're stripping that here.
     # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
     return value.best_prefix().format("{value}{unit}")[:-1]
+
+
+def convert_to_bytes(value: Union[str, int]) -> bitmath.Byte:
+    """
+    Converts disk size strings used in Kubernetes, e.g. ``"256Gi"`` or Bytes
+    to :class:`bitmath.Byte`.
+    """
+    if isinstance(value, str):
+        return bitmath.parse_string_unsafe(value).to_Byte()
+    if isinstance(value, int):
+        return bitmath.Byte(value)

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -26,6 +26,7 @@ from kubernetes_asyncio.client import AppsV1Api, CoreV1Api, CustomObjectsApi
 from crate.operator.config import config
 from crate.operator.constants import (
     API_GROUP,
+    DATA_PVC_NAME_PREFIX,
     LABEL_COMPONENT,
     LABEL_MANAGED_BY,
     LABEL_NAME,
@@ -528,7 +529,7 @@ class TestStatefulSetCrateVolumeMounts:
         assert vm_jmxdir.name == "jmxdir"
         assert vm_resource.name == "debug"
         assert [(vm.mount_path, vm.name) for vm in vm_data] == [
-            (f"/data/data{i}", f"data{i}") for i in range(disks)
+            (f"/data/data{i}", f"{DATA_PVC_NAME_PREFIX}{i}") for i in range(disks)
         ]
 
     def test_with_ssl(self, faker):
@@ -540,7 +541,7 @@ class TestStatefulSetCrateVolumeMounts:
         assert vm_jmxdir.name == "jmxdir"
         assert vm_resource.name == "debug"
         assert [(vm.mount_path, vm.name) for vm in vm_data] == [
-            (f"/data/data{i}", f"data{i}") for i in range(disks)
+            (f"/data/data{i}", f"{DATA_PVC_NAME_PREFIX}{i}") for i in range(disks)
         ]
         assert vm_ssl.name == "keystore"
 
@@ -570,7 +571,7 @@ class TestStatefulSetPVC:
             }
         }
         pvcs = get_statefulset_pvc(None, node_spec)
-        expected_pvcs = [f"data{i}" for i in range(count)]
+        expected_pvcs = [f"{DATA_PVC_NAME_PREFIX}{i}" for i in range(count)]
         expected_pvcs.append("debug")
         expected_sizes = [s] * count
         expected_sizes.append(format_bitmath(config.DEBUG_VOLUME_SIZE))

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -1,0 +1,169 @@
+# CrateDB Kubernetes Operator
+# Copyright (C) 2022 Crate.IO GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import bitmath
+import pytest
+from kubernetes_asyncio.client import (
+    CoreV1Api,
+    CustomObjectsApi,
+    StorageV1Api,
+    V1Namespace,
+)
+
+from crate.operator.constants import (
+    API_GROUP,
+    DATA_PVC_NAME_PREFIX,
+    KOPF_STATE_STORE_PREFIX,
+    RESOURCE_CRATEDB,
+)
+from crate.operator.cratedb import connection_factory
+from crate.operator.utils.formatting import convert_to_bytes
+
+from .utils import (
+    DEFAULT_TIMEOUT,
+    assert_wait_for,
+    create_test_sys_jobs_table,
+    is_cluster_healthy,
+    is_kopf_handler_finished,
+    start_cluster,
+)
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("16Gi", 17179869184),
+        ("256GiB", 274877906944),
+        ("34359738368", 34359738368),
+        (68719476736, 68719476736),
+    ],
+)
+def test_convert_to_bytes(input, expected):
+    assert convert_to_bytes(input) == bitmath.Byte(expected)
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+async def test_expand_cluster_storage(
+    faker,
+    namespace,
+    kopf_runner,
+    api_client,
+):
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    storage = StorageV1Api(api_client)
+    name = faker.domain_word()
+    number_of_nodes = 2
+
+    expansion_supported = await _is_volume_expansion_supported(storage)
+    if expansion_supported is not True:
+        pytest.skip("The `default` StorageClass does not support volume expansion.")
+
+    host, password = await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        number_of_nodes,
+    )
+
+    await assert_wait_for(
+        True,
+        is_cluster_healthy,
+        connection_factory(host, password),
+        number_of_nodes,
+        err_msg="Cluster wasn't healthy after 5 minutes.",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+    conn_factory = connection_factory(host, password)
+    await create_test_sys_jobs_table(conn_factory)
+
+    await _expand_volume(coapi, name, namespace, "32Gi")
+
+    # we just check if the PVC has been patched with the correct new disk size. We
+    # do not wait for the PVC to be really resized because there is no guarantee
+    # it is supported.
+    await assert_wait_for(
+        True,
+        _all_pvcs_resized,
+        core,
+        namespace.metadata.name,
+        "32Gi",
+        err_msg="Volume expansion has not finished.",
+        timeout=DEFAULT_TIMEOUT * 3,
+    )
+
+    # assert the cluster has been scaled up again to the initial number of nodes
+    await assert_wait_for(
+        True,
+        is_cluster_healthy,
+        connection_factory(host, password),
+        number_of_nodes,
+        err_msg="Cluster wasn't back up again after 5 minutes.",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Volume Expansion handler has not finished.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+
+
+async def _all_pvcs_resized(
+    core: CoreV1Api, namespace: str, expected_size: str
+) -> bool:
+    pvcs = await core.list_namespaced_persistent_volume_claim(namespace=namespace)
+    for pvc in pvcs.items:
+        if pvc.metadata.name.startswith(DATA_PVC_NAME_PREFIX) and convert_to_bytes(
+            pvc.spec.resources.requests["storage"]
+        ) != convert_to_bytes(expected_size):
+            return False
+
+    return True
+
+
+async def _is_volume_expansion_supported(storage: StorageV1Api) -> bool:
+    sc = await storage.read_storage_class(name="default")
+
+    return sc.allow_volume_expansion is True
+
+
+async def _expand_volume(
+    coapi: CustomObjectsApi, name: str, namespace: V1Namespace, disk_size: str
+):
+    patch_body = [
+        {
+            "op": "replace",
+            "path": "/spec/nodes/data/0/resources/disk/size",
+            "value": disk_size,
+        }
+    ]
+    await coapi.patch_namespaced_custom_object(
+        group=API_GROUP,
+        version="v1",
+        plural=RESOURCE_CRATEDB,
+        namespace=namespace.metadata.name,
+        name=name,
+        body=patch_body,
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,7 @@ from kubernetes_asyncio.client import (
 from crate.operator.config import config
 from crate.operator.constants import (
     API_GROUP,
+    DATA_NODE_NAME,
     KOPF_STATE_STORE_PREFIX,
     RESOURCE_CRATEDB,
 )
@@ -98,7 +99,7 @@ async def start_cluster(
             "nodes": {
                 "data": [
                     {
-                        "name": "hot",
+                        "name": DATA_NODE_NAME,
                         "replicas": hot_nodes,
                         "resources": {
                             "cpus": 2,


### PR DESCRIPTION
## Summary of changes

In the cratedb update handler we check now which value of the data nodes has changed. If `replicas` changed, we perform the scaling as usual. If `resources.disk.size` changed, we start three new subhandlers:

1) `SuspendClusterSubHandler` checks if the cluster is healthy before starting the whole process and scales the sts down to 0 replicas

2) `ExpandVolumeSubHandler` patches all PVCs whose name starts with `data` to the new disk size and continuously checks if the real value from `status.capacity.storage` equals the desired new disk size in `resources.requests.storage` OR if the PVC has the `FileSystemResizePending` condition. It keeps doing that for a configurable amout of time - currently 30 minutes. If it does not match after that, we assume the underlying storageclass provisioner does not support volume expansion.

3) (depends on 1. and 2. to be finished) `StartClusterSubHandler` scales the cluster back up to the initial number of replicas.

1. and 2. run in parallel, 3. has to run even if 2. expired or failed

In the test I reduce the timeout of the `ExpandVolumeSubHandler` to 90sec and test only if the PVCs were patched successfully, not if the volume expansion really worked, because I assume most people working on the operator will use the hostpath provisioner which does not support resizing, even if `allowVolumeExpansion` is set to `True`. The test is skipped entirely if the StorageClass does not have the `allowVolumeExpansion` flag set to `True`, because then even the patching of the PVC would fail.

Status update notifications are sent to the API. `SuspendClusterSubHandler` and `ExpandVolumeSubHandler` send the same message because they run in parallel, to avoid messages overwriting each other and confusing people.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
