### PR TITLE
Removed handling of licenses.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # The users listed below are global owners and will be
 # requested for review when someone opens a pull request.
-*       @Taliik @tomach @juanpardo @SStorm @walbeh
+*       @plaharanne @tomach @WalBeh @Taliik @juanpardo @SStorm

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 
 * Added the type of operation to the feedback webhooks payload.
 
+* Removed handling of licenses. The operator will no longer attempt to set a license,
+  even if one is configured in the CRD. Licenses are deprecated since CrateDB 4.5.
+
 2.25.0 (2023-03-23)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ A minimal custom resource for a 3 node CrateDB cluster may look like this:
      cluster:
        imageRegistry: crate
        name: crate-dev
-       version: 4.3.1
+       version: 5.2.5
      nodes:
        data:
        - name: hot
@@ -73,6 +73,11 @@ A minimal custom resource for a 3 node CrateDB cluster may look like this:
    NAMESPACE   NAME         AGE
    dev         my-cluster   36s
 
+
+Please note that the minimum version of CrateDB that the operator supports is **4.5**.
+Previous versions might work, but the operator will not attempt to set a license.
+
+
 🎉 Features
 ==========
 
@@ -87,7 +92,7 @@ A minimal custom resource for a 3 node CrateDB cluster may look like this:
 - region/zone awareness for AWS and Azure
 
 💽 Installation
-==============
+===============
 
 Installation with Helm
 ----------------------

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -26,7 +26,7 @@ import kopf
 from kubernetes_asyncio.client import V1LocalObjectReference, V1OwnerReference
 
 from crate.operator.backup import CreateBackupsSubHandler
-from crate.operator.bootstrap import BootstrapClusterSubHandler
+from crate.operator.bootstrap import CreateUsersSubHandler
 from crate.operator.config import config
 from crate.operator.constants import (
     API_GROUP,
@@ -199,9 +199,8 @@ async def create_cratedb(
         master_node_pod = f"crate-data-{node_name}-{name}-0"
 
     kopf.register(
-        fn=BootstrapClusterSubHandler(namespace, name, hash, context)(
+        fn=CreateUsersSubHandler(namespace, name, hash, context)(
             master_node_pod=master_node_pod,
-            license=spec["cluster"].get("license"),
             has_ssl="ssl" in spec["cluster"],
             users=spec.get("users"),
         ),

--- a/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
+++ b/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
@@ -198,6 +198,8 @@ spec:
                         - key
                         - name
                         type: object
+                        description: Deprecated and no longer has any effect.
+                          Only here for backwards-compatibility.
                     required:
                     - secretKeyRef
                     type: object

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -30,6 +30,7 @@ from crate.operator.upgrade import upgrade_command
 from crate.operator.webhooks import WebhookEvent, WebhookStatus
 
 from .utils import (
+    CRATE_VERSION,
     DEFAULT_TIMEOUT,
     assert_wait_for,
     cluster_routing_allocation_enable_equals,
@@ -49,8 +50,8 @@ from .utils import (
 async def test_upgrade_cluster(
     mock_send_notification, faker, namespace, kopf_runner, api_client
 ):
-    version_from = "4.6.1"
-    version_to = "4.6.4"
+    version_from = "5.0.0"
+    version_to = CRATE_VERSION
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)
     name = faker.domain_word()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,7 +62,7 @@ from crate.operator.utils.kubeapi import (
 
 logger = logging.getLogger(__name__)
 
-CRATE_VERSION = "5.0.0"
+CRATE_VERSION = "5.2.5"
 DEFAULT_TIMEOUT = 60
 
 


### PR DESCRIPTION
## Summary of changes

The operator will no longer attempt to set a license, even if one is configured in the CRD. Licenses are deprecated since CrateDB 4.5, and are about to be removed in the next CrateDB minor version.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
