### PR TITLE
Change `max_restore_bytes_per_sec` to `240mb`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Increased ``max_restore_bytes_per_sec`` when creating a repository for a backup restore operation.
+
 * Added ``cratedb_unreplicated_tables`` metric to the sql exporter.
 
 2.27.0 (2023-05-08)

--- a/crate/operator/restore_backup.py
+++ b/crate/operator/restore_backup.py
@@ -525,7 +525,8 @@ class RestoreBackupSubHandler(StateBasedSubHandler):
                         await cursor.execute(
                             f"CREATE REPOSITORY {repository_ident} type s3 with "
                             "(access_key = %s, secret_key = %s, bucket = %s, "
-                            "base_path = %s, readonly=true)",
+                            "base_path = %s, readonly=true,",
+                            "max_restore_bytes_per_sec = '240mb')",
                             (
                                 data["accessKeyId"],
                                 data["secretAccessKey"],


### PR DESCRIPTION
## Summary of changes
Setting `max_restore_bytes_per_sec` from default (`40mb`) to `240mb`.

https://crate.io/docs/crate/reference/en/5.3/sql/statements/create-repository.html#sql-create-repository

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
