### PR TITLE
Add support for restoring clusters from a backup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Added support to restore a snapshot from a backup repository.
+
 2.19.0 (2022-11-29)
 -------------------
 

--- a/crate/operator/cratedb.py
+++ b/crate/operator/cratedb.py
@@ -21,7 +21,7 @@
 
 import functools
 import logging
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 
 import aiopg
 from aiopg import Cursor
@@ -208,7 +208,7 @@ async def set_cluster_setting(
     logger: logging.Logger,
     *,
     setting: str,
-    value: str,
+    value: Union[str, int],
     mode: str = "TRANSIENT",
 ) -> None:
     """

--- a/crate/operator/handlers/handle_restore_backup.py
+++ b/crate/operator/handlers/handle_restore_backup.py
@@ -1,0 +1,271 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import datetime
+import hashlib
+import logging
+from typing import List
+
+import kopf
+
+from crate.operator.config import config
+from crate.operator.handlers.handle_update_cratedb import get_backoff
+from crate.operator.operations import (
+    AfterClusterUpdateSubHandler,
+    BeforeClusterUpdateSubHandler,
+    get_cratedb_resource,
+)
+from crate.operator.restore_backup import (
+    AfterRestoreBackupSubHandler,
+    BeforeRestoreBackupSubHandler,
+    ResetSnapshotSubHandler,
+    RestoreBackupSubHandler,
+    RestoreSystemUserPasswordSubHandler,
+    SendSuccessNotificationSubHandler,
+    ensure_no_restore_in_progress,
+    get_crash_pod_name,
+    get_crash_scheme,
+)
+from crate.operator.utils.notifications import FlushNotificationsSubHandler
+
+CLUSTER_RESTORE_FIELD_ID = "cluster_restore/spec.cluster.restoreSnapshot"
+
+
+async def restore_backup(
+    namespace: str,
+    name: str,
+    diff: kopf.Diff,
+    new: kopf.Body,
+    patch: kopf.Patch,
+    status: kopf.Status,
+    started: datetime.datetime,
+    logger: logging.Logger,
+):
+    context = status.get(CLUSTER_RESTORE_FIELD_ID)
+    hash_string = str(diff) + str(started)
+    change_hash = hashlib.md5(hash_string.encode("utf-8")).hexdigest()
+    if not context:
+        context = {"ref": change_hash}
+    elif context.get("ref", "") != change_hash:
+        context["ref"] = change_hash
+
+    cratedb = await get_cratedb_resource(namespace, name)
+    snapshot = new["snapshot"]
+    tables = new.get("tables", ["all"])
+
+    scheme = get_crash_scheme(cratedb)
+    pod_name = get_crash_pod_name(cratedb, name)
+    repository = f"restore_backup_{int(started.timestamp())}"
+
+    # If there is a restore operation in progress, we do not do
+    # anything else until it is finished.
+    await ensure_no_restore_in_progress(
+        namespace, name, snapshot, pod_name, scheme, logger
+    )
+
+    depends_on: List[str] = []
+
+    register_before_restore_handlers(
+        namespace, name, patch, change_hash, context, depends_on
+    )
+
+    register_restore_handlers(
+        namespace,
+        name,
+        change_hash,
+        context,
+        depends_on,
+        repository,
+        snapshot,
+        tables,
+    )
+
+    register_after_restore_handlers(
+        namespace,
+        name,
+        status,
+        change_hash,
+        context,
+        depends_on,
+        repository,
+    )
+
+    kopf.register(
+        fn=FlushNotificationsSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+            run_on_dep_failures=True,
+        )(),
+        id="flush_notifications",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{CLUSTER_RESTORE_FIELD_ID}/flush_notifications")
+
+    # This needs to be the last subhandler, otherwise the operation does
+    # not finish properly.
+    kopf.register(
+        fn=ResetSnapshotSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+            run_on_dep_failures=True,
+        )(),
+        id="reset_snapshot",
+        backoff=get_backoff(),
+    )
+
+    patch.status[CLUSTER_RESTORE_FIELD_ID] = context
+
+
+def register_before_restore_handlers(
+    namespace: str,
+    name: str,
+    patch: kopf.Patch,
+    change_hash: str,
+    context: dict,
+    depends_on: list,
+):
+
+    kopf.register(
+        fn=BeforeClusterUpdateSubHandler(
+            namespace, name, change_hash, context, depends_on=depends_on.copy()
+        )(),
+        id="before_cluster_update",
+        backoff=get_backoff(),
+    )
+    kopf.register(
+        fn=BeforeRestoreBackupSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+        )(patch=patch),
+        id="before_restore_backup",
+        backoff=get_backoff(),
+    )
+    depends_on.extend(
+        [
+            f"{CLUSTER_RESTORE_FIELD_ID}/before_cluster_update",
+            f"{CLUSTER_RESTORE_FIELD_ID}/before_restore_backup",
+        ]
+    )
+
+
+def register_restore_handlers(
+    namespace: str,
+    name: str,
+    change_hash: str,
+    context: dict,
+    depends_on: list,
+    repository: str,
+    snapshot: str,
+    tables: list,
+):
+    kopf.register(
+        fn=RestoreBackupSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+        )(
+            repository=repository,
+            snapshot=snapshot,
+            tables=tables,
+        ),
+        id="restore_backup_data",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{CLUSTER_RESTORE_FIELD_ID}/restore_backup_data")
+
+    kopf.register(
+        fn=RestoreSystemUserPasswordSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+            run_on_dep_failures=True,
+        )(),
+        id="restore_system_user_password",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{CLUSTER_RESTORE_FIELD_ID}/restore_system_user_password")
+
+
+def register_after_restore_handlers(
+    namespace: str,
+    name: str,
+    status: kopf.Status,
+    change_hash: str,
+    context: dict,
+    depends_on: list,
+    repository: str,
+):
+    kopf.register(
+        fn=AfterRestoreBackupSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+            run_on_dep_failures=True,
+        )(status=status, repository=repository),
+        id="after_restore_backup",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{CLUSTER_RESTORE_FIELD_ID}/after_restore_backup")
+
+    kopf.register(
+        fn=AfterClusterUpdateSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+            run_on_dep_failures=True,
+        )(),
+        id="after_cluster_update",
+        backoff=get_backoff(),
+        timeout=config.RESTORE_BACKUP_TIMEOUT,
+    )
+    depends_on.append(f"{CLUSTER_RESTORE_FIELD_ID}/after_cluster_update")
+
+    # Ensure success notification is only sent after all other handlers
+    # finished successfully.
+    kopf.register(
+        fn=SendSuccessNotificationSubHandler(
+            namespace,
+            name,
+            change_hash,
+            context,
+            depends_on=depends_on.copy(),
+        )(),
+        id="send_success_notification",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{CLUSTER_RESTORE_FIELD_ID}/send_success_notification")

--- a/crate/operator/restore_backup.py
+++ b/crate/operator/restore_backup.py
@@ -1,0 +1,795 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import asyncio
+import logging
+import re
+from typing import Any, List
+
+import kopf
+from aiohttp.client_exceptions import WSServerHandshakeError
+from aiopg import Cursor
+from kubernetes_asyncio.client import ApiException, CoreV1Api, CustomObjectsApi
+from kubernetes_asyncio.client.api_client import ApiClient
+from kubernetes_asyncio.stream import WsApiClient
+from psycopg2 import DatabaseError, ProgrammingError
+from psycopg2.errors import DuplicateTable
+from psycopg2.extensions import AsIs, QuotedString, quote_ident
+
+from crate.operator.config import config
+from crate.operator.constants import API_GROUP, RESOURCE_CRATEDB, SYSTEM_USERNAME
+from crate.operator.cratedb import (
+    connection_factory,
+    get_cluster_settings,
+    set_cluster_setting,
+)
+from crate.operator.operations import (
+    get_cratedb_resource,
+    scale_backup_metrics_deployment,
+)
+from crate.operator.utils import crate
+from crate.operator.utils.kopf import StateBasedSubHandler, subhandler_partial
+from crate.operator.utils.kubeapi import (
+    get_host,
+    get_system_user_password,
+    resolve_secret_key_ref,
+)
+from crate.operator.utils.notifications import send_operation_progress_notification
+from crate.operator.webhooks import (
+    WebhookEvent,
+    WebhookFeedbackPayload,
+    WebhookOperation,
+    WebhookStatus,
+)
+
+RESTORE_BACKUP_SECRETS: List[str] = [
+    "bucket",
+    "secretAccessKey",
+    "basePath",
+    "accessKeyId",
+]
+RESTORE_MAX_BYTES_PER_SEC: str = "200mb"
+RESTORE_CLUSTER_CONCURRENT_REBALANCE: int = 6
+DEFAULT_MAX_BYTES_PER_SEC: str = "40mb"
+DEFAULT_CLUSTER_CONCURRENT_REBALANCE: int = 2
+CRASH_COMMAND_DELAY: int = 30
+
+
+def is_valid_snapshot(new: kopf.Body, **kwargs) -> bool:
+    """
+    This checks if the new snapshot name is valid or not (empty).
+    This check is necessary to avoid another restore operation is
+    triggered after we reset the snapshot field at the end of a
+    completed restore operation.
+
+    :param new: The new CrateDB resource
+    """
+    try:
+        return len(new["spec"]["cluster"]["restoreSnapshot"]["snapshot"]) > 0
+    except KeyError:
+        return False
+
+
+def get_crash_pod_name(spec: dict, name: str) -> str:
+    """
+    Returns the pod name where crash commands should be run.
+
+    :param spec: The CrateDB custom resource definition.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    """
+    has_master_nodes = "master" in spec["spec"]["nodes"]
+    if has_master_nodes:
+        return f"crate-master-{name}-0"
+    else:
+        node_name = spec["spec"]["nodes"]["data"][0]["name"]
+        return f"crate-data-{node_name}-{name}-0"
+
+
+def get_crash_scheme(spec: dict) -> str:
+    """
+    Return the host scheme for running crash commands.
+
+    :param spec: The CrateDB custom resource definition.
+    """
+    return "https" if "ssl" in spec["spec"]["cluster"] else "http"
+
+
+async def drop_repository(cursor: Cursor, repository: str, logger: logging.Logger):
+    """
+    Drops a backup repository if it exists.
+
+    :param cursor: A database cursor to a current and open database connection.
+    :param repository: The name of the repository to drop.
+    :param logger: the logger on which we're logging
+    """
+    try:
+        await cursor.execute(
+            "SELECT * FROM sys.repositories WHERE name=%s", (repository,)
+        )
+        row = await cursor.fetchone()
+        if row:
+            repository_ident = quote_ident(repository, cursor._impl)
+            await cursor.execute(f"DROP REPOSITORY {repository_ident}")
+    except ProgrammingError as e:
+        logger.warning("Failed to drop repository", exc_info=e)
+
+
+async def run_crash_command(
+    namespace: str,
+    pod_name: str,
+    scheme: str,
+    command: str,
+    logger,
+    delay: int = CRASH_COMMAND_DELAY,
+):
+    """
+    This connects to a CrateDB pod and executes a crash command in the
+    ``crate`` container. It returns the result of the execution.
+
+    :param namespace: The Kubernetes namespace of the CrateDB cluster.
+    :param pod_name: The pod name where the command should be run.
+    :param scheme: The host scheme for running the command.
+    :param command: The SQL query that should be run.
+    :param logger: the logger on which we're logging
+    :param delay: Time in seconds between the retries when executing
+        the query.
+    """
+    async with WsApiClient() as ws_api_client:
+        core_ws = CoreV1Api(ws_api_client)
+        try:
+            exception_logger = logger.exception if config.TESTING else logger.error
+            crash_command = [
+                "crash",
+                "--verify-ssl=false",
+                f"--host={scheme}://localhost:4200",
+                "-c",
+                command,
+            ]
+            result = await core_ws.connect_get_namespaced_pod_exec(
+                namespace=namespace,
+                name=pod_name,
+                command=crash_command,
+                container="crate",
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
+        except ApiException as e:
+            # We don't use `logger.exception()` to not accidentally include sensitive
+            # data in the log messages which might be part of the string
+            # representation of the exception.
+            exception_logger("... failed. Status: %s Reason: %s", e.status, e.reason)
+            raise kopf.TemporaryError(delay=delay)
+        except WSServerHandshakeError as e:
+            # We don't use `logger.exception()` to not accidentally include sensitive
+            # data in the log messages which might be part of the string
+            # representation of the exception.
+            exception_logger("... failed. Status: %s Message: %s", e.status, e.message)
+            raise kopf.TemporaryError(delay=delay)
+        else:
+            return result
+
+
+async def ensure_no_restore_in_progress(
+    namespace: str,
+    name: str,
+    snapshot: str,
+    pod_name: str,
+    scheme: str,
+    logger: logging.Logger,
+):
+    """
+    This checks if there is a restore operation of the given snapshot
+    currently in progress by querying the ``sys.snapshot_restore`` table.
+    If there is a restore in progress, it queries the ``sys.shards`` table
+    to get the progress of the operation. It sends this information to
+    the API and raises a ``kopf.TemporaryError``.
+    Use crash here because during a restore the system user password
+    might be restored to a different value already.
+
+    :param namespace: The Kubernetes namespace of the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param snapshot: The name of the snapshot.
+    :param pod_name: The pod name where the crash command should be run.
+    :param scheme: The host scheme for running the crash command.
+    :param logger: the logger on which we're logging
+    """
+
+    command = (
+        "SELECT * FROM sys.snapshot_restore WHERE "
+        f"name='{snapshot}' AND state NOT IN ('SUCCESS', 'FAILURE')"
+    )
+    result = await run_crash_command(namespace, pod_name, scheme, command, logger)
+    if snapshot in result:
+        progress_command = (
+            "SELECT min(recovery['size']['percent']) FROM sys.shards "
+            "where state='RECOVERING' and recovery['type']='SNAPSHOT';"
+        )
+        result = await run_crash_command(
+            namespace, pod_name, scheme, progress_command, logger
+        )
+        pct = int(re.findall(r"(\d+)", result)[0]) or 0
+        await send_operation_progress_notification(
+            namespace=namespace,
+            name=name,
+            message=f"Please wait while cluster data is being restored... ({pct}%)",
+            logger=logger,
+            status=WebhookStatus.IN_PROGRESS,
+            operation=WebhookOperation.UPDATE,
+        )
+        raise kopf.TemporaryError(
+            "A snapshot restore is currently in progress "
+            f"({pct}% done), waiting for it to finish...",
+            delay=15,
+        )
+
+
+async def get_source_backup_repository_data(
+    core: CoreV1Api,
+    namespace: str,
+    name: str,
+    logger: logging.Logger,
+) -> dict:
+    """
+    Read the secret values to access the backup repository of the source
+    cluster defined by ``secretKeyRef`` in ``restoreSnapshot``.
+
+    :param core: An instance of the Kubernetes Core V1 API.
+    :param namespace: The namespace where to lookup the secret and its value.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param logger: the logger on which we're logging
+    """
+    data = {}
+    cratedb = await get_cratedb_resource(namespace, name)
+    for key in RESTORE_BACKUP_SECRETS:
+        try:
+            secret_key_ref = cratedb["spec"]["cluster"]["restoreSnapshot"][key][
+                "secretKeyRef"
+            ]
+            data[key] = await resolve_secret_key_ref(
+                core,
+                namespace,
+                secret_key_ref,
+            )
+        except ApiException as e:
+            logger.warning("Reading secret failed: %s", str(e))
+            raise kopf.PermanentError(
+                f'Secret {secret_key_ref["name"]} could not be found.'
+            )
+        except KeyError:
+            raise kopf.PermanentError(f"Key {key} not found in secret.")
+
+    return data
+
+
+class BeforeRestoreBackupSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        patch: kopf.Patch,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        await send_operation_progress_notification(
+            namespace=namespace,
+            name=name,
+            message="Preparing to restore data from snapshot.",
+            logger=logger,
+            status=WebhookStatus.IN_PROGRESS,
+            operation=WebhookOperation.UPDATE,
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._prepare_cluster_settings, namespace, name, patch, logger
+            ),
+            id="prepare_cluster_settings",
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._suspend_backup_metrics, namespace, name, logger
+            ),
+            id="suspend_backup_metrics",
+        )
+
+    async def _prepare_cluster_settings(
+        self, namespace: str, name: str, patch: kopf.Patch, logger: logging.Logger
+    ):
+        """
+        This reads (and updates during the restore operation) the cluster settings
+        ``cluster.routing.allocation.cluster_concurrent_rebalance`` and
+        ``indices.recovery.max_bytes_per_sec`` and preserves the old values in the
+        status object of the CrateDB crd to be able to reset them after the restore.
+
+        :param namespace: The Kubernetes namespace of the CrateDB cluster.
+        :param name: The CrateDB custom resource name defining the CrateDB cluster.
+        :param patch: The ``kopf.Patch`` object to store the old settings values.
+        :param logger: the logger on which we're logging
+        """
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+            password, host = await asyncio.gather(
+                get_system_user_password(core, namespace, name),
+                get_host(core, namespace, name),
+            )
+            conn_factory = connection_factory(host, password)
+            try:
+                async with conn_factory() as conn:
+                    async with conn.cursor() as cursor:
+                        cluster_settings = await get_cluster_settings(cursor)
+                        max_bytes_per_sec = (
+                            cluster_settings.get("indices", {})
+                            .get("recovery", {})
+                            .get("max_bytes_per_sec", DEFAULT_MAX_BYTES_PER_SEC)
+                        )
+                        cluster_concurrent_rebalance = (
+                            cluster_settings.get("cluster", {})
+                            .get("routing", {})
+                            .get("allocation", {})
+                            .get(
+                                "cluster_concurrent_rebalance",
+                                DEFAULT_CLUSTER_CONCURRENT_REBALANCE,
+                            )
+                        )
+                        patch.status["maxBytesPerSec"] = max_bytes_per_sec
+                        patch.status[
+                            "clusterConcurrentRebalance"
+                        ] = cluster_concurrent_rebalance
+                        # update the settings during restore operation
+                        await set_cluster_setting(
+                            conn_factory,
+                            logger,
+                            setting="cluster.routing.allocation.cluster_concurrent_rebalance",  # noqa
+                            value=RESTORE_CLUSTER_CONCURRENT_REBALANCE,
+                            mode="PERSISTENT",
+                        )
+                        await set_cluster_setting(
+                            conn_factory,
+                            logger,
+                            setting="indices.recovery.max_bytes_per_sec",
+                            value=RESTORE_MAX_BYTES_PER_SEC,
+                            mode="PERSISTENT",
+                        )
+            except (DatabaseError, asyncio.exceptions.TimeoutError):
+                raise kopf.TemporaryError(
+                    "Could not read settings.",
+                )
+
+    async def _suspend_backup_metrics(
+        self, namespace: str, name: str, logger: logging.Logger
+    ):
+        await scale_backup_metrics_deployment(namespace, name, 0)
+
+
+class RestoreBackupSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        repository: str,
+        snapshot: str,
+        tables: List,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+            data = await get_source_backup_repository_data(
+                core,
+                namespace,
+                name,
+                logger,
+            )
+            password, host = await asyncio.gather(
+                get_system_user_password(core, namespace, name),
+                get_host(core, namespace, name),
+            )
+            conn_factory = connection_factory(host, password)
+
+            await self._create_backup_repository(conn_factory, repository, data, logger)
+
+            await self._ensure_snapshot_exists(
+                conn_factory, repository, snapshot, logger
+            )
+
+            await self._start_restore_snapshot(
+                conn_factory, repository, snapshot, tables, logger
+            )
+
+    @staticmethod
+    async def _create_backup_repository(
+        conn_factory,
+        repository: str,
+        data: dict,
+        logger: logging.Logger,
+    ):
+        """
+        Create a backup repository with the given credentials if it does not exist yet.
+
+        :param conn_factory: A function that establishes a database connection to
+            the CrateDB cluster used for SQL queries.
+        :param repository: The name of the repository to be created.
+        :param data: a dict containing the bucket name, base path and secrets to access
+            the source backup repository.
+        :param logger: the logger on which we're logging
+        """
+        try:
+            async with conn_factory() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(
+                        "SELECT * FROM sys.repositories WHERE name=%s", (repository,)
+                    )
+                    row = await cursor.fetchone()
+                    if not row:
+                        repository_ident = quote_ident(repository, cursor._impl)
+                        await cursor.execute(
+                            f"CREATE REPOSITORY {repository_ident} type s3 with "
+                            "(access_key = %s, secret_key = %s, bucket = %s, "
+                            "base_path = %s, readonly=true)",
+                            (
+                                data["accessKeyId"],
+                                data["secretAccessKey"],
+                                data["bucket"],
+                                data["basePath"],
+                            ),
+                        )
+        except DatabaseError as e:
+            logger.warning("DatabaseError in _create_backup_repository", exc_info=e)
+            raise kopf.PermanentError("Backup repository could not be created.")
+
+    @staticmethod
+    async def _ensure_snapshot_exists(
+        conn_factory,
+        repository: str,
+        snapshot: str,
+        logger: logging.Logger,
+    ):
+        """
+        Verify that the snapshot to restore really exists in the given repository.
+
+        :param conn_factory: A function that establishes a database connection to
+            the CrateDB cluster used for SQL queries.
+        :param repository: The name of the repository.
+        :param snapshot: The name of the snapshot to restore.
+        :param logger: the logger on which we're logging
+        """
+        try:
+            async with conn_factory() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(
+                        "SELECT * FROM sys.snapshots WHERE repository=%s "
+                        "AND name=%s LIMIT 1;",
+                        (
+                            repository,
+                            snapshot,
+                        ),
+                    )
+                    row = await cursor.fetchone()
+                    if not row:
+                        raise kopf.PermanentError(
+                            f"Snapshot {snapshot} does not exist "
+                            f"in repository {repository}."
+                        )
+        except DatabaseError as e:
+            logger.warning("DatabaseError in _ensure_snapshot_exists", exc_info=e)
+            raise kopf.PermanentError("Snapshots could not be fetched.")
+
+    @staticmethod
+    async def _start_restore_snapshot(
+        conn_factory,
+        repository: str,
+        snapshot: str,
+        tables: List,
+        logger: logging.Logger,
+    ):
+        """
+        Run the ``RESTORE SNAPSHOT`` command to start the restore operation in the
+        target CrateDB cluster.
+
+        :param conn_factory: A function that establishes a database connection to
+            the CrateDB cluster used for SQL queries.
+        :param repository: The name of the repository.
+        :param snapshot: The name of the snapshot to restore.
+        :param tables: The list of tables that should be restored.
+        :param logger: the logger on which we're logging
+        """
+        if not tables or (len(tables) == 1 and tables[0].lower() == "all"):
+            tables_str = "all"
+        else:
+            tables_str = f'TABLE {",".join(tables)}'
+        try:
+            async with conn_factory() as conn:
+                async with conn.cursor() as cursor:
+                    repository_ident = quote_ident(repository, cursor._impl)
+                    snapshot_ident = quote_ident(snapshot, cursor._impl)
+
+                    await cursor.execute(
+                        f"RESTORE SNAPSHOT {repository_ident}.{snapshot_ident} "
+                        f"{AsIs(tables_str)} with (wait_for_completion=false)"
+                    )
+        except DuplicateTable as e:
+            logger.warning("Relation already exists.", exc_info=e)
+            raise kopf.PermanentError("Relation with the same name already exists.")
+        except DatabaseError as e:
+            logger.warning("DatabaseError in _start_restore_snapshot", exc_info=e)
+            raise kopf.PermanentError("Snapshot could not be restored")
+
+
+class RestoreSystemUserPasswordSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        """
+        Restore the system user password from the secret in the namespace.
+        Use crash here because during a restore the system user password was
+        probably set to a different value.
+
+        :param namespace: The Kubernetes namespace of the CrateDB cluster.
+        :param name: The CrateDB custom resource name defining the CrateDB cluster.
+        :param logger: the logger on which we're logging
+        """
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+            password = await get_system_user_password(core, namespace, name)
+            password_quoted = QuotedString(password).getquoted().decode()
+            command = (
+                f'ALTER USER "{SYSTEM_USERNAME}" SET (password={password_quoted});'
+            )
+            cratedb = await get_cratedb_resource(namespace, name)
+            pod_name = get_crash_pod_name(cratedb, name)
+            scheme = get_crash_scheme(cratedb)
+
+            result = await run_crash_command(
+                namespace, pod_name, scheme, command, logger
+            )
+            if "ALTER OK" in result:
+                logger.info("... success")
+            else:
+                logger.info("... error. %s", result)
+                raise kopf.TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)
+
+
+class AfterRestoreBackupSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        status: kopf.Status,
+        repository: str,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        kopf.register(
+            fn=subhandler_partial(
+                self._reset_cluster_settings,
+                namespace,
+                name,
+                logger,
+                status,
+            ),
+            id="reset_cluster_settings",
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._drop_backup_repository, namespace, name, logger, repository
+            ),
+            id="drop_backup_repository",
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._delete_backup_credentials_secret, namespace, name, logger
+            ),
+            id="delete_secret",
+        )
+        kopf.register(
+            fn=subhandler_partial(
+                self._restart_backup_metrics, namespace, name, logger
+            ),
+            id="restart_backup_metrics",
+        )
+
+    async def _reset_cluster_settings(
+        self,
+        namespace: str,
+        name: str,
+        logger: logging.Logger,
+        status: kopf.Status,
+    ):
+        """
+        This checks if all shards have been restored and resets the cluster
+        settings ``cluster.routing.allocation.cluster_concurrent_rebalance``
+        and ``indices.recovery.max_bytes_per_sec`` to the values before the
+        restore operation.
+
+        :param namespace: The Kubernetes namespace of the CrateDB cluster.
+        :param name: The CrateDB custom resource name defining the CrateDB cluster.
+        :param logger: the logger on which we're logging
+        :param status: kopf.Status to retrieve the preserved settings values.
+        :param snapshot: The name of the snapshot to check if it has been
+            restored completely.
+        """
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+            password, host = await asyncio.gather(
+                get_system_user_password(core, namespace, name),
+                get_host(core, namespace, name),
+            )
+            conn_factory = connection_factory(host, password)
+
+            # set back settings to the preserved values
+            cluster_concurrent_rebalance = (
+                status.get("clusterConcurrentRebalance")
+                or DEFAULT_CLUSTER_CONCURRENT_REBALANCE
+            )
+            max_bytes_per_sec = (
+                status.get("maxBytesPerSec") or DEFAULT_MAX_BYTES_PER_SEC
+            )
+            logger.info(
+                "restored settings... max_bytes_per_sec: %s, "
+                "cluster_concurrent_rebalance: %s",
+                max_bytes_per_sec,
+                cluster_concurrent_rebalance,
+            )
+            await set_cluster_setting(
+                conn_factory,
+                logger,
+                setting="cluster.routing.allocation.cluster_concurrent_rebalance",  # noqa
+                value=cluster_concurrent_rebalance,
+                mode="PERSISTENT",
+            )
+            await set_cluster_setting(
+                conn_factory,
+                logger,
+                setting="indices.recovery.max_bytes_per_sec",
+                value=max_bytes_per_sec,
+                mode="PERSISTENT",
+            )
+
+    async def _drop_backup_repository(
+        self, namespace: str, name: str, logger: logging.Logger, repository: str
+    ):
+        """
+        Drop the temporary backup repository from the target CrateDB cluster.
+
+        :param namespace: The Kubernetes namespace of the CrateDB cluster.
+        :param name: The CrateDB custom resource name defining the CrateDB cluster.
+        :param logger: the logger on which we're logging
+        :param repository: The name of the repository to drop.
+        """
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+            password, host = await asyncio.gather(
+                get_system_user_password(core, namespace, name),
+                get_host(core, namespace, name),
+            )
+            conn_factory = connection_factory(host, password)
+            try:
+                async with conn_factory() as conn:
+                    async with conn.cursor() as cursor:
+                        await drop_repository(cursor, repository, logger)
+            except (DatabaseError, asyncio.exceptions.TimeoutError) as e:
+                logger.warning("Drop repository operation failed: %s", str(e))
+                raise kopf.TemporaryError("Drop repository operation failed.")
+
+    async def _delete_backup_credentials_secret(
+        self, namespace: str, name: str, logger: logging.Logger
+    ):
+        """
+        Delete the temporary secret containing the source backup credentials. For
+        safety reasons we do not get the secret's name from the ``restoreSnapshot``
+        section in the CrateDB resource but rather only delete the secret if it
+        was named as defined in ``config.RESTORE_BACKUP_SECRET_NAME``
+
+        :param namespace: The Kubernetes namespace of the CrateDB cluster.
+        :param name: The CrateDB custom resource name defining the CrateDB cluster.
+        :param logger: the logger on which we're logging
+        """
+        async with ApiClient() as api_client:
+            core = CoreV1Api(api_client)
+            try:
+                await core.delete_namespaced_secret(
+                    namespace=namespace,
+                    name=config.RESTORE_BACKUP_SECRET_NAME.format(name=name),
+                )
+            except ApiException as e:
+                logger.warning("Deleting secret failed: %s", str(e))
+
+    async def _restart_backup_metrics(
+        self, namespace: str, name: str, logger: logging.Logger
+    ):
+        await scale_backup_metrics_deployment(namespace, name, 1)
+
+
+class SendSuccessNotificationSubHandler(StateBasedSubHandler):
+    """
+    A handler which depends on all other subhandlers having finished successfully
+    and schedules a success notification of the restore process.
+    """
+
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        """
+        Schedule success notification and send it after the cluster
+        has been restored successfully.
+
+        :param namespace: The Kubernetes namespace of the CrateDB cluster.
+        :param name: The CrateDB custom resource name defining the CrateDB cluster.
+        :param logger: the logger on which we're logging
+        """
+        self.schedule_notification(
+            WebhookEvent.FEEDBACK,
+            WebhookFeedbackPayload(
+                message="The snapshot has been restored successfully.",
+                operation=WebhookOperation.UPDATE,
+            ),
+            WebhookStatus.SUCCESS,
+        )
+
+
+class ResetSnapshotSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        """
+        Reset the snapshot name in the CrateDB spec to ensure the same snapshot can
+        be restored again if it failed for any reason. This has to be done last
+        because kopf recognizes it as a new change in the restoreSnapshot field.
+
+        :param namespace: The Kubernetes namespace of the CrateDB cluster.
+        :param name: The CrateDB custom resource name defining the CrateDB cluster.
+        :param logger: the logger on which we're logging
+        """
+        async with ApiClient() as api_client:
+            coapi = CustomObjectsApi(api_client)
+            await coapi.patch_namespaced_custom_object(
+                group=API_GROUP,
+                version="v1",
+                plural=RESOURCE_CRATEDB,
+                namespace=namespace,
+                name=name,
+                body=[
+                    {
+                        "op": "replace",
+                        "path": "/spec/cluster/restoreSnapshot/snapshot",
+                        "value": "",
+                    }
+                ],
+            )

--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -203,9 +203,14 @@ class StateBasedSubHandler(abc.ABC):
 
         Slightly naughty, but there is no better way at the time of writing.
         """
