### PR TITLE
Revert "Bump kubernetes-asyncio from 21.7.1 to 23.6.0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "kopf==1.35.1",
         # Careful with 22+ - it is currently not compatible
         # and results in various "permission denied" errors.
-        "kubernetes-asyncio==23.6.0",
+        "kubernetes-asyncio==21.7.1",
         "PyYAML<7.0",
         "prometheus_client==0.14.1",
         # Versions 3.8+ incompatible with pytest-aiohttp.


### PR DESCRIPTION
Incompatible.

Reverts crate/crate-operator#368