### PR TITLE
Disabled parallel cluster suspension and volume resizing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Unreleased
   and defaults to false. The feature must be supported by the underlying infrastructure,
   i.e. Azure AKS or AWS EKS supports it using CSI drivers.
 
+* Disabled parallel cluster suspension and volume resizing. This was causing issues on
+  Azure AKS. Will now first suspend the cluster and only then attempt to resize volumes.
+
 2.16.0 (2022-10-17)
 -------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,6 @@ def load_config(worker_id):
         "CRATEDB_OPERATOR_BOOTSTRAP_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_HEALTH_CHECK_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_CRATEDB_STATUS_CHECK_INTERVAL": "5",
-        "CRATEDB_OPERATOR_NO_DOWNTIME_STORAGE_EXPANSION": "true",
     }
     # If the environment already has any of these keys defined, leave them be
     for k in env.keys():


### PR DESCRIPTION
## Summary of changes

This was causing issues on Azure AKS. Will now first suspend the cluster and only then attempt to resize volumes.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