-        # Handler names have dots instead of slashes in annotations
-        normalized_name = handler_name.replace("/", ".")
-        key = f"{KOPF_STATE_STORE_PREFIX}/{normalized_name}"
+        # Use the same procedure as kopf to create the handler name for the
+        # annotations lookup. Important if the handler name exceeds the maximum
+        # allowed length of 63 chars which is likely for @kopf.on.field() handlers
+        # that have the field path in the name.
+        progressor = kopf.AnnotationsProgressStorage(
+            v1=False, prefix=KOPF_STATE_STORE_PREFIX
+        )
+        key = progressor.make_v2_key(handler_name)
         status_str = annotations.get(key)
         if not status_str:
             return False

--- a/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
+++ b/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
@@ -195,6 +195,103 @@ spec:
                     description: Name of the cluster
                     pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$
                     type: string
+                  restoreSnapshot:
+                    description: Restore data from a snapshot.
+                    properties:
+                      accessKeyId:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                description: The key within the Kubernetes Secret
+                                  that holds the Access Key ID.
+                                type: string
+                              name:
+                                description: Name of a Kubernetes Secret that contains
+                                  the Access Key ID to be used for accessing the
+                                  backup of the source cluster.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                      basePath:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                description: The key within the Kubernetes Secret
+                                  that holds the base path of the repository.
+                                type: string
+                              name:
+                                description: Name of a Kubernetes Secret that contains
+                                  the base path to be used.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                      bucket:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                description: The key within the Kubernetes Secret
+                                  that holds the snapshot's bucket name.
+                                type: string
+                              name:
+                                description: Name of a Kubernetes Secret that contains
+                                  the snapshot's bucket name to be used for the restore.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                      secretAccessKey:
+                        properties:
+                          secretKeyRef:
+                            properties:
+                              key:
+                                description: The key within the Kubernetes Secret
+                                  that holds the Secret Access Key.
+                                type: string
+                              name:
+                                description: Name of a Kubernetes Secret that contains
+                                  the Secret Access Key to be used for accessing the
+                                  backup of the source cluster..
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - secretKeyRef
+                        type: object
+                      snapshot:
+                        description: The name of the snapshot to use.
+                        type: string
+                      tables:
+                        description: The tables to restore from the backup.
+                          Format '<schema_name>.<table_name>'. Defaults to 'all'
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - snapshot
+                    - bucket
+                    - secretAccessKey
+                    - basePath
+                    - accessKeyId
+                    type: object
                   settings:
                     description: Additional settings to apply to all nodes in the
                       cluster.

