### PR TITLE
Using no-downtime storage expansion in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,7 @@ def load_config(worker_id):
         "CRATEDB_OPERATOR_BOOTSTRAP_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_HEALTH_CHECK_RETRY_DELAY": "5",
         "CRATEDB_OPERATOR_CRATEDB_STATUS_CHECK_INTERVAL": "5",
+        "CRATEDB_OPERATOR_NO_DOWNTIME_STORAGE_EXPANSION": "true",
     }
     # If the environment already has any of these keys defined, leave them be
     for k in env.keys():

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -118,7 +118,7 @@ async def test_expand_cluster_storage(
 
     # we just check if the PVC has been patched with the correct new disk size. We
     # do not wait for the PVC to be really resized because there is no guarantee
-    # it is supported.
+    # it is supported on the cluster we are running the tests on.
     await assert_wait_for(
         True,
         _all_pvcs_resized,
@@ -137,7 +137,7 @@ async def test_expand_cluster_storage(
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
         err_msg="Cluster update has not finished",
-        timeout=DEFAULT_TIMEOUT * 2,
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     # The host needs to be retrieved again because the IP address has changed.


### PR DESCRIPTION
## Summary of changes

We use this by default now in CrateDB Cloud, so makes sense to test with it too.


## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
