### PR TITLE
RTD: Update to Ubuntu 22 and Python 3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,12 @@
 ---
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
+
 python:
   install:
   - requirements: docs/requirements.txt
-  version: 3.8
 
 sphinx:
   builder: html


### PR DESCRIPTION
Proactively update Read the Docs environment to compensate for recent release of urllib3 2.x, otherwise failing on an incompatibility with older OpenSSL versions.

```
Could not import extension sphinx.builders.linkcheck (exception:
urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module
is compiled with OpenSSL 1.0.2n  7 Dec 2017.
See: https://github.com/urllib3/urllib3/issues/2168)
```