### PR TITLE
Downgrade busybox to previous version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Unreleased
 
 * sql_exporter 0.9.2 has been released.
 
+* Downgrade to busybox 1.35.0 for a few containers. Apparently 1.36 was erroneously marked
+  as 'latest' whereas it is unstable -> https://github.com/docker-library/busybox/issues/162
+
 2.20.0 (2022-12-15)
 -------------------
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -578,7 +578,7 @@ def get_statefulset_init_containers(crate_image: str) -> List[V1Container]:
             # security context. We don't want to run CrateDB with that context,
             # thus doing it before.
             command=["sysctl", "-w", "vm.max_map_count=262144"],
-            image="busybox",
+            image="busybox:1.35.0",
             image_pull_policy="IfNotPresent",
             name="init-sysctl",
             security_context=V1SecurityContext(privileged=True),
@@ -590,7 +590,7 @@ def get_statefulset_init_containers(crate_image: str) -> List[V1Container]:
                 f"/jmxdir/crate-jmx-exporter-{config.JMX_EXPORTER_VERSION}.jar",
                 f"https://repo1.maven.org/maven2/io/crate/crate-jmx-exporter/{config.JMX_EXPORTER_VERSION}/crate-jmx-exporter-{config.JMX_EXPORTER_VERSION}.jar",  # noqa
             ],
-            image="busybox",
+            image="busybox:1.35.0",
             image_pull_policy="IfNotPresent",
             name="fetch-jmx-exporter",
             volume_mounts=[V1VolumeMount(name="jmxdir", mount_path="/jmxdir")],


### PR DESCRIPTION
## Summary of changes

Apparently 1.36 was erroneously marked as 'latest' whereas it is unstable -> https://github.com/docker-library/busybox/issues/162

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
