### PR TITLE
Changed the metrics to also export the namespace as a label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Changed the metrics to also export the namespace as a label.
+
 2.28.0 (2023-06-05)
 -------------------
 

--- a/crate/operator/handlers/handle_ping_cratedb_status.py
+++ b/crate/operator/handlers/handle_ping_cratedb_status.py
@@ -76,7 +76,7 @@ async def ping_cratedb_status(
             logger.warning("Failed to ping cluster.", exc_info=e)
             status = PrometheusClusterStatus.UNREACHABLE
 
-        report_cluster_status(name, status)
+        report_cluster_status(name, namespace, status)
         patch.status[CLUSTER_STATUS_KEY] = {"health": status.name}
 
         await webhook_client.send_notification(


### PR DESCRIPTION
## Summary of changes

We use the `exported_namespace` label because `namespace` is scraped automatically from wherever the operator just so happens to live in.

**Note:** not merging yet as our prometheus setup ignores this label for some reason. Will figure it out. 

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
