### PR TITLE
PoC to switch from the all-encompassing update handler

### DIFF
--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -377,3 +377,13 @@ class Config:
 
 #: The global instance of the CrateDB operator config
 config = Config(prefix="CRATEDB_OPERATOR_")
+
+
+def get_backoff() -> int:
+    """
+    When in testing mode, use a shorter backoff period as it help with speeding up some
+    tests (they don't have to wait so long due to transient errors).
+    """
+    if config.TESTING:
+        return 5
+    return 30

--- a/crate/operator/handlers/handle_upgrade_cratedb.py
+++ b/crate/operator/handlers/handle_upgrade_cratedb.py
@@ -1,0 +1,102 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import datetime
+import hashlib
+
+import kopf
+
+from crate.operator.config import get_backoff
+from crate.operator.operations import (
+    AfterClusterUpdateSubHandler,
+    BeforeClusterUpdateSubHandler,
+    RestartSubHandler,
+)
+from crate.operator.upgrade import AfterUpgradeSubHandler, UpgradeSubHandler
+
+
+async def upgrade_cratedb(
+    namespace: str,
+    name: str,
+    patch: kopf.Patch,
+    status: kopf.Status,
+    diff: kopf.Diff,
+    started: datetime.datetime,
+    handler_id: str,
+    field: str,
+):
+    context = status.get(handler_id)
+    hash_string = str(diff) + str(started)
+    hash = hashlib.md5(hash_string.encode("utf-8")).hexdigest()
+    if not context:
+        context = {"ref": hash}
+    elif context.get("ref", "") != hash:
+        context["ref"] = hash
+
+    depends_on = [f"{handler_id}/{field}/before_cluster_update"]
+
+    kopf.register(
+        fn=BeforeClusterUpdateSubHandler(namespace, name, hash, context)(),
+        id="before_cluster_update",
+        backoff=get_backoff(),
+    )
+
+    kopf.register(
+        fn=UpgradeSubHandler(
+            namespace, name, hash, context, depends_on=depends_on.copy()
+        )(),
+        id="upgrade",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{handler_id}/{field}/upgrade")
+
+    kopf.register(
+        fn=RestartSubHandler(
+            namespace, name, hash, context, depends_on=depends_on.copy()
+        )(),
+        id="restart",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{handler_id}/{field}/restart")
+
+    kopf.register(
+        fn=AfterUpgradeSubHandler(
+            namespace, name, hash, context, depends_on=depends_on.copy()
+        )(),
+        id="after_upgrade",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{handler_id}/{field}/after_upgrade")
+
+    kopf.register(
+        fn=AfterClusterUpdateSubHandler(
+            namespace,
+            name,
+            hash,
+            context,
+            depends_on=depends_on.copy(),
+            run_on_dep_failures=True,
+        )(),
+        id="after_cluster_update",
+        backoff=get_backoff(),
+    )
+
+    patch.status["upgrade"] = context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,7 +146,7 @@ def cratedb_crd(request, tmp_path_factory, load_config):
     with FileLock(f"{root_tmp_dir}/operator-apply-lock"):
         subprocess.run(
             [
-                "/home/romanas/bin/kubectl",
+                "kubectl",
                 "--kubeconfig",
                 str(pathlib.Path(kubeconfig).expanduser().resolve()),
                 "apply",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,7 +146,7 @@ def cratedb_crd(request, tmp_path_factory, load_config):
     with FileLock(f"{root_tmp_dir}/operator-apply-lock"):
         subprocess.run(
             [
-                "kubectl",
+                "/home/romanas/bin/kubectl",
                 "--kubeconfig",
                 str(pathlib.Path(kubeconfig).expanduser().resolve()),
                 "apply",

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -44,8 +44,8 @@ from .utils import (
 @pytest.mark.k8s
 @pytest.mark.asyncio
 async def test_upgrade_cluster(faker, namespace, kopf_runner, api_client):
-    version_from = "4.6.1"
-    version_to = "4.6.4"
+    version_from = "4.8.2"
+    version_to = "5.0.1"
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)
     name = faker.domain_word()
@@ -117,7 +117,7 @@ async def test_upgrade_cluster(faker, namespace, kopf_runner, api_client):
         coapi,
         name,
         namespace.metadata.name,
-        "operator.cloud.crate.io/cluster_update.upgrade",
+        "operator.cloud.crate.io/upgrade.upgrade",
         err_msg="Upgrade has not finished",
         timeout=DEFAULT_TIMEOUT * 5,
     )
@@ -128,7 +128,7 @@ async def test_upgrade_cluster(faker, namespace, kopf_runner, api_client):
         coapi,
         name,
         namespace.metadata.name,
-        "operator.cloud.crate.io/cluster_update.restart",
+        "operator.cloud.crate.io/upgrade.restart",
         err_msg="Restart has not finished",
         timeout=DEFAULT_TIMEOUT,
     )


### PR DESCRIPTION
## Summary of changes

... to individual field handlers. This has been done for the upgrade operation only.

Biggest issue by far is that the semantics of the new and old fields changes - they now refer not to the entire body, but to the individual field that changed.

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
