### PR TITLE
Bump sql_exporter to 0.11.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Bump sql_exporter to 0.11.1
+
 2.30.0 (2023-06-27)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -152,7 +152,7 @@ class Config:
     PROMETHEUS_PORT: int = 8080
 
     #: The sql_exporter image to use
-    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.10.1"
+    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.11.1"
 
     #: Name of the secret containing credentials to access the source
     #: backup when restoring a snapshot.

--- a/crate/operator/data/sql-exporter.yaml
+++ b/crate/operator/data/sql-exporter.yaml
@@ -5,9 +5,9 @@ collector_files:
 global:
   # Maximum number of open connections to any one target. Metric queries will run concurrently on
   # multiple connections.
-  max_connections: 1
+  max_connections: 3
   # Maximum number of idle connections to any one target.
-  max_idle_connections: 1
+  max_idle_connections: 3
   # Minimum interval between collector runs: by default (0s) collectors are executed on every scrape.
   min_interval: 0s
   # Subtracted from Prometheus' scrape_timeout to give us some headroom and prevent Prometheus from


### PR DESCRIPTION
## Summary of changes
We want to switch to the latest available version and increase the concurrency settings in the sql_exporter configuration.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
