### PR TITLE
Fix topology spread constraint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Change the value of ``when_unsatisfiable`` in the ``TopologySpreadConstraint`` to
+  ``ScheduleAnyway`` to be able to deploy a cluster with more than 3 nodes again.
+
 * Eliminated the minimum of 1 replica data nodes to allow suspending clusters.
 
 * Clusters can now be suspended (replicas set to 0, keeping the storage) and resumed.

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -244,7 +244,7 @@ def get_topology_spread(
             V1TopologySpreadConstraint(
                 max_skew=1,
                 topology_key="topology.kubernetes.io/zone",
-                when_unsatisfiable="DoNotSchedule",
+                when_unsatisfiable="ScheduleAnyway",
                 label_selector=V1LabelSelector(
                     match_expressions=[
                         V1LabelSelectorRequirement(


### PR DESCRIPTION
## Summary of changes
Change the value of ``when_unsatisfiable`` in the ``TopologySpreadConstraint`` to
  ``ScheduleAnyway`` to be able to deploy a cluster with more than 3 nodes again.

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
