### PR TITLE
Fixed update admin password sometimes sending false succeeded webhook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Fixed a bug that lead to sending false succeed webhooks when updating an admin password.
+
 2.20.0 (2022-12-15)
 -------------------
 

--- a/crate/operator/update_user_password.py
+++ b/crate/operator/update_user_password.py
@@ -110,8 +110,8 @@ async def update_user_password(
             # representation of the exception.
             exception_logger("... failed. Status: %s Message: %s", e.status, e.message)
             raise TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)
-        except TemporaryError as e:
-            raise e
+        except TemporaryError:
+            raise
         except Exception as e:
             exception_logger(
                 "... failed. Unexpected exception was raised. Class: %s. Message: %s",

--- a/crate/operator/update_user_password.py
+++ b/crate/operator/update_user_password.py
@@ -84,6 +84,12 @@ async def update_user_password(
                 stdout=True,
                 tty=False,
             )
+            if "ALTER OK" in result:
+                logger.info("... success")
+            else:
+                logger.info("... error. %s", result)
+                raise TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)
+
             await send_operation_progress_notification(
                 namespace=namespace,
                 name=cluster_id,
@@ -104,9 +110,8 @@ async def update_user_password(
             # representation of the exception.
             exception_logger("... failed. Status: %s Message: %s", e.status, e.message)
             raise TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)
-        else:
-            if "ALTER OK" in result:
-                logger.info("... success")
-            else:
-                logger.info("... error. %s", result)
-                raise TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)
+        except Exception as e:
+            exception_logger(
+                "... failed. Unexpected exception was raised. Class: %s",
+                type(e).__name__,
+            )

--- a/crate/operator/update_user_password.py
+++ b/crate/operator/update_user_password.py
@@ -110,8 +110,12 @@ async def update_user_password(
             # representation of the exception.
             exception_logger("... failed. Status: %s Message: %s", e.status, e.message)
             raise TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)
+        except TemporaryError as e:
+            raise e
         except Exception as e:
             exception_logger(
-                "... failed. Unexpected exception was raised. Class: %s",
+                "... failed. Unexpected exception was raised. Class: %s. Message: %s",
                 type(e).__name__,
+                str(e),
             )
+            raise TemporaryError(delay=config.BOOTSTRAP_RETRY_DELAY)

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -32,10 +32,10 @@ from kubernetes_asyncio.client import (
     V1Secret,
 )
 from psycopg2 import DatabaseError, OperationalError
-from update_user_password import update_user_password
 
 from crate.operator.constants import LABEL_USER_PASSWORD
 from crate.operator.cratedb import get_connection
+from crate.operator.update_user_password import update_user_password
 from crate.operator.utils.formatting import b64encode
 from crate.operator.webhooks import (
     WebhookEvent,

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -20,6 +20,7 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import asyncio
+import logging
 from typing import Any, List, Mapping
 from unittest import mock
 
@@ -31,6 +32,7 @@ from kubernetes_asyncio.client import (
     V1Secret,
 )
 from psycopg2 import DatabaseError, OperationalError
+from update_user_password import update_user_password
 
 from crate.operator.constants import LABEL_USER_PASSWORD
 from crate.operator.cratedb import get_connection
@@ -174,3 +176,24 @@ async def test_update_cluster_password(
         err_msg="Did not notify user password status success.",
         timeout=DEFAULT_TIMEOUT,
     )
+
+
+@mock.patch("crate.operator.webhooks.webhook_client.send_notification")
+@mock.patch("kubernetes_asyncio.client.CoreV1Api.connect_get_namespaced_pod_exec")
+async def test_update_cluster_password_errors(
+    mock_pod_exec, mock_send_notification: mock.AsyncMock
+):
+    mock_pod_exec.side_effect = Exception("test-exception")
+    with pytest.raises(Exception) as e:
+        await update_user_password(
+            namespace="a-namespace",
+            cluster_id="a-cluster-id",
+            pod_name="a-pod-name",
+            username="a-non-existent-username",
+            new_password=b64encode("a-new-base64-encoded-password"),
+            has_ssl=False,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert e.typename == "TemporaryError"
+    mock_send_notification.assert_not_called()


### PR DESCRIPTION
## Summary of changes
Fixed update admin password sometimes sending false succeeded webhook

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
