### PR TITLE
Added support for parallel testing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Added support for parallel testing, which greatly reduces test runtime.
+
 2.14.0 (2022-09-13)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -112,6 +112,11 @@ class Config:
     #: allow for easier testing in smaller Kubernetes clusters.
     TESTING: bool = False
 
+    #: Allows running tests in parallel. If enabled, filters the CrateDB resources
+    #: by the PID in which they were created, allowing multiple operators to run
+    #: in parallel.
+    PARALLEL_TESTING: bool = False
+
     #: HTTP Basic Auth password for web requests made to :attr:`WEBHOOK_URL`.
     WEBHOOK_PASSWORD: Optional[str] = None
 
@@ -275,6 +280,9 @@ class Config:
 
         testing = self.env("TESTING", default=str(self.TESTING))
         self.TESTING = testing.lower() == "true"
+
+        testing = self.env("PARALLEL_TESTING", default=str(self.PARALLEL_TESTING))
+        self.PARALLEL_TESTING = testing.lower() == "true"
 
         self.WEBHOOK_PASSWORD = self.env(
             "WEBHOOK_PASSWORD", default=self.WEBHOOK_PASSWORD

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -149,6 +149,16 @@ Finally, you can run ``pytest`` using the required arguments:
 .. _minikube tunnel: https://minikube.sigs.k8s.io/docs/handbook/accessing/#using-minikube-tunnel
 
 
+Running test in parallel
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The operator supports running the entire test suite in parallel, to significantly speed
+up execution. To do that, simply run the tests with the ``-n X`` parameter to pytest:
+
+.. code-block:: console
+
+   (env)$ pytest -n 2 --dist loadfile -vv --kube-config=~/.kube/test_config --kube-context=crate-testing
+
 Code style
 ----------
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
             "pytest-aiohttp==0.3.0",
             "pytest-asyncio==0.19.0",
             "pytest-xdist==2.5.0",  # enables parallel testing
+            "filelock==3.8.0",  # used for locks when running in parallel mode
         ],
         "develop": [
             "black==22.3.0",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     install_requires=[
         "aiopg==1.3.4",
         "bitmath==1.3.3.1",
-        "kopf==1.35.1",
+        "kopf==1.35.6",
         # Careful with 22+ - it is currently not compatible
         # and results in various "permission denied" errors.
         "kubernetes-asyncio==21.7.1",
@@ -74,6 +74,7 @@ setup(
             "pytest==7.1.3",
             "pytest-aiohttp==0.3.0",
             "pytest-asyncio==0.19.0",
+            "pytest-xdist==2.5.0",  # enables parallel testing
         ],
         "develop": [
             "black==22.3.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
-def load_config():
+def load_config(worker_id):
     env = {
         "CRATEDB_OPERATOR_CLUSTER_BACKUP_IMAGE": "crate/does-not-exist-backup",
         "CRATEDB_OPERATOR_DEBUG_VOLUME_SIZE": "2GiB",
@@ -104,6 +104,9 @@ def load_config():
         "CRATEDB_OPERATOR_JMX_EXPORTER_VERSION": "1.0.0",
         "CRATEDB_OPERATOR_LOG_LEVEL": "DEBUG",
         "CRATEDB_OPERATOR_TESTING": "true",
+        "CRATEDB_OPERATOR_PARALLEL_TESTING": "false"
+        if worker_id == "master"
+        else "true",
         "CRATEDB_OPERATOR_JOBS_TABLE": "test.test_sys_jobs",
         "CRATEDB_OPERATOR_BOOTSTRAP_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_HEALTH_CHECK_RETRY_DELAY": "5",
@@ -173,7 +176,7 @@ def kopf_runner(request, cratedb_crd):
         ),
     }
     with mock.patch.dict(os.environ, env):
-        with KopfRunner(["run", "--standalone", main.__file__]) as runner:
+        with KopfRunner(["run", "--standalone", "-A", main.__file__]) as runner:
             yield runner
 
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -50,7 +50,7 @@ async def test_upgrade_cluster(faker, namespace, kopf_runner, api_client):
     core = CoreV1Api(api_client)
     name = faker.domain_word()
 
-    host, password = await start_cluster(name, namespace, core, coapi, 3, version_from)
+    host, password = await start_cluster(name, namespace, core, coapi, 2, version_from)
 
     await assert_wait_for(
         True,
@@ -60,7 +60,6 @@ async def test_upgrade_cluster(faker, namespace, kopf_runner, api_client):
         {
             f"crate-data-hot-{name}-0",
             f"crate-data-hot-{name}-1",
-            f"crate-data-hot-{name}-2",
         },
     )
 
@@ -70,7 +69,7 @@ async def test_upgrade_cluster(faker, namespace, kopf_runner, api_client):
         True,
         is_cluster_healthy,
         conn_factory,
-        3,
+        2,
         err_msg="Cluster wasn't healthy",
         timeout=DEFAULT_TIMEOUT,
     )
@@ -138,7 +137,7 @@ async def test_upgrade_cluster(faker, namespace, kopf_runner, api_client):
         True,
         is_cluster_healthy,
         connection_factory(host, password),
-        3,
+        2,
         err_msg="Cluster wasn't healthy",
         timeout=DEFAULT_TIMEOUT,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,6 +21,7 @@
 
 import asyncio
 import logging
+import os
 from typing import Any, Callable, List, Mapping, Optional, Set, Tuple
 from unittest import mock
 
@@ -109,7 +110,7 @@ async def start_cluster(
     body: dict = {
         "apiVersion": "cloud.crate.io/v1",
         "kind": "CrateDB",
-        "metadata": {"name": name},
+        "metadata": {"name": name, "annotations": {"testing": f"{os.getpid()}"}},
         "spec": {
             "cluster": {
                 "imageRegistry": "crate",


### PR DESCRIPTION
## Summary of changes

This is done using pytest-xdist and by adding the `-n X` parameter to pytest, where X is the number of parallel executors.

This required a locking mechanism to be implemented, as each worker spawns it's own operator (in the `kopf_runner` fixture). If the tests detect that they are running in parallel mode, the operator will only process the CrateDBs that have the `{"testing": "$PID"}` annotation - meaning that they will only process CrateDBs from the same worker. This allows us to continue using various `@mock.patch` monkey-patches that assume there's just one process running.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
