### PR TITLE
Explicitly lowering TCP keepalives to 120s to deal with naughty load balancers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Unreleased
 * Increased the timeout for querying ``sys.snapshots`` table when verifying backup
   repository.
 
+* Explicitly lowering TCP keepalives to 120s to deal with naughty load balancers.
+  Looking at you, AWS NLB.
+
 2.30.3 (2023-08-29)
 -------------------
 


### PR DESCRIPTION
## Summary of changes

Looking at you, AWS NLB.

https://github.com/crate/cloud/issues/1473

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
