### PR TITLE
Only send notification once actually succeeded

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fixed a bug that would prematurely send a notification about the success of updating
+  the user's password.
+
 2.13.3 (2022-07-12)
 -------------------
 

--- a/crate/operator/handlers/handle_update_user_password_secret.py
+++ b/crate/operator/handlers/handle_update_user_password_secret.py
@@ -81,16 +81,10 @@ async def update_user_password_secret(
                                 user_spec["name"],
                                 old_value,
                                 new_value,
+                                namespace,
+                                cluster_id,
                                 logger,
                             ),
                             id=f"update-{crate_custom_object['metadata']['name']}-{user_spec['name']}",  # noqa
                             timeout=config.BOOTSTRAP_TIMEOUT,
                         )
-    await send_operation_progress_notification(
-        namespace=namespace,
-        name=cluster_id,
-        message="Password updated successfully.",
-        logger=logger,
-        status=WebhookStatus.SUCCESS,
-        operation=WebhookOperation.UPDATE,
-    )


### PR DESCRIPTION
## Summary of changes

We were sending this prematurely, regardless of whether the update succeeded or not.


## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
