### PR TITLE
Added an ability to specify additional annotations for the created LoadBalancer services.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Added an ability to specify additional annotations for the created LoadBalancer
+  services. This is useful when, i.e., wanting to override the type of load balancer
+  to be used.
+
 2.24.0 (2023-03-21)
 -------------------
 

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -128,6 +128,9 @@ async def create_cratedb(
             transport_port=transport_port,
             dns_record=spec.get("cluster", {}).get("externalDNS"),
             source_ranges=source_ranges,
+            additional_annotations=spec.get("cluster", {})
+            .get("service", {})
+            .get("annotations", {}),
         ),
         id="services",
     )

--- a/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
+++ b/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
@@ -307,6 +307,14 @@ spec:
                       cluster.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  service:
+                    description: Additional configuration for k8s services.
+                    properties:
+                      annotations:
+                        description: Additional annotations to add to the k8s load balancer service.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
                   ssl:
                     properties:
                       keystore:


### PR DESCRIPTION
## Summary of changes

This is useful when, i.e., wanting to override the type of load balancer to be used.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
