### PR TITLE
Fixed PVC resize tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 * Suspending a cluster now deletes the load balancer.
   Resuming the cluster re-creates it.
 
+* Fixed PVC resize tests. They were impacted by the fact that we're not deleting the load balancer.
+
 2.26.1 (2023-04-12)
 -------------------
 

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -136,7 +136,7 @@ async def test_expand_cluster_storage(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
-        err_msg="Scaling up has not finished",
+        err_msg="Cluster update has not finished",
         timeout=DEFAULT_TIMEOUT * 2,
     )
 

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -129,6 +129,17 @@ async def test_expand_cluster_storage(
         timeout=DEFAULT_TIMEOUT * 3,
     )
 
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Scaling up has not finished",
+        timeout=DEFAULT_TIMEOUT * 2,
+    )
+
     # The host needs to be retrieved again because the IP address has changed.
     # This is due to suspending and resuming the cluster recreates the load balancer.
     # Make sure we wait for the cluster to be suspended.
@@ -141,17 +152,6 @@ async def test_expand_cluster_storage(
         connection_factory(host, password),
         number_of_nodes,
         err_msg="Cluster wasn't back up again after 5 minutes.",
-        timeout=DEFAULT_TIMEOUT * 5,
-    )
-
-    await assert_wait_for(
-        True,
-        is_kopf_handler_finished,
-        coapi,
-        name,
-        namespace.metadata.name,
-        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
-        err_msg="Volume Expansion handler has not finished.",
         timeout=DEFAULT_TIMEOUT * 5,
     )
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -50,13 +50,13 @@ from .utils import (
 async def test_upgrade_cluster(
     mock_send_notification, faker, namespace, kopf_runner, api_client
 ):
-    version_from = "5.0.0"
+    version_from = "5.2.3"
     version_to = CRATE_VERSION
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)
     name = faker.domain_word()
 
-    host, password = await start_cluster(name, namespace, core, coapi, 2, version_from)
+    host, password = await start_cluster(name, namespace, core, coapi, 3, version_from)
 
     await assert_wait_for(
         True,
@@ -66,6 +66,7 @@ async def test_upgrade_cluster(
         {
             f"crate-data-hot-{name}-0",
             f"crate-data-hot-{name}-1",
+            f"crate-data-hot-{name}-2",
         },
     )
 
@@ -75,7 +76,7 @@ async def test_upgrade_cluster(
         True,
         is_cluster_healthy,
         conn_factory,
-        2,
+        3,
         err_msg="Cluster wasn't healthy",
         timeout=DEFAULT_TIMEOUT,
     )
@@ -143,7 +144,7 @@ async def test_upgrade_cluster(
         True,
         is_cluster_healthy,
         connection_factory(host, password),
-        2,
+        3,
         err_msg="Cluster wasn't healthy",
         timeout=DEFAULT_TIMEOUT,
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,7 +62,7 @@ from crate.operator.utils.kubeapi import (
 
 logger = logging.getLogger(__name__)
 
-CRATE_VERSION = "5.2.5"
+CRATE_VERSION = "5.2.6"
 DEFAULT_TIMEOUT = 60
 
 
@@ -294,7 +294,8 @@ async def create_test_sys_jobs_table(conn_factory):
             table_name = config.JOBS_TABLE
             logger.info(f"Creating {table_name}")
             await cursor.execute(
-                f"CREATE TABLE {table_name} (id INTEGER, stmt VARCHAR)"
+                f"CREATE TABLE {table_name} (id INTEGER, stmt VARCHAR) "
+                "WITH (number_of_replicas='0-all')"
             )
 
 


### PR DESCRIPTION
## Summary of changes

They were impacted by the fact that we're not deleting the load balancer. So now we explicitly wait for the update handler to finish before we query the hostname.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
