### PR TITLE
Update suspend cluster status notification message

### DIFF
--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -59,8 +59,7 @@ async def expand_volume(
     await send_operation_progress_notification(
         namespace=namespace,
         name=name,
-        message="Suspending cluster and waiting for Persistent "
-        "Volume Claim(s) to be resized.",
+        message="Suspending cluster.",
         logger=logger,
         status=WebhookStatus.IN_PROGRESS,
         operation=WebhookOperation.UPDATE,

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -523,8 +523,7 @@ async def suspend_or_start_cluster(
                 await send_operation_progress_notification(
                     namespace=namespace,
                     name=name,
-                    message="Suspending cluster and waiting for Persistent "
-                    "Volume Claim(s) to be resized.",
+                    message="Suspending cluster.",
                     logger=logger,
                     status=WebhookStatus.IN_PROGRESS,
                     operation=WebhookOperation.UPDATE,


### PR DESCRIPTION
## Summary of changes
Temporarily update status notification message, so it can be used for both operations, volume expansion and suspend clusters.

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
