### PR TITLE
Fix a bug that would cause suspending a cluster to get stuck

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Fix a bug that would cause suspending a cluster to get stuck.
+
 2.13.2 (2022-07-11)
 -------------------
 

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -467,7 +467,8 @@ async def does_backup_metrics_pod_exist(
     core: CoreV1Api, name: str, namespace: V1Namespace
 ) -> bool:
     backup_metrics_pods = await get_pods_in_deployment(core, namespace, name)
-    return len(backup_metrics_pods) > 0
+    backup_metrics_name = BACKUP_METRICS_DEPLOYMENT_NAME.format(name=name)
+    return any(p["name"].startswith(backup_metrics_name) for p in backup_metrics_pods)
 
 
 async def does_deployment_exist(apps: AppsV1Api, namespace: str, name: str) -> bool:


### PR DESCRIPTION
## Summary of changes
Fixed a bug in the check if the backup metrics deployment has been scaled down successfully, or rather if the `backup-metrics` pod is gone. The `crate-snapshot` pods in the same namespace have the same labels, so the operation to suspend a cluster would have been stuck as long as such a pod was present

```
Handler 'cluster_update/scale' failed temporarily: Waiting for backup metrics pods [{'uid': '719c8f9f-743c-497e-aceb-7b46ba98edeb', 'name': 'create-snapshot-7987a175-ea95-445d-995f-43378fe3a16d-276252qd6z'}] to match desired number of replicas 0
```

https://github.com/crate/cloud/issues/702

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
