### PR TITLE
Fixed success notifications being sent too soon for update operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 
 * Added cratedb_cluster_last_user_activity metric to the sql exporter
 
+* Fixed success notifications being sent too soon for update operations.
+
 2.15.0 (2022-09-28)
 -------------------
 

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -55,12 +55,12 @@ class ChangeComputeSubHandler(StateBasedSubHandler):
             apps = AppsV1Api(api_client)
             await change_cluster_compute(apps, namespace, name, webhook_payload, logger)
 
-        self.schedule_notification(
+        await self.send_notification_now(
+            logger,
             WebhookEvent.COMPUTE_CHANGED,
             webhook_payload,
             WebhookStatus.IN_PROGRESS,
         )
-        await self.send_notifications(logger)
 
 
 class AfterChangeComputeSubHandler(StateBasedSubHandler):
@@ -84,7 +84,6 @@ class AfterChangeComputeSubHandler(StateBasedSubHandler):
             generate_change_compute_payload(old, body),
             WebhookStatus.SUCCESS,
         )
-        await self.send_notifications(logger)
 
 
 def generate_change_compute_payload(old, body):

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -269,6 +269,7 @@ async def update_cratedb(
 
     patch.status[CLUSTER_UPDATE_ID] = context
 
+    # Ensure all success notifications are only sent at the very end of the handler
     kopf.register(
         fn=FlushNotificationsSubHandler(
             namespace,

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -649,8 +649,6 @@ class RestartSubHandler(StateBasedSubHandler):
             core = CoreV1Api(api_client)
             await restart_cluster(core, namespace, name, old, logger, patch, status)
 
-        await self.send_notifications(logger)
-
 
 DISABLE_CRONJOB_HANDLER_ID = "disable_cronjob"
 IGNORE_CRONJOB = "ignore_cronjob"
@@ -786,12 +784,12 @@ class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
                     )
 
     async def _notify_backup_running(self, logger):
-        self.schedule_notification(
+        await self.send_notification_now(
+            logger,
             WebhookEvent.DELAY,
             WebhookTemporaryFailurePayload(reason="A snapshot is in progress"),
             WebhookStatus.TEMPORARY_FAILURE,
         )
-        await self.send_notifications(logger)
 
     async def _set_cluster_routing_allocation_setting(
         self, namespace: str, name: str, logger: logging.Logger

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -932,8 +932,6 @@ class StartClusterSubHandler(StateBasedSubHandler):
                     logger,
                 )
 
-        await self.send_notifications(logger)
-
 
 class SuspendClusterSubHandler(StateBasedSubHandler):
     @crate.on.error(error_handler=crate.send_update_failed_notification)

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -728,7 +728,6 @@ class ScaleSubHandler(StateBasedSubHandler):
             ),
             WebhookStatus.SUCCESS,
         )
-        await self.send_notifications(logger)
 
 
 async def _ensure_cluster_healthy(

--- a/crate/operator/upgrade.py
+++ b/crate/operator/upgrade.py
@@ -222,4 +222,3 @@ class AfterUpgradeSubHandler(StateBasedSubHandler):
             ),
             WebhookStatus.SUCCESS,
         )
-        await self.send_notifications(logger)

--- a/crate/operator/upgrade.py
+++ b/crate/operator/upgrade.py
@@ -183,7 +183,8 @@ class UpgradeSubHandler(StateBasedSubHandler):
             apps = AppsV1Api(api_client)
             await upgrade_cluster(apps, namespace, name, body, old, logger)
 
-        self.schedule_notification(
+        await self.send_notification_now(
+            logger,
             WebhookEvent.UPGRADE,
             WebhookUpgradePayload(
                 old_registry=old["spec"]["cluster"]["imageRegistry"],
@@ -193,7 +194,6 @@ class UpgradeSubHandler(StateBasedSubHandler):
             ),
             WebhookStatus.IN_PROGRESS,
         )
-        await self.send_notifications(logger)
 
 
 class AfterUpgradeSubHandler(StateBasedSubHandler):

--- a/crate/operator/utils/notifications.py
+++ b/crate/operator/utils/notifications.py
@@ -21,7 +21,6 @@
 
 
 import logging
-from datetime import datetime
 from typing import Any
 
 import kopf
@@ -66,6 +65,4 @@ class FlushNotificationsSubHandler(StateBasedSubHandler):
         status: kopf.Status,
         **kwargs: Any,
     ):
-        logger.info(f"{datetime.now()} NOTIFY-UPDATE handler started!")
-        await self.send_notifications(logger)
-        logger.info(f"{datetime.now()} NOTIFY-UPDATE handler finished!")
+        await self.send_registered_notifications(logger)

--- a/tests/test_change_compute.py
+++ b/tests/test_change_compute.py
@@ -178,20 +178,6 @@ async def test_change_compute_from_request_to_limit(
         timeout=DEFAULT_TIMEOUT * 5,
     )
 
