### PR TITLE
Update only data of sql-exporter configmap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 * Bump sql_exporter to 0.11.1
 
+* Fixed patching of sql exporter configmap.
+
 2.30.0 (2023-06-27)
 -------------------
 

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -847,7 +847,7 @@ async def update_sql_exporter_configmap(
                 logger,
                 name=name,
                 namespace=namespace,
-                body=config_map,
+                body={"data": config_map.data},
             )
         else:
             warnings.warn("Cannot load or missing SQL Exporter Collector config!")


### PR DESCRIPTION
## Summary of changes
Update only `data` of the `sql-exporter` configmap. This should fix the occasional `409 Conflict` error in the tests when also `resourceVersion`, `creationTimestamp` and `uid` are tried to be patched.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