--- a/tests/test_restore_backup.py
+++ b/tests/test_restore_backup.py
@@ -1,0 +1,467 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+from unittest import mock
+
+import kopf
+import pytest
+from kubernetes_asyncio.client import (
+    CoreV1Api,
+    CustomObjectsApi,
+    V1ObjectMeta,
+    V1Secret,
+)
+
+from crate.operator.config import config
+from crate.operator.constants import (
+    API_GROUP,
+    KOPF_STATE_STORE_PREFIX,
+    RESOURCE_CRATEDB,
+)
+from crate.operator.cratedb import connection_factory
+from crate.operator.restore_backup import (
+    RESTORE_CLUSTER_CONCURRENT_REBALANCE,
+    RESTORE_MAX_BYTES_PER_SEC,
+)
+from crate.operator.utils.formatting import b64encode
+from crate.operator.webhooks import WebhookEvent, WebhookOperation, WebhookStatus
+from tests.utils import (
+    DEFAULT_TIMEOUT,
+    assert_wait_for,
+    cluster_setting_equals,
+    create_test_sys_jobs_table,
+    does_backup_metrics_pod_exist,
+    is_cluster_healthy,
+    is_kopf_handler_finished,
+    mocked_coro_func_called_with,
+    start_backup_metrics,
+    start_cluster,
+    was_notification_sent,
+)
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+@mock.patch("crate.operator.webhooks.webhook_client._send")
+@mock.patch(
+    "crate.operator.restore_backup.RestoreBackupSubHandler._create_backup_repository"
+)
+@mock.patch(
+    "crate.operator.restore_backup.RestoreBackupSubHandler._ensure_snapshot_exists"
+)
+@mock.patch(
+    "crate.operator.restore_backup.RestoreBackupSubHandler._start_restore_snapshot"
+)
+async def test_restore_backup(
+    mock_start_restore_snapshot,
+    mock_ensure_snapshot_exists,
+    mock_create_repository,
+    mock_send_notification,
+    faker,
+    namespace,
+    kopf_runner,
+    api_client,
+):
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+    number_of_nodes = 1
+
+    bucket = faker.domain_word()
+    base_path = faker.uri_path()
+    secret_access_key = faker.domain_word()
+    access_key_id = faker.domain_word()
+    snapshot = faker.domain_word()
+
+    await core.create_namespaced_secret(
+        namespace=namespace.metadata.name,
+        body=V1Secret(
+            data={
+                "bucket": b64encode(bucket),
+                "base-path": b64encode(base_path),
+                "secret-access-key": b64encode(secret_access_key),
+                "access-key-id": b64encode(access_key_id),
+            },
+            metadata=V1ObjectMeta(
+                name=config.RESTORE_BACKUP_SECRET_NAME.format(name=name)
+            ),
+            type="Opaque",
+        ),
+    )
+
+    host, password = await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        number_of_nodes,
+    )
+
+    conn_factory = connection_factory(host, password)
+    await create_test_sys_jobs_table(conn_factory)
+
+    await start_backup_metrics(name, namespace, faker)
+
+    await assert_wait_for(
+        True,
+        is_cluster_healthy,
+        connection_factory(host, password),
+        number_of_nodes,
+        err_msg="Cluster wasn't healthy after 5 minutes.",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+    await patch_cluster_spec(coapi, namespace.metadata.name, name, snapshot, faker)
+
+    await assert_wait_for(
+        True,
+        was_notification_sent,
+        mock_send_notification,
+        mock.call(
+            WebhookEvent.FEEDBACK,
+            WebhookStatus.IN_PROGRESS,
+            namespace.metadata.name,
+            name,
+            feedback_data={
+                "message": "Preparing to restore data from snapshot.",
+                "operation": WebhookOperation.UPDATE.value,
+            },
+            unsafe=mock.ANY,
+            logger=mock.ANY,
+        ),
+        err_msg="In progress notification has not been sent.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        True,
+        cluster_setting_equals,
+        connection_factory(host, password),
+        "indices.recovery.max_bytes_per_sec",
+        RESTORE_MAX_BYTES_PER_SEC,
+        err_msg="Cluster setting `max_bytes_per_sec` has not been updated.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        True,
+        cluster_setting_equals,
+        connection_factory(host, password),
+        "cluster.routing.allocation.cluster_concurrent_rebalance",
+        RESTORE_CLUSTER_CONCURRENT_REBALANCE,
+        err_msg="Cluster setting `cluster_concurrent_rebalance` has not been updated.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        False,
+        does_backup_metrics_pod_exist,
+        core,
+        name,
+        namespace.metadata.name,
+        err_msg="Backup metrics has not been scaled down.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        True,
+        mocked_coro_func_called_with,
+        mock_create_repository,
+        mock.call(
+            mock.ANY,
+            mock.ANY,
+            {
+                "basePath": base_path,
+                "bucket": bucket,
+                "accessKeyId": access_key_id,
+                "secretAccessKey": secret_access_key,
+            },
+            mock.ANY,
+        ),
+        err_msg="Expected create repository call not found.",
+        timeout=DEFAULT_TIMEOUT * 2,
+    )
+    await assert_wait_for(
+        True,
+        mocked_coro_func_called_with,
+        mock_ensure_snapshot_exists,
+        mock.call(
+            mock.ANY,
+            mock.ANY,
+            snapshot,
+            mock.ANY,
+        ),
+        err_msg="Did not call ensure snapshot exists.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        True,
+        mocked_coro_func_called_with,
+        mock_start_restore_snapshot,
+        mock.call(
+            mock.ANY,
+            mock.ANY,
+            snapshot,
+            ["all"],
+            mock.ANY,
+        ),
+        err_msg="Did not call start restore snapshot.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        True,
+        does_backup_metrics_pod_exist,
+        core,
+        name,
+        namespace.metadata.name,
+        err_msg="Backup metrics has not been scaled up again.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        False,
+        does_credentials_secret_exist,
+        core,
+        name,
+        namespace.metadata.name,
+        err_msg="Secret has not been deleted.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        True,
+        was_notification_sent,
+        mock_send_notification,
+        mock.call(
+            WebhookEvent.FEEDBACK,
+            WebhookStatus.SUCCESS,
+            namespace.metadata.name,
+            name,
+            feedback_data={
+                "message": "The snapshot has been restored successfully.",
+                "operation": WebhookOperation.UPDATE.value,
+            },
+            unsafe=mock.ANY,
+            logger=mock.ANY,
+        ),
+        err_msg="Success notification has not been sent.",
+        timeout=DEFAULT_TIMEOUT * 3,
+    )
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_restore/spec.cluster.restoreSnapshot",
+        err_msg="Restore handler has not finished",
+        timeout=DEFAULT_TIMEOUT * 3,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+@mock.patch("crate.operator.webhooks.webhook_client._send")
+@mock.patch(
+    "crate.operator.restore_backup.RestoreBackupSubHandler._create_backup_repository",
+    side_effect=kopf.PermanentError(
+        "Backup repository is not accessible with the given credentials."
+    ),
+)
+@mock.patch(
+    "crate.operator.restore_backup.RestoreBackupSubHandler._ensure_snapshot_exists"
+)
+@mock.patch(
+    "crate.operator.restore_backup.RestoreBackupSubHandler._start_restore_snapshot"
+)
+async def test_restore_backup_create_repo_fails(
+    mock_start_restore_snapshot,
+    mock_ensure_snapshot_exists,
+    mock_create_repository,
+    mock_send_notification,
+    faker,
+    namespace,
+    kopf_runner,
+    api_client,
+):
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+    snapshot = faker.domain_word()
+    number_of_nodes = 1
+
+    await core.create_namespaced_secret(
+        namespace=namespace.metadata.name,
+        body=V1Secret(
+            data={
+                "bucket": b64encode(faker.domain_word()),
+                "base-path": b64encode(faker.uri_path()),
+                "secret-access-key": b64encode(faker.domain_word()),
+                "access-key-id": b64encode(faker.domain_word()),
+            },
+            metadata=V1ObjectMeta(
+                name=config.RESTORE_BACKUP_SECRET_NAME.format(name=name)
+            ),
+            type="Opaque",
+        ),
+    )
+
+    host, password = await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        number_of_nodes,
+    )
+
+    conn_factory = connection_factory(host, password)
+    await create_test_sys_jobs_table(conn_factory)
+
+    await start_backup_metrics(name, namespace, faker)
+
+    await assert_wait_for(
+        True,
+        is_cluster_healthy,
+        connection_factory(host, password),
+        number_of_nodes,
+        err_msg="Cluster wasn't healthy after 5 minutes.",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+    await patch_cluster_spec(coapi, namespace.metadata.name, name, snapshot, faker)
+
+    await assert_wait_for(
+        True,
+        was_notification_sent,
+        mock_send_notification,
+        mock.call(
+            WebhookEvent.FEEDBACK,
+            WebhookStatus.IN_PROGRESS,
+            namespace.metadata.name,
+            name,
+            feedback_data={
+                "message": "Preparing to restore data from snapshot.",
+                "operation": WebhookOperation.UPDATE.value,
+            },
+            unsafe=mock.ANY,
+            logger=mock.ANY,
+        ),
+        err_msg="In progress notification has not been sent.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        True,
+        was_notification_sent,
+        mock_send_notification,
+        mock.call(
+            WebhookEvent.FEEDBACK,
+            WebhookStatus.FAILURE,
+            namespace.metadata.name,
+            name,
+            feedback_data={
+                "message": (
+                    "Backup repository is not accessible with the given credentials."
+                ),
+                "operation": WebhookOperation.UPDATE.value,
+            },
+            unsafe=mock.ANY,
+            logger=mock.ANY,
+        ),
+        err_msg="Exception notification has not been sent.",
+        timeout=DEFAULT_TIMEOUT * 3,
+    )
+    await assert_wait_for(
+        True,
+        does_backup_metrics_pod_exist,
+        core,
+        name,
+        namespace.metadata.name,
+        err_msg="Backup metrics has not been scaled up again.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    await assert_wait_for(
+        False,
+        does_credentials_secret_exist,
+        core,
+        name,
+        namespace.metadata.name,
+        err_msg="Secret has not been deleted.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_restore/spec.cluster.restoreSnapshot",
+        err_msg="Restore handler has not finished",
+        timeout=DEFAULT_TIMEOUT * 3,
+    )
+
+
+async def patch_cluster_spec(
+    coapi: CustomObjectsApi, namespace: str, name: str, snapshot: str, faker
+):
+    restore_snapshot_spec = {
+        "accessKeyId": {
+            "secretKeyRef": {
+                "key": "access-key-id",
+                "name": config.RESTORE_BACKUP_SECRET_NAME.format(name=name),
+            },
+        },
+        "basePath": {
+            "secretKeyRef": {
+                "key": "base-path",
+                "name": config.RESTORE_BACKUP_SECRET_NAME.format(name=name),
+            },
+        },
+        "bucket": {
+            "secretKeyRef": {
+                "key": "bucket",
+                "name": config.RESTORE_BACKUP_SECRET_NAME.format(name=name),
+            },
+        },
+        "secretAccessKey": {
+            "secretKeyRef": {
+                "key": "secret-access-key",
+                "name": config.RESTORE_BACKUP_SECRET_NAME.format(name=name),
+            },
+        },
+        "snapshot": snapshot,
+        "tables": ["all"],
+    }
+    await coapi.patch_namespaced_custom_object(
+        group=API_GROUP,
+        version="v1",
+        plural=RESOURCE_CRATEDB,
+        namespace=namespace,
+        name=name,
+        body=[
+            {
+                "op": "add",
+                "path": "/spec/cluster/restoreSnapshot",
+                "value": restore_snapshot_spec,
+            },
+        ],
+    )
+
+
+async def does_credentials_secret_exist(
+    core: CoreV1Api, namespace: str, name: str
+) -> bool:
+    secrets = await core.list_namespaced_secret(namespace)
+    return config.RESTORE_BACKUP_SECRET_NAME.format(name=name) in (
+        s.metadata.name for s in secrets.items
+    )

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -41,11 +41,10 @@ from crate.operator.constants import (
 )
 from crate.operator.cratedb import connection_factory
 from crate.operator.create import get_statefulset_crate_command
-from crate.operator.operations import get_pods_in_deployment, get_pods_in_statefulset
+from crate.operator.operations import get_pods_in_statefulset
 from crate.operator.scale import parse_replicas, patch_command
 from crate.operator.webhooks import WebhookEvent, WebhookStatus
-
-from .utils import (
+from tests.utils import (
     DEFAULT_TIMEOUT,
     assert_wait_for,
     clear_test_snapshot_jobs,
@@ -53,6 +52,7 @@ from .utils import (
     create_fake_snapshot_job,
     create_test_sys_jobs_table,
     delete_fake_snapshot_job,
+    does_backup_metrics_pod_exist,
     insert_test_snapshot_job,
     is_cluster_healthy,
     is_kopf_handler_finished,
@@ -484,14 +484,6 @@ async def _scale_cluster(
     )
 
     await asyncio.sleep(1.0)
-
-
-async def does_backup_metrics_pod_exist(
-    core: CoreV1Api, name: str, namespace: V1Namespace
-) -> bool:
-    backup_metrics_pods = await get_pods_in_deployment(core, namespace, name)
-    backup_metrics_name = BACKUP_METRICS_DEPLOYMENT_NAME.format(name=name)
-    return any(p["name"].startswith(backup_metrics_name) for p in backup_metrics_pods)
 
 
 async def does_deployment_exist(apps: AppsV1Api, namespace: str, name: str) -> bool:


### PR DESCRIPTION
## Summary of changes
This change allows restoring a backup from a different source crateDB cluster into another crateDB cluster. To trigger this operation, an object called `spec.cluster.restoreSnapshot` has to be created in the cratedb crd e.g. like this 

```yml
    restoreSnapshot:
      accessKeyId:
        secretKeyRef:
          key: access-key-id
          name: restore-from-backup-{target_cluster_id}
      basePath:
        secretKeyRef:
          key: base-path
          name: restore-from-backup-{target_cluster_id}
      bucket:
        secretKeyRef:
          key: bucket
          name: restore-from-backup-{target_cluster_id}
      secretAccessKey:
        secretKeyRef:
          key: secret-access-key
          name: restore-from-backup-{target_cluster_id}
      snapshot: "{snapshot_name}"
      tables:
      - all
```

Also the secret called `restore-from-backup-{target_cluster_id}` in the target cluster's namespace containing `bucket`, `base-path`, `secret-access-key`, `access-key-id` has to be created as specified above. Note that the secrets could be read from any other secret, but only secrets named `restore-from-backup-{cluster_id}` are automtaically deleted at the end of the restore operation for safety reasons.

The operator handles changes to the field `spec.cluster.restoreSnapshot`. In each iteration it checks at the beginning if there is a restore operation already in progress by querying the `sys.snapshot_restore` table. If there is a restore in progress, it only reports a status update to the API. Nothing else is done while a restore is in progress.

The operation consists basically of 3 parts:
- `before_restore_handlers`
  - `BeforeClusterUpdateSubHandler` - this one is already known from other cluster operations. It ensures there is no snapshot in progress, disables cronjobs, etc.
  - `BeforeRestoreBackupSubHandler` - performs restore specific preparation tasks. It suspends the backup-metrics deployment and updates cluster settings `cluster.routing.allocation.cluster_concurrent_rebalance` and `indices.recovery.max_bytes_per_sec` (it preserves the old values in the `status` object of the crd to be able to reset them after the restore)
- `restore_handlers`
  - `RestoreBackupSubHandler` - the main operation happens here.
    - it reads the necessary credentials from the given secret to be able to access the source backup repository
    - it creates a temporary backup repository with the given secrets
    - it ensures that the given snapshot name exists in the repository
    - it performs a `RESTORE SNAPSHOT` with the given table names or `all`
    (Note: most errors in this part raise a `PermanentError` because I think it is unlikely that retries would help if a snapshot is not available in a repository, a secret contains invalid credentials etc.)
  - `RestoreSystemUserPasswordSubHandler` - it reads the system user's password from the secret and restores it using `crash` (during the restore operation the `sys.users` table was probably overwritten)
- `after_restore_handlers`
  - `AfterRestoreBackupSubHandler` - cleanup after restore
    - it resets the cluster settings `cluster.routing.allocation.cluster_concurrent_rebalance` and `indices.recovery.max_bytes_per_sec` to the preserved values
    - it drops the temporary backup repository
    - it deletes the secret containing the credentials (only if it is named `restore-from-backup-{cluster_id}`)
    - it scales the backup-metrics deployment back up
  - `AfterClusterUpdateSubHandler` - already known from other cluster operations. It re-enables the cronjob etc.

In the end, a success notification is sent to the API and the value of `spec.cluster.restoreSnapshot.snapshot` is deleted to be able to restore the same snapshot again in case anything goes wrong.

https://github.com/crate/cloud/issues/546

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
