### PR TITLE
Added the `-A` option (all-namespaces) to the operator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Unreleased
 
 * Added Helm Chart and ``Helm Chart Releaser`` GitHub action.
 
+* Added the ``-A`` option (all-namespaces) to the operator run command in the Dockerfile.
+  This fixes a warning that the operator prints when starting.
+
 2.14.0 (2022-09-13)
 -------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,5 @@ RUN pip install --no-cache-dir -U pip wheel && \
 
 USER crate-operator
 
-ENTRYPOINT ["kopf", "run", "--standalone"]
+ENTRYPOINT ["kopf", "run", "--standalone", "-A"]
 CMD ["main.py"]


### PR DESCRIPTION
## Summary of changes

... run command in the Dockerfile. This fixes a warning that the operator prints when starting.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
