### PR TITLE
Fix expand volume test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             "sphinx-autodoc-typehints",
             # Pinning this as 0.18 does not work
             "docutils==0.17.1",
+            "Jinja2<3.1",
         ],
         "testing": [
             "faker==13.3.2",

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -126,7 +126,7 @@ async def test_expand_cluster_storage(
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
         err_msg="Volume Expansion handler has not finished.",
-        timeout=DEFAULT_TIMEOUT,
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
 


### PR DESCRIPTION
## Summary of changes
The check if the `cluster_update` handler has been finished starts earlier because `_all_pvcs_resized` check only checks if the PVC has been patched and finishes faster than the `expand_volume` subhandler really succeeds or times out. Increasing the timeout to 5min should fix it.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
