### PR TITLE
Rollback CrateDB version on upgrade failures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
 
 * Include ``sys.cluster`` for checking cluster healthiness.
 
+* Revert ``spec.cluster.version`` on upgrade failures.
+
 2.22.0 (2023-01-31)
 -------------------
 

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -138,7 +138,6 @@ async def cluster_create(
     annotations=annotation_filter(),
 )
 @crate.on.error(error_handler=crate.send_update_failed_notification)
-@crate.timeout(timeout=float(config.CLUSTER_UPDATE_TIMEOUT))
 async def cluster_update(
     namespace: str,
     name: str,

--- a/crate/operator/utils/kopf.py
+++ b/crate/operator/utils/kopf.py
@@ -23,6 +23,7 @@ import abc
 import functools
 import json
 import logging
+from datetime import datetime
 from functools import wraps
 from typing import Any, Callable, Optional, TypedDict
 
@@ -120,7 +121,11 @@ class StateBasedSubHandler(abc.ABC):
         status = kwargs["status"]
         annotations = kwargs["annotations"]
         logger = kwargs["logger"]
+        patch = kwargs["patch"]
         waiting_for = []
+
+        self._init_handler_starttime(status, patch, logger)
+
         for dependency in self.depends_on:
             if self._get_status(status, dependency, logger) is None:
                 if self._should_run_on_failed_dependency(
@@ -132,6 +137,12 @@ class StateBasedSubHandler(abc.ABC):
 
         if len(waiting_for) > 0:
             wt = ",".join(waiting_for)
+            patch.status.setdefault("subhandlerStartedAt", {})[
+                self.__class__.__name__
+            ] = {
+                "ref": self.ref,
+                "started": int(datetime.utcnow().timestamp()),
+            }
             # If running in testing mode (i.e. running ITs) we can reduce the delay
             # significantly as things generally move fast.
             raise kopf.TemporaryError(
@@ -227,6 +238,46 @@ class StateBasedSubHandler(abc.ABC):
                 )
 
         return False
+
+    def _run_only_on_failed_dependency(
+        self, annotations: dict, dependencies: list, logger: logging.Logger
+    ) -> bool:
+        """
+        Peek into kopf's internal state storage - the annotations on the CrateDB
+        objects to check if any of our dependencies has failed.
+        """
+        for handler_name in dependencies:
+            progressor = kopf.AnnotationsProgressStorage(
+                v1=False, prefix=KOPF_STATE_STORE_PREFIX
+            )
+            key = progressor.make_v2_key(handler_name)
+            status_str = annotations.get(key)
+            if not status_str:
+                return False
+            status = json.loads(status_str)
+
+            if status["failure"]:
+                return True
+        return False
+
+    def _init_handler_starttime(
+        self, statuses: dict, patch: kopf.Patch, logger: logging.Logger
+    ):
+        """
+        This sets the intitial start time of the subhandler. It gets constantly updated
+        when a subhandler is delayed because of unfinished dependencies. This is
+        required to calculate the correct runtime of a subhandler in the timeout
+        decorator.
+        """
+        status = statuses.get("subhandlerStartedAt", {}).get(self.__class__.__name__)
+
+        if (
+            not (status and status.get("started") and status.get("ref") == self.ref)
+            and patch
+        ):
+            patch.status.setdefault("subhandlerStartedAt", {})[
+                self.__class__.__name__
+            ] = {"started": int(datetime.utcnow().timestamp()), "ref": self.ref}
 
 
 async def send_webhook_notification(

--- a/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
+++ b/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
@@ -358,6 +358,9 @@ spec:
                   version:
                     description: CrateDB version
                     type: string
+                  lastUpdatedAt:
+                    description: Timestamp of the last CrateDB update
+                    type: string
                 required:
                 - imageRegistry
                 - name

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -75,8 +75,17 @@ async def test_upgrade_cluster_timeout(
             await handler._subhandler(
                 logger=logging.getLogger(__name__),
                 runtime=datetime.timedelta(seconds=runtime),
-                status={},
+                status={
+                    "subhandlerStartedAt": {
+                        "ActionSubhandler": {
+                            "started": int(datetime.datetime.utcnow().timestamp())
+                            - runtime,
+                            "ref": hash,
+                        }
+                    }
+                },
                 annotations={},
+                patch={},
             )
         await assert_wait_for(
             True,
@@ -103,7 +112,16 @@ async def test_upgrade_cluster_timeout(
         res = await handler._subhandler(
             logger=logging.getLogger(__name__),
             runtime=datetime.timedelta(seconds=runtime),
-            status={},
+            status={
+                "subhandlerStartedAt": {
+                    "ActionSubhandler": {
+                        "started": int(datetime.datetime.utcnow().timestamp())
+                        - runtime,
+                        "ref": hash,
+                    }
+                }
+            },
             annotations={},
+            patch={},
         )
         assert res["result"] == {"success": True}


### PR DESCRIPTION
## Summary of changes
- revert `spec.cluster.version` at the end of the execution in case there was an error somewhere in the upgrade process. To avoid kopf getting stuck or ending in an infinite loop setting the value back and forth, the "rollback" is done at the end of the execution, only followed by updating the introduced `spec.cluster.lastUpdatedAt` timestamp. This is recognized by kopf as another change (which is actually ignored afterwards) to the CRD and helps cleaning up the status annotations in the resource.
- move timeout handling from the main `cluster_update` handler to the individual subhandlers. Therefore it is necessary to store the timestamp when each subhandler really started working somewhere (in the `status` object in this case) 

https://github.com/crate/cloud/issues/1079

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
