### PR TITLE
Added cratedb_cluster_last_activity metric to the sql exporter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Added cratedb_cluster_last_activity metric to the sql exporter
+
 2.15.0 (2022-09-28)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 Unreleased
 ----------
 
-* Added cratedb_cluster_last_activity metric to the sql exporter
+* Added cratedb_cluster_last_user_activity metric to the sql exporter
 
 2.15.0 (2022-09-28)
 -------------------

--- a/crate/operator/data/cratedb_cluster_last_activity-collector.yaml
+++ b/crate/operator/data/cratedb_cluster_last_activity-collector.yaml
@@ -1,0 +1,14 @@
+---
+collector_name: cratedb_cluster_last_activity_collector
+# This metric is intended to know if the cluster is used
+# and to calculate for how long it has not been used.
+metrics:
+- help: "Indicates when the last job occured on the cluster."
+  metric_name: cratedb_cluster_last_activity
+  query: |
+    SELECT max(ended) AS cratedb_cluster_last_activity
+    FROM sys.jobs_log
+    WHERE username NOT IN ('crate', 'system');
+  type: gauge
+  value_label: cratedb_cluster_last_activity
+  values: [cratedb_cluster_last_activity]

--- a/crate/operator/data/cratedb_cluster_last_user_activity-collector.yaml
+++ b/crate/operator/data/cratedb_cluster_last_user_activity-collector.yaml
@@ -6,7 +6,7 @@ metrics:
 - help: "Indicates when the last job occured on the cluster."
   metric_name: cratedb_cluster_last_user_activity
   query: |
-    SELECT max(ended) AS cratedb_cluster_last_user_activity
+    SELECT cast(extract(epoch from max(ended)) as integer) AS cratedb_cluster_last_user_activity
     FROM sys.jobs_log
     WHERE username NOT IN ('crate', 'system');
   type: gauge

--- a/crate/operator/data/cratedb_cluster_last_user_activity-collector.yaml
+++ b/crate/operator/data/cratedb_cluster_last_user_activity-collector.yaml
@@ -1,14 +1,14 @@
 ---
-collector_name: cratedb_cluster_last_activity_collector
+collector_name: cratedb_cluster_last_user_activity_collector
 # This metric is intended to know if the cluster is used
 # and to calculate for how long it has not been used.
 metrics:
 - help: "Indicates when the last job occured on the cluster."
-  metric_name: cratedb_cluster_last_activity
+  metric_name: cratedb_cluster_last_user_activity
   query: |
-    SELECT max(ended) AS cratedb_cluster_last_activity
+    SELECT max(ended) AS cratedb_cluster_last_user_activity
     FROM sys.jobs_log
     WHERE username NOT IN ('crate', 'system');
   type: gauge
-  value_label: cratedb_cluster_last_activity
-  values: [cratedb_cluster_last_activity]
+  value_label: cratedb_cluster_last_user_activity
+  values: [cratedb_cluster_last_user_activity]

--- a/crate/operator/data/sql-exporter.yaml
+++ b/crate/operator/data/sql-exporter.yaml
@@ -14,7 +14,7 @@ global:
   # timing out first.
   scrape_timeout_offset: 500ms
 target:
-  collectors: [responsivity_collector, cratedb_max_shards_collector]
+  collectors: [responsivity_collector, cratedb_max_shards_collector, cratedb_cluster_last_activity_collector]
   # To test sql exporter against a local crateDB service you can add "&sslmode=disable" to the data_source_name.
   # Please do not use sslmode=disable in production as it hinders security.
   data_source_name: "postgres://crate@localhost:5432/?connect_timeout=5"

--- a/crate/operator/data/sql-exporter.yaml
+++ b/crate/operator/data/sql-exporter.yaml
@@ -14,7 +14,7 @@ global:
   # timing out first.
   scrape_timeout_offset: 500ms
 target:
-  collectors: [responsivity_collector, cratedb_max_shards_collector, cratedb_cluster_last_activity_collector]
+  collectors: [responsivity_collector, cratedb_max_shards_collector, cratedb_cluster_last_user_activity_collector]
   # To test sql exporter against a local crateDB service you can add "&sslmode=disable" to the data_source_name.
   # Please do not use sslmode=disable in production as it hinders security.
   data_source_name: "postgres://crate@localhost:5432/?connect_timeout=5"


### PR DESCRIPTION
## Summary of changes

https://github.com/crate/cloud/issues/589

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
