### PR TITLE
Added support for expanding volumes online (without suspending the cluster)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 Unreleased
 ----------
 
+* Added support for expanding volumes online (without suspending the cluster).
+  This is controlled by the ``NO_DOWNTIME_STORAGE_EXPANSION`` config option
+  and defaults to false. The feature must be supported by the underlying infrastructure,
+  i.e. Azure AKS or AWS EKS supports it using CSI drivers.
+
 2.16.0 (2022-10-17)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -103,10 +103,14 @@ class Config:
     CLUSTER_UPDATE_TIMEOUT = 7200
 
     #: Time in seconds for which the operator will continue and wait to perform
-    #: a check if volume expansion has finshed successfully. Once this threshold
-    # has passed, a volume expansion is considered failed or not supported by the
-    # StorageClass.
+    #: a check if volume expansion has finished successfully. Once this threshold
+    #: has passed, volume expansion is considered failed or not supported by the
+    #: StorageClass.
     EXPAND_VOLUME_TIMEOUT = 1800
+
+    #: Do not scale down cluster when performing storage expansion.
+    #: The underlying infrastructure must support this - i.e. Azure or AWS CSI volumes.
+    NO_DOWNTIME_STORAGE_EXPANSION: bool = False
 
     #: Enable several testing behaviors, such as relaxed pod anti-affinity to
     #: allow for easier testing in smaller Kubernetes clusters.
@@ -354,6 +358,11 @@ class Config:
                 f"Invalid {self._prefix}EXPAND_VOLUME_TIMEOUT="
                 f"'{expand_volume_timeout}'. Needs to be a positive integer or 0."
             )
+        expansion = self.env(
+            "NO_DOWNTIME_STORAGE_EXPANSION",
+            default=str(self.NO_DOWNTIME_STORAGE_EXPANSION),
+        )
+        self.NO_DOWNTIME_STORAGE_EXPANSION = expansion.lower() == "true"
 
     def env(self, name: str, *, default=UNDEFINED) -> str:
         """

--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -64,7 +64,7 @@ async def expand_volume(
     await send_operation_progress_notification(
         namespace=namespace,
         name=name,
-        message="Suspending cluster.",
+        message="Resizing volume(s).",
         logger=logger,
         status=WebhookStatus.IN_PROGRESS,
         operation=WebhookOperation.UPDATE,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -173,6 +173,17 @@ expected to use upper case letters and must be prefixed with
 
    The default value is ``None``.
 
+.. envvar:: NO_DOWNTIME_STORAGE_EXPANSION
+
+   Whether to perform volume expansion operations without suspending the cluster.
+   For this to work, it must be supported by the underlying infrastructure. At the time
+   of writing, this works on Azure AKS and AWS EKS if using the CSI drivers.
+
+   By default, the operator will suspend the cluster while performing volume expansion,
+   and resume it once the PVCs expand.
+
+   The default value is ``False``.
+
 
 .. _12 Factor Principles: https://12factor.net/
 .. _Prometheus: https://prometheus.io/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,7 @@ def load_config(worker_id):
         "CRATEDB_OPERATOR_BOOTSTRAP_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_HEALTH_CHECK_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_CRATEDB_STATUS_CHECK_INTERVAL": "5",
+        "CRATEDB_OPERATOR_NO_DOWNTIME_STORAGE_EXPANSION": "true",
     }
     # If the environment already has any of these keys defined, leave them be
     for k in env.keys():


### PR DESCRIPTION
## Summary of changes

This is controlled by the ``NO_DOWNTIME_STORAGE_EXPANSION`` config option and defaults to false. The feature must be supported by the underlying infrastructure, i.e. Azure AKS or AWS EKS supports it using CSI drivers.

https://github.com/crate/cloud/issues/917



## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
