### PR TITLE
Update nightly version comparison

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Updated the ``CrateVersion`` nightly parsing to accept the new datetime format
+  of ``yyyy-mm-dd-hh-mm`` while still being compatible with the old ``yyyymmdd`` format.
+
 2.31.0 (2023-09-11)
 -------------------
 


### PR DESCRIPTION
## Summary of changes
Updated the ``CrateVersion`` nightly parsing to accept the new datetime format of ``yyyy-mm-dd-hh-mm`` while still being compatible with the old ``yyyymmdd`` format.

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
