### PR TITLE
Use crash to update user password

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Fixed the way user passwords are updated to not require the old password anymore.
+
 2.17.0 (2022-10-31)
 -------------------
 


### PR DESCRIPTION
## Summary of changes
To avoid passwords getting out of sync if a user changes it directly in CrateDB (`ALTER USER`), we change the way the new password is set to do it directly on the pod using `crash`

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
