### PR TITLE
Set TopologySpreadConstraint to DoNotSchedule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Unreleased
 
 * Fixed the way user passwords are updated to not require the old password anymore.
 
+* Change the value of ``when_unsatisfiable`` in the ``TopologySpreadConstraint`` to
+  ``DoNotSchedule``, this seems to work now. Tested on kubernetes `1.22.12`.
+
 2.17.0 (2022-10-31)
 -------------------
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -261,7 +261,7 @@ def get_topology_spread(
             V1TopologySpreadConstraint(
                 max_skew=1,
                 topology_key="topology.kubernetes.io/zone",
-                when_unsatisfiable="ScheduleAnyway",
+                when_unsatisfiable="DoNotSchedule",
                 label_selector=V1LabelSelector(
                     match_expressions=[
                         V1LabelSelectorRequirement(


### PR DESCRIPTION
## Summary of changes
Set TopologySpreadConstraint to DoNotSchedule. We changed this sometime ago in https://github.com/crate/crate-operator/pull/363, it did not allow to schedule Statefulsets >3. The behavior seems different now (`1.22.15`) and seems to avoid situations where Pods are scheduled on to the same availability group.

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
