### PR TITLE
No pre-flight check on PVC expand

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Do not perform cluster pre-flights checks when expanding disk.
+
 * Fix failing operator tests.
 
 * Include ``sys.cluster`` for checking cluster healthiness.

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -134,6 +134,9 @@ async def update_cratedb(
                     "size"
                 ) != new_spec.get("resources", {}).get("disk", {}).get("size"):
                     do_expand_volume = True
+                    if config.NO_DOWNTIME_STORAGE_EXPANSION:
+                        do_before_update = False
+                        do_after_update = False
                 elif has_compute_changed(old_spec, new_spec):
                     do_change_compute = True
                     # pod resources won't change until each pod is recreated


### PR DESCRIPTION
## Summary of changes
Do not perform cluster pre-flights checks when expanding disk.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