-    notification_success_call = mock.call(
-        WebhookEvent.COMPUTE_CHANGED,
-        WebhookStatus.SUCCESS,
-        namespace.metadata.name,
-        name,
-        compute_changed_data=mock.ANY,
-        unsafe=mock.ANY,
-        logger=mock.ANY,
-    )
-
-    assert not await was_notification_sent(
-        mock_send_notification=mock_send_notification, call=notification_success_call
-    ), "A success notification was sent too early"
-
     await assert_wait_for(
         True,
         is_kopf_handler_finished,
@@ -280,6 +266,15 @@ async def test_change_compute_from_request_to_limit(
         timeout=DEFAULT_TIMEOUT,
     )
 
+    notification_success_call = mock.call(
+        WebhookEvent.COMPUTE_CHANGED,
+        WebhookStatus.SUCCESS,
+        namespace.metadata.name,
+        name,
+        compute_changed_data=mock.ANY,
+        unsafe=mock.ANY,
+        logger=mock.ANY,
+    )
     assert await was_notification_sent(
         mock_send_notification=mock_send_notification, call=notification_success_call
     ), "A success notification was expected but was not sent"

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -115,10 +115,6 @@ async def test_expand_cluster_storage(
 
     await _expand_volume(coapi, name, namespace, "32Gi")
 
-    assert not await was_notification_sent(
-        mock_send_notification=mock_send_notification, call=notification_success_call
-    ), "A success notification was sent too early"
-
     # we just check if the PVC has been patched with the correct new disk size. We
     # do not wait for the PVC to be really resized because there is no guarantee
     # it is supported.

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -18,6 +18,7 @@
 # However, if you have executed another commercial license agreement
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
+from unittest import mock
 
 import bitmath
 import pytest
@@ -36,6 +37,7 @@ from crate.operator.constants import (
 )
 from crate.operator.cratedb import connection_factory
 from crate.operator.utils.formatting import convert_to_bytes
+from crate.operator.webhooks import WebhookEvent, WebhookStatus
 
 from .utils import (
     DEFAULT_TIMEOUT,
@@ -44,6 +46,7 @@ from .utils import (
     is_cluster_healthy,
     is_kopf_handler_finished,
     start_cluster,
+    was_notification_sent,
 )
 
 
@@ -62,7 +65,9 @@ def test_convert_to_bytes(input, expected):
 
 @pytest.mark.k8s
 @pytest.mark.asyncio
+@mock.patch("crate.operator.webhooks.webhook_client._send")
 async def test_expand_cluster_storage(
+    mock_send_notification,
     faker,
     namespace,
     kopf_runner,
@@ -73,6 +78,16 @@ async def test_expand_cluster_storage(
     storage = StorageV1Api(api_client)
     name = faker.domain_word()
     number_of_nodes = 2
+
+    notification_success_call = mock.call(
+        WebhookEvent.FEEDBACK,
+        WebhookStatus.SUCCESS,
+        namespace.metadata.name,
+        name,
+        feedback_data=mock.ANY,
+        unsafe=mock.ANY,
+        logger=mock.ANY,
+    )
 
     expansion_supported = await _is_volume_expansion_supported(storage)
     if expansion_supported is not True:
@@ -99,6 +114,10 @@ async def test_expand_cluster_storage(
     await create_test_sys_jobs_table(conn_factory)
 
     await _expand_volume(coapi, name, namespace, "32Gi")
+
+    assert not await was_notification_sent(
+        mock_send_notification=mock_send_notification, call=notification_success_call
+    ), "A success notification was sent too early"
 
     # we just check if the PVC has been patched with the correct new disk size. We
     # do not wait for the PVC to be really resized because there is no guarantee
@@ -133,6 +152,10 @@ async def test_expand_cluster_storage(
         err_msg="Volume Expansion handler has not finished.",
         timeout=DEFAULT_TIMEOUT * 5,
     )
+
+    assert await was_notification_sent(
+        mock_send_notification=mock_send_notification, call=notification_success_call
+    ), "A success notification was expected but was not sent"
 
 
 async def _all_pvcs_resized(

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -21,6 +21,7 @@
 
 import asyncio
 import sys
+from unittest import mock
 
 import pytest
 from kubernetes_asyncio.client import (
@@ -42,6 +43,7 @@ from crate.operator.cratedb import connection_factory
 from crate.operator.create import get_statefulset_crate_command
 from crate.operator.operations import get_pods_in_deployment, get_pods_in_statefulset
 from crate.operator.scale import parse_replicas, patch_command
+from crate.operator.webhooks import WebhookEvent, WebhookStatus
 
 from .utils import (
     DEFAULT_TIMEOUT,
@@ -56,6 +58,7 @@ from .utils import (
     is_kopf_handler_finished,
     start_backup_metrics,
     start_cluster,
+    was_notification_sent,
 )
 
 
@@ -136,7 +139,9 @@ def test_patch_sts_command_deprecated(total, quorum, new_total, new_quorum):
         (3, 2),  # scale down from 3 to 2 data nodes
     ],
 )
+@mock.patch("crate.operator.webhooks.webhook_client._send")
 async def test_scale_cluster(
+    mock_send_notification,
     repl_hot_from,
     repl_hot_to,
     faker,
@@ -147,6 +152,16 @@ async def test_scale_cluster(
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)
     name = faker.domain_word()
+
+    notification_success_call = mock.call(
+        WebhookEvent.SCALE,
+        WebhookStatus.SUCCESS,
+        namespace.metadata.name,
+        name,
+        scale_data=mock.ANY,
+        unsafe=mock.ANY,
+        logger=mock.ANY,
+    )
 
     host, password = await start_cluster(
         name,
@@ -160,6 +175,10 @@ async def test_scale_cluster(
     await create_test_sys_jobs_table(conn_factory)
 
     await _scale_cluster(coapi, name, namespace, repl_hot_to)
+
+    assert not await was_notification_sent(
+        mock_send_notification=mock_send_notification, call=notification_success_call
+    ), "A success notification was sent too early"
 
     await assert_wait_for(
         True,
@@ -180,6 +199,10 @@ async def test_scale_cluster(
         err_msg="Scaling has not finished",
         timeout=DEFAULT_TIMEOUT,
     )
+
+    assert await was_notification_sent(
+        mock_send_notification=mock_send_notification, call=notification_success_call
+    ), "A success notification was expected but was not sent"
 
 
 @pytest.mark.k8s

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -153,16 +153,6 @@ async def test_scale_cluster(
     core = CoreV1Api(api_client)
     name = faker.domain_word()
 
-    notification_success_call = mock.call(
-        WebhookEvent.SCALE,
-        WebhookStatus.SUCCESS,
-        namespace.metadata.name,
-        name,
-        scale_data=mock.ANY,
-        unsafe=mock.ANY,
-        logger=mock.ANY,
-    )
-
     host, password = await start_cluster(
         name,
         namespace,
@@ -175,10 +165,6 @@ async def test_scale_cluster(
     await create_test_sys_jobs_table(conn_factory)
 
     await _scale_cluster(coapi, name, namespace, repl_hot_to)
-
-    assert not await was_notification_sent(
-        mock_send_notification=mock_send_notification, call=notification_success_call
-    ), "A success notification was sent too early"
 
     await assert_wait_for(
         True,
@@ -200,6 +186,15 @@ async def test_scale_cluster(
         timeout=DEFAULT_TIMEOUT,
     )
 
+    notification_success_call = mock.call(
+        WebhookEvent.SCALE,
+        WebhookStatus.SUCCESS,
+        namespace.metadata.name,
+        name,
+        scale_data=mock.ANY,
+        unsafe=mock.ANY,
+        logger=mock.ANY,
+    )
     assert await was_notification_sent(
         mock_send_notification=mock_send_notification, call=notification_success_call
     ), "A success notification was expected but was not sent"

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -55,16 +55,6 @@ async def test_upgrade_cluster(
     core = CoreV1Api(api_client)
     name = faker.domain_word()
 
-    notification_success_call = mock.call(
-        WebhookEvent.UPGRADE,
-        WebhookStatus.SUCCESS,
-        namespace.metadata.name,
-        name,
-        upgrade_data=mock.ANY,
-        unsafe=mock.ANY,
-        logger=mock.ANY,
-    )
-
     host, password = await start_cluster(name, namespace, core, coapi, 2, version_from)
 
     await assert_wait_for(
@@ -126,10 +116,6 @@ async def test_upgrade_cluster(
         timeout=DEFAULT_TIMEOUT * 15,
     )
 
-    assert not await was_notification_sent(
-        mock_send_notification=mock_send_notification, call=notification_success_call
-    ), "A success notification was sent too early"
-
     await assert_wait_for(
         True,
         is_kopf_handler_finished,
@@ -170,6 +156,15 @@ async def test_upgrade_cluster(
         timeout=DEFAULT_TIMEOUT * 5,
     )
 
+    notification_success_call = mock.call(
+        WebhookEvent.UPGRADE,
+        WebhookStatus.SUCCESS,
+        namespace.metadata.name,
+        name,
+        upgrade_data=mock.ANY,
+        unsafe=mock.ANY,
+        logger=mock.ANY,
+    )
     assert await was_notification_sent(
         mock_send_notification=mock_send_notification, call=notification_success_call
     ), "A success notification was expected but was not sent"


### PR DESCRIPTION
## Summary of changes
Fixed success notifications being sent too soon for update operations

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
