### PR TITLE
Fix union for operator tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 Unreleased
 ----------
 
-* Include ``sys.node_checks`` for checking cluster healthiness.
+* Fix failing operator tests.
+
+* Include ``sys.cluster`` for checking cluster healthiness.
 
 2.22.0 (2023-01-31)
 -------------------

--- a/crate/operator/cratedb.py
+++ b/crate/operator/cratedb.py
@@ -128,9 +128,10 @@ async def get_healthiness(cursor: Cursor) -> int:
     """
     await cursor.execute(
         "SELECT max(severity) FROM ("
-        "  SELECT MAX(severity) as severity FROM sys.health"
-        "  UNION"
-        '  SELECT 3 as "severity" FROM sys.cluster where master_node is null'
+        "  SELECT CAST(max(severity) as integer) as severity FROM sys.health"
+        "  UNION ALL"
+        "  SELECT CAST(3 as integer) as severity FROM sys.cluster"
+        "    WHERE master_node is null"
         ") sub;"
     )
     row = await cursor.fetchone()

--- a/tests/test_cratedb.py
+++ b/tests/test_cratedb.py
@@ -100,9 +100,10 @@ async def test_get_healthiness(healthiness):
     assert (await get_healthiness(cursor)) == healthiness
     cursor.execute.assert_awaited_once_with(
         "SELECT max(severity) FROM ("
-        "  SELECT MAX(severity) as severity FROM sys.health"
-        "  UNION"
-        '  SELECT 3 as "severity" FROM sys.cluster where master_node is null'
+        "  SELECT CAST(max(severity) as integer) as severity FROM sys.health"
+        "  UNION ALL"
+        "  SELECT CAST(3 as integer) as severity FROM sys.cluster"
+        "    WHERE master_node is null"
         ") sub;"
     )
     cursor.fetchone.assert_awaited_once()


### PR DESCRIPTION
## Summary of changes
Looks like that for the operator tests, we need to fix some issues.

```
psycopg2.errors.InternalError_: UNION [DISTINCT] is not supported
```

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
