### PR TITLE
Add cratedb_unreplicated_tables metric to sql exporter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Added ``cratedb_unreplicated_tables`` metric to the sql exporter.
+
 2.27.0 (2023-05-08)
 -------------------
 

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -22,6 +22,7 @@
 import enum
 
 API_GROUP = "cloud.crate.io"
+RESOURCE_CONFIGMAP = "configmaps"
 RESOURCE_CRATEDB = "cratedbs"
 
 LABEL_COMPONENT = "app.kubernetes.io/component"
@@ -43,6 +44,7 @@ CLUSTER_CREATE_ID = "cluster_create"
 BACKUP_METRICS_DEPLOYMENT_NAME = "backup-metrics-{name}"
 DATA_NODE_NAME = "hot"
 DATA_PVC_NAME_PREFIX = "data"
+SQL_EXPORTER_CONFIGMAP_PREFIX = "crate-sql-exporter"
 
 SHARED_NODE_SELECTOR_KEY = "cratedb"
 SHARED_NODE_SELECTOR_VALUE = "shared"

--- a/crate/operator/data/cratedb_unreplicated_tables-collector.yaml
+++ b/crate/operator/data/cratedb_unreplicated_tables-collector.yaml
@@ -1,0 +1,19 @@
+---
+collector_name: cratedb_unreplicated_tables_collector
+# This metric is intended to know if there are (partitioned) tables
+# with 0 replicas in the cluster. It is used to remind the customer to
+# configure replicas, which is strongly advised.
+metrics:
+- help: "Indicates tables with 0 replicas. Does not return if there are no unreplicated tables."
+  key_labels: [table_name]
+  metric_name: cratedb_unreplicated_tables
+  query: |
+    SELECT concat(table_schema,'.', table_name) as table_name, number_of_replicas
+    FROM information_schema.table_partitions
+    WHERE table_schema NOT IN ('information_schema', 'sys', 'pg_catalog') AND number_of_replicas = 0
+    UNION DISTINCT
+    SELECT concat(table_schema,'.', table_name) as table_name, number_of_replicas
+    FROM information_schema.tables
+    WHERE table_schema NOT IN ('information_schema', 'sys', 'pg_catalog') AND number_of_replicas = 0;
+  type: gauge
+  values: [number_of_replicas]

--- a/crate/operator/data/sql-exporter.yaml
+++ b/crate/operator/data/sql-exporter.yaml
@@ -14,7 +14,7 @@ global:
   # timing out first.
   scrape_timeout_offset: 500ms
 target:
-  collectors: [responsivity_collector, cratedb_max_shards_collector, cratedb_cluster_last_user_activity_collector]
+  collectors: [responsivity_collector, cratedb_max_shards_collector, cratedb_cluster_last_user_activity_collector, cratedb_unreplicated_tables_collector]
   # To test sql exporter against a local crateDB service you can add "&sslmode=disable" to the data_source_name.
   # Please do not use sslmode=disable in production as it hinders security.
   data_source_name: "postgres://crate@localhost:5432/?connect_timeout=5"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,11 +19,23 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import logging
 import time
 
+import pytest
+from kubernetes_asyncio.client import CoreV1Api, V1ConfigMap, V1ObjectMeta
 from prometheus_client import REGISTRY
 
+from crate.operator.constants import (
+    LABEL_COMPONENT,
+    LABEL_MANAGED_BY,
+    LABEL_NAME,
+    LABEL_PART_OF,
+)
+from crate.operator.operations import update_sql_exporter_configmap
 from crate.operator.prometheus import PrometheusClusterStatus, report_cluster_status
+
+logger = logging.getLogger(__name__)
 
 
 def test_will_report_metrics_for_clusters():
@@ -97,3 +109,55 @@ def test_will_not_report_last_seen_for_unreachable_clusters():
         cloud_clusters_health_sample.value == PrometheusClusterStatus.UNREACHABLE.value
     )
     assert cloud_clusters_last_seen_sample is None
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+async def test_update_sql_exporter_configmap(
+    faker,
+    namespace,
+    kopf_runner,
+    api_client,
+):
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+    config_map_name = f"crate-sql-exporter-{name}"
+    labels = {
+        LABEL_MANAGED_BY: "crate-operator",
+        LABEL_NAME: name,
+        LABEL_PART_OF: "cratedb",
+        LABEL_COMPONENT: "cratedb",
+    }
+
+    await core.create_namespaced_config_map(
+        namespace=namespace.metadata.name,
+        body=V1ConfigMap(
+            metadata=V1ObjectMeta(
+                name=config_map_name,
+                labels=labels,
+            ),
+            data={"sql-exporter.yaml": ""},
+        ),
+    )
+
+    await update_sql_exporter_configmap(
+        namespace.metadata.name,
+        config_map_name,
+        logger=logger,
+    )
+
+    config_map = await core.read_namespaced_config_map(
+        name=config_map_name, namespace=namespace.metadata.name
+    )
+    assert (
+        "collectors: [responsivity_collector, cratedb_max_shards_collector, "
+        "cratedb_cluster_last_user_activity_collector, "
+        "cratedb_unreplicated_tables_collector]"
+    ) in config_map.data["sql-exporter.yaml"]
+    for collector in [
+        "responsivity-collector.yaml",
+        "cratedb_max_shards-collector.yaml",
+        "cratedb_cluster_last_user_activity-collector.yaml",
+        "cratedb_unreplicated_tables-collector.yaml",
+    ]:
+        assert collector in config_map.data.keys()


### PR DESCRIPTION
## Summary of changes
- export metric `cratedb_unreplicated_tables` if there are (partitioned) tables with 0 replicas in the cluster
- add a `kopf.on.resume` handler which adds this metric to all `crate-sql-exporter` configmaps

https://github.com/crate/cloud/issues/959

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
