### PR TITLE
Change the node name to "hot"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ A minimal custom resource for a 3 node CrateDB cluster may look like this:
        version: 4.3.1
      nodes:
        data:
-       - name: default
+       - name: hot
          replicas: 3
          resources:
            limits:


### PR DESCRIPTION
## Summary of changes

The CRD, when printing `kubectl get cratedbs` shows the number of "hot" nodes. 

This is also what CrateDB Cloud uses by default.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
