### PR TITLE
Fix a bug that would lead to the operator getting stuck when performing repeated operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fix a bug that would lead to the operator getting stuck when performing repeated
+  operations (i.e. suspend/resume/suspend/resume/...)
+
 2.13.0 (2022-06-21)
 -------------------
 

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+import datetime
 import logging
 
 import kopf
@@ -116,12 +116,13 @@ async def cluster_update(
     patch: kopf.Patch,
     status: kopf.Status,
     diff: kopf.Diff,
+    started: datetime.datetime,
     **_kwargs,
 ):
     """
     Handles updates to the CrateDB resource.
     """
-    await update_cratedb(namespace, name, patch, status, diff)
+    await update_cratedb(namespace, name, patch, status, diff, started)
 
 
 @kopf.on.update("", "v1", "secrets", labels={LABEL_USER_PASSWORD: "true"})


### PR DESCRIPTION
## Summary of changes

This was caused by the hash staying the same and the operator failing to figure out what ops we still need to wait for.

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
