### PR TITLE
Add service annotation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 * Added support for parallel testing, which greatly reduces test runtime.
 
+* Change AWS Loadbalancer to type NLB instead of CLASSIC.
+
 2.14.0 (2022-09-13)
 -------------------
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -886,6 +886,7 @@ def get_data_service(
                 "service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout": "1800",  # noqa
                 # Default idle timeout is 60s, which kills the connection on long-running queries # noqa
                 "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": "3600",  # noqa
+                "service.beta.kubernetes.io/aws-load-balancer-type": "nlb",  # noqa
             }
         )
     elif config.CLOUD_PROVIDER == CloudProvider.AZURE:

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -952,6 +952,10 @@ class TestServiceModels:
                 "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"  # noqa
                 in annotation_keys
             )
+            assert (
+                "service.beta.kubernetes.io/aws-load-balancer-type"  # noqa
+                in annotation_keys
+            )
         if provider == "azure":
             assert (
                 "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset"


### PR DESCRIPTION
## Summary of changes
While looking into https://github.com/crate/cloud/issues/807 we found that we need to change to type of AWS Loadbalancer to type `NLB`. Without this annotation it is created as type `CLASSIC`, which does not support AWS private endpoints.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
