### PR TITLE
Deprecated APIs for pdb and batch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Remove ``beta1`` from `PodDisruptionBudget` and ``Cronjob/Batch`` API version.
+
 * Fixed a missing permission that was causing a warning on kopf startup.
 
 2.23.0 (2023-02-28)

--- a/crate/operator/backup.py
+++ b/crate/operator/backup.py
@@ -24,17 +24,16 @@ from typing import Any, Dict, List, Optional
 
 from kubernetes_asyncio.client import (
     AppsV1Api,
-    BatchV1beta1Api,
-    V1beta1CronJob,
-    V1beta1CronJobSpec,
-    V1beta1JobTemplateSpec,
     V1Container,
     V1ContainerPort,
+    V1CronJob,
+    V1CronJobSpec,
     V1Deployment,
     V1DeploymentSpec,
     V1EnvVar,
     V1EnvVarSource,
     V1JobSpec,
+    V1JobTemplateSpec,
     V1LabelSelector,
     V1LocalObjectReference,
     V1ObjectFieldSelector,
@@ -131,7 +130,7 @@ def get_backup_cronjob(
     backup_aws: Dict[str, Any],
     image_pull_secrets: Optional[List[V1LocalObjectReference]],
     has_ssl: bool,
-) -> V1beta1CronJob:
+) -> V1CronJob:
     env = (
         [
             V1EnvVar(
@@ -174,16 +173,16 @@ def get_backup_cronjob(
             )
         )
 
-    return V1beta1CronJob(
+    return V1CronJob(
         metadata=V1ObjectMeta(
             name=f"create-snapshot-{name}",
             labels=labels,
             owner_references=owner_references,
         ),
-        spec=V1beta1CronJobSpec(
+        spec=V1CronJobSpec(
             concurrency_policy="Forbid",
             failed_jobs_history_limit=1,
-            job_template=V1beta1JobTemplateSpec(
+            job_template=V1JobTemplateSpec(
                 metadata=V1ObjectMeta(labels=labels, name=f"create-snapshot-{name}"),
                 spec=V1JobSpec(
                     template=V1PodTemplateSpec(
@@ -284,10 +283,10 @@ async def create_backups(
     backup_aws = backups.get("aws")
     async with ApiClient() as api_client:
         apps = AppsV1Api(api_client)
-        batchv1_beta1 = BatchV1beta1Api(api_client)
+        batch = BatchV1Api(api_client)
         if backup_aws:
             await call_kubeapi(
-                batchv1_beta1.create_namespaced_cron_job,
+                batch.create_namespaced_cron_job,
                 logger,
                 continue_on_conflict=True,
                 namespace=namespace,

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -30,10 +30,8 @@ import yaml
 from kubernetes_asyncio.client import (
     AppsV1Api,
     CoreV1Api,
-    PolicyV1beta1Api,
+    PolicyV1Api,
     V1Affinity,
-    V1beta1PodDisruptionBudget,
-    V1beta1PodDisruptionBudgetSpec,
     V1ConfigMap,
     V1ConfigMapVolumeSource,
     V1Container,
@@ -56,6 +54,8 @@ from kubernetes_asyncio.client import (
     V1PersistentVolumeClaimSpec,
     V1PodAffinityTerm,
     V1PodAntiAffinity,
+    V1PodDisruptionBudget,
+    V1PodDisruptionBudgetSpec,
     V1PodSpec,
     V1PodTemplateSpec,
     V1Probe,
@@ -836,13 +836,13 @@ async def create_statefulset(
                 logger,
             ),
         )
-        policy = PolicyV1beta1Api(api_client)
-        pdb = V1beta1PodDisruptionBudget(
+        policy = PolicyV1Api(api_client)
+        pdb = V1PodDisruptionBudget(
             metadata=V1ObjectMeta(
                 name=f"crate-{name}",
                 owner_references=owner_references,
             ),
-            spec=V1beta1PodDisruptionBudgetSpec(
+            spec=V1PodDisruptionBudgetSpec(
                 max_unavailable=1,
                 selector=V1LabelSelector(
                     match_labels={

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -27,10 +27,9 @@ import kopf
 from kubernetes_asyncio.client import (
     AppsV1Api,
     BatchV1Api,
-    BatchV1beta1Api,
     CoreV1Api,
     CustomObjectsApi,
-    V1beta1CronJobList,
+    V1CronJobList,
     V1JobList,
     V1JobStatus,
     V1PersistentVolumeClaimList,
@@ -738,9 +737,9 @@ class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
         namespace: str, name: str, logger: logging.Logger
     ) -> Optional[Dict]:
         async with ApiClient() as api_client:
-            batch = BatchV1beta1Api(api_client)
+            batch = BatchV1Api(api_client)
 
-            jobs: V1beta1CronJobList = await batch.list_namespaced_cron_job(namespace)
+            jobs: V1CronJobList = await batch.list_namespaced_cron_job(namespace)
 
             for job in jobs.items:
                 job_name = job.metadata.name
@@ -895,9 +894,9 @@ class AfterClusterUpdateSubHandler(StateBasedSubHandler):
         async with ApiClient() as api_client:
             job_name = disabler_job_status[CRONJOB_NAME]
 
-            batch = BatchV1beta1Api(api_client)
+            batch = BatchV1Api(api_client)
 
-            jobs: V1beta1CronJobList = await batch.list_namespaced_cron_job(namespace)
+            jobs: V1CronJobList = await batch.list_namespaced_cron_job(namespace)
 
             for job in jobs.items:
                 if job.metadata.name == job_name:

--- a/crate/operator/utils/typing.py
+++ b/crate/operator/utils/typing.py
@@ -22,8 +22,8 @@
 from typing import Dict, TypedDict, TypeVar
 
 from kubernetes_asyncio.client.models import (
-    V1beta1CronJob,
     V1ConfigMap,
+    V1CronJob,
     V1Deployment,
     V1PersistentVolume,
     V1PersistentVolumeClaim,
@@ -35,7 +35,7 @@ from kubernetes_asyncio.client.models import (
 LabelType = Dict[str, str]
 K8sModel = TypeVar(
     "K8sModel",
-    V1beta1CronJob,
+    V1CronJob,
     V1ConfigMap,
     V1Deployment,
     V1PersistentVolume,

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -22,7 +22,7 @@
 import logging
 
 import pytest
-from kubernetes_asyncio.client import AppsV1Api, BatchV1beta1Api, V1beta1CronJob
+from kubernetes_asyncio.client import AppsV1Api, BatchV1Api, V1CronJob
 
 from crate.operator.backup import create_backups
 from crate.operator.constants import (
@@ -38,17 +38,15 @@ from .utils import assert_wait_for
 @pytest.mark.asyncio
 class TestBackup:
     async def does_cronjob_exist(
-        self, batchv1_beta1: BatchV1beta1Api, namespace: str, name: str
+        self, batch: BatchV1Api, namespace: str, name: str
     ) -> bool:
-        cjs = await batchv1_beta1.list_namespaced_cron_job(namespace=namespace)
+        cjs = await batch.list_namespaced_cron_job(namespace=namespace)
         return name in (cj.metadata.name for cj in cjs.items)
 
     async def get_cronjob(
-        selfself, batchv1_beta1: BatchV1beta1Api, namespace: str, name: str
-    ) -> V1beta1CronJob:
-        return await batchv1_beta1.read_namespaced_cron_job(
-            namespace=namespace, name=name
-        )
+        self, batch: BatchV1Api, namespace: str, name: str
+    ) -> V1CronJob:
+        return await batch.read_namespaced_cron_job(namespace=namespace, name=name)
 
     async def does_deployment_exist(
         self, apps: AppsV1Api, namespace: str, name: str
@@ -58,7 +56,7 @@ class TestBackup:
 
     async def test_create(self, faker, namespace, api_client):
         apps = AppsV1Api(api_client)
-        batchv1_beta1 = BatchV1beta1Api(api_client)
+        batch = BatchV1Api(api_client)
         name = faker.domain_word()
 
         backups_spec = {
@@ -107,7 +105,7 @@ class TestBackup:
         await assert_wait_for(
             True,
             self.does_cronjob_exist,
-            batchv1_beta1,
+            batch,
             namespace.metadata.name,
             f"create-snapshot-{name}",
         )
@@ -122,7 +120,7 @@ class TestBackup:
     async def test_create_with_custom_backup_location(
         self, faker, namespace, api_client
     ):
-        batchv1_beta1 = BatchV1beta1Api(api_client)
+        batchv1 = BatchV1Api(api_client)
         name = faker.domain_word()
 
         backups_spec = {
@@ -178,12 +176,12 @@ class TestBackup:
         await assert_wait_for(
             True,
             self.does_cronjob_exist,
-            batchv1_beta1,
+            batchv1,
             namespace.metadata.name,
             f"create-snapshot-{name}",
         )
         job = await self.get_cronjob(
-            batchv1_beta1, namespace.metadata.name, f"create-snapshot-{name}"
+            batchv1, namespace.metadata.name, f"create-snapshot-{name}"
         )
         env_vars = [
             env.name
@@ -194,7 +192,7 @@ class TestBackup:
     async def test_not_enabled(self, faker, namespace, api_client):
         name = faker.domain_word()
         apps = AppsV1Api(api_client)
-        batchv1_beta1 = BatchV1beta1Api(api_client)
+        batchv1 = BatchV1Api(api_client)
 
         await create_backups(
             None,
@@ -210,7 +208,7 @@ class TestBackup:
         )
         assert (
             await self.does_cronjob_exist(
-                batchv1_beta1, namespace.metadata.name, f"create-snapshot-{name}"
+                batchv1, namespace.metadata.name, f"create-snapshot-{name}"
             )
             is False
         )

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -26,7 +26,7 @@ from unittest import mock
 import pytest
 from kubernetes_asyncio.client import (
     AppsV1Api,
-    BatchV1beta1Api,
+    BatchV1Api,
     CoreV1Api,
     CustomObjectsApi,
     V1Namespace,
@@ -457,7 +457,7 @@ async def _is_blocked_on_running_snapshot(
 
 
 async def _backup_cronjob_is_suspended(api_client, namespace: str):
-    batch = BatchV1beta1Api(api_client)
+    batch = BatchV1Api(api_client)
     jobs = await batch.list_namespaced_cron_job(namespace)
 
     for job in jobs.items:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,7 +30,6 @@ import psycopg2
 from aiopg import Connection
 from kubernetes_asyncio.client import (
     BatchV1Api,
-    BatchV1beta1Api,
     CoreV1Api,
     CustomObjectsApi,
     V1Namespace,
@@ -361,9 +360,9 @@ async def create_fake_cronjob(api_client, name, namespace):
 
     This can be used in tests to check for cronjobs existing, and their statuses.
     """
-    batch = BatchV1beta1Api(api_client)
+    batch = BatchV1Api(api_client)
     body = {
-        "apiVersion": "batch/v1beta1",
+        "apiVersion": "batch/v1",
         "kind": "CronJob",
         "metadata": {
             "name": f"create-snapshot-{name}",


### PR DESCRIPTION
## Summary of changes

```
Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1
Warning: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
