### PR TITLE
Improve cluster healthiness query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Include ``sys.node_checks`` for checking cluster healthiness.
+
 2.22.0 (2023-01-31)
 -------------------
 

--- a/crate/operator/cratedb.py
+++ b/crate/operator/cratedb.py
@@ -126,7 +126,13 @@ async def get_healthiness(cursor: Cursor) -> int:
 
     :param cursor: A database cursor to a current and open database connection.
     """
-    await cursor.execute("SELECT MAX(severity) FROM sys.health")
+    await cursor.execute(
+        "SELECT max(severity) FROM ("
+        "  SELECT MAX(severity) as severity FROM sys.health"
+        "  UNION"
+        '  SELECT 3 as "severity" FROM sys.cluster where master_node is null'
+        ") sub;"
+    )
     row = await cursor.fetchone()
     return row and row[0]
 

--- a/tests/test_cratedb.py
+++ b/tests/test_cratedb.py
@@ -98,7 +98,13 @@ async def test_get_healthiness(healthiness):
     cursor = mock.AsyncMock()
     cursor.fetchone.return_value = (healthiness,) if healthiness is not None else None
     assert (await get_healthiness(cursor)) == healthiness
-    cursor.execute.assert_awaited_once_with("SELECT MAX(severity) FROM sys.health")
+    cursor.execute.assert_awaited_once_with(
+        "SELECT max(severity) FROM ("
+        "  SELECT MAX(severity) as severity FROM sys.health"
+        "  UNION"
+        '  SELECT 3 as "severity" FROM sys.cluster where master_node is null'
+        ") sub;"
+    )
     cursor.fetchone.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary of changes
Add `sys.node_checks` to the health query

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
