### PR TITLE
Deploy grand central backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Unreleased
 
 * Bumped aiohttp to latest to fix CVE-2023-49081
 
+* Added ``grandCentral`` section to the CRD and create the resources for grand-central
+  backend when a cluster is deployed.
+
+* Implemented a handler allowing changing the ``backendImage`` of ``grandCentral``.
+
+
 2.33.0 (2023-11-14)
 -------------------
 

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -52,6 +52,9 @@ SHARED_NODE_TOLERATION_EFFECT = "NoSchedule"
 SHARED_NODE_TOLERATION_KEY = "cratedb"
 SHARED_NODE_TOLERATION_VALUE = "shared"
 
+GRAND_CENTRAL_RESOURCE_PREFIX = "grand-central"
+GRAND_CENTRAL_BACKEND_API_PORT = 5050
+
 
 class CloudProvider(str, enum.Enum):
     AWS = "aws"

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -1,0 +1,436 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import logging
+from typing import Any, List, Optional
+
+import kopf
+from kubernetes_asyncio.client import (
+    AppsV1Api,
+    CoreV1Api,
+    NetworkingV1Api,
+    V1Affinity,
+    V1Container,
+    V1ContainerPort,
+    V1Deployment,
+    V1DeploymentSpec,
+    V1EnvVar,
+    V1EnvVarSource,
+    V1HTTPGetAction,
+    V1HTTPIngressPath,
+    V1HTTPIngressRuleValue,
+    V1Ingress,
+    V1IngressBackend,
+    V1IngressRule,
+    V1IngressServiceBackend,
+    V1IngressSpec,
+    V1IngressTLS,
+    V1LabelSelector,
+    V1LocalObjectReference,
+    V1NodeAffinity,
+    V1NodeSelector,
+    V1NodeSelectorRequirement,
+    V1NodeSelectorTerm,
+    V1ObjectMeta,
+    V1OwnerReference,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1Probe,
+    V1ResourceRequirements,
+    V1SecretKeySelector,
+    V1Service,
+    V1ServiceBackendPort,
+    V1ServicePort,
+    V1ServiceSpec,
+    V1Toleration,
+)
+from kubernetes_asyncio.client.api_client import ApiClient
+
+from crate.operator.constants import (
+    GRAND_CENTRAL_BACKEND_API_PORT,
+    GRAND_CENTRAL_RESOURCE_PREFIX,
+    LABEL_NAME,
+    SHARED_NODE_SELECTOR_KEY,
+    SHARED_NODE_SELECTOR_VALUE,
+    SHARED_NODE_TOLERATION_EFFECT,
+    SHARED_NODE_TOLERATION_KEY,
+    SHARED_NODE_TOLERATION_VALUE,
+    SYSTEM_USERNAME,
+)
+from crate.operator.utils import crate
+from crate.operator.utils.kopf import StateBasedSubHandler
+from crate.operator.utils.kubeapi import call_kubeapi
+from crate.operator.utils.typing import LabelType
+
+
+def get_grand_central_deployment(
+    owner_references: Optional[List[V1OwnerReference]],
+    name: str,
+    labels: LabelType,
+    image_pull_secrets: Optional[List[V1LocalObjectReference]],
+    spec: kopf.Spec,
+) -> V1Deployment:
+    env = [
+        V1EnvVar(name="CRATEDB_CENTER_CRATEDB_USERNAME", value=SYSTEM_USERNAME),
+        V1EnvVar(
+            name="CRATEDB_CENTER_CRATEDB_ADDRESS",
+            value=f"https://crate-discovery-{name}:4200",
+        ),
+        V1EnvVar(
+            name="CRATEDB_CENTER_USE_SSL",
+            value="true",
+        ),
+        V1EnvVar(
+            name="CRATEDB_CENTER_VERIFY_SSL",
+            value="false",
+        ),
+        V1EnvVar(name="CRATEDB_CENTER_CLUSTER_ID", value=name),
+        V1EnvVar(
+            name="CRATEDB_CENTER_JWK_ENDPOINT",
+            value=spec["grandCentral"]["jwkUrl"],
+        ),
+        V1EnvVar(
+            name="CRATEDB_CENTER_CRATEDB_PASSWORD",
+            value_from=V1EnvVarSource(
+                secret_key_ref=V1SecretKeySelector(
+                    key="password", name=f"user-system-{name}"
+                ),
+            ),
+        ),
+    ]
+    return V1Deployment(
+        metadata=V1ObjectMeta(
+            name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+            labels=labels,
+            owner_references=owner_references,
+        ),
+        spec=V1DeploymentSpec(
+            replicas=1,
+            selector=V1LabelSelector(
+                match_labels={
+                    LABEL_NAME: f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+                }
+            ),
+            template=V1PodTemplateSpec(
+                metadata=V1ObjectMeta(
+                    labels=labels,
+                    name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+                ),
+                spec=V1PodSpec(
+                    containers=[
+                        V1Container(
+                            env=env,
+                            image=spec["grandCentral"]["backendImage"],
+                            image_pull_policy="Always",
+                            name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-api",
+                            ports=[
+                                V1ContainerPort(
+                                    container_port=GRAND_CENTRAL_BACKEND_API_PORT,
+                                    name="grand-central",
+                                )
+                            ],
+                            resources=V1ResourceRequirements(
+                                limits={
+                                    "cpu": 2,
+                                    "memory": "512Mi",
+                                },
+                                requests={"cpu": "500m", "memory": "512Mi"},
+                            ),
+                            liveness_probe=V1Probe(
+                                http_get=V1HTTPGetAction(
+                                    path="/api/health",
+                                    port=GRAND_CENTRAL_BACKEND_API_PORT,
+                                ),
+                                initial_delay_seconds=180,
+                                period_seconds=10,
+                            ),
+                        )
+                    ],
+                    affinity=V1Affinity(
+                        node_affinity=V1NodeAffinity(
+                            required_during_scheduling_ignored_during_execution=V1NodeSelector(  # noqa
+                                node_selector_terms=[
+                                    V1NodeSelectorTerm(
+                                        match_expressions=[
+                                            V1NodeSelectorRequirement(
+                                                key=SHARED_NODE_SELECTOR_KEY,
+                                                operator="In",
+                                                values=[SHARED_NODE_SELECTOR_VALUE],
+                                            )
+                                        ]
+                                    )
+                                ]
+                            )
+                        )
+                    ),
+                    tolerations=[
+                        V1Toleration(
+                            effect=SHARED_NODE_TOLERATION_EFFECT,
+                            key=SHARED_NODE_TOLERATION_KEY,
+                            operator="Equal",
+                            value=SHARED_NODE_TOLERATION_VALUE,
+                        )
+                    ],
+                    image_pull_secrets=image_pull_secrets,
+                    restart_policy="Always",
+                ),
+            ),
+        ),
+    )
+
+
+def get_grand_central_service(
+    owner_references: Optional[List[V1OwnerReference]],
+    name: str,
+    labels: LabelType,
+) -> V1Service:
+    return V1Service(
+        metadata=V1ObjectMeta(
+            name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+            labels=labels,
+            owner_references=owner_references,
+        ),
+        spec=V1ServiceSpec(
+            type="ClusterIP",
+            ports=[
+                V1ServicePort(
+                    name="api",
+                    port=GRAND_CENTRAL_BACKEND_API_PORT,
+                    target_port=GRAND_CENTRAL_BACKEND_API_PORT,
+                ),
+            ],
+            selector={LABEL_NAME: f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}"},
+        ),
+    )
+
+
+async def read_grand_central_ingress(namespace: str, name: str) -> Optional[V1Ingress]:
+    async with ApiClient() as api_client:
+        networking = NetworkingV1Api(api_client)
+
+        ingresses = await networking.list_namespaced_ingress(namespace=namespace)
+        return next(
+            (
+                ing
+                for ing in ingresses.items
+                if ing.metadata.name == f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}"
+            ),
+            None,
+        )
+
+
+async def read_grand_central_deployment(
+    namespace: str, name: str
+) -> Optional[V1Deployment]:
+    async with ApiClient() as api_client:
+        apps = AppsV1Api(api_client)
+        deployments = await apps.list_namespaced_deployment(namespace=namespace)
+        return next(
+            (
+                deploy
+                for deploy in deployments.items
+                if deploy.metadata.name == f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}"
+            ),
+            None,
+        )
+
+
+def get_grand_central_ingress(
+    owner_references: Optional[List[V1OwnerReference]],
+    name: str,
+    labels: LabelType,
+    hostname: str,
+) -> V1Ingress:
+    return V1Ingress(
+        metadata=V1ObjectMeta(
+            name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+            labels=labels,
+            owner_references=owner_references,
+            annotations={
+                "external-dns.alpha.kubernetes.io/hostname": hostname,
+                "nginx.ingress.kubernetes.io/proxy-body-size": "1Gi",
+                "nginx.ingress.kubernetes.io/configuration-snippet": (
+                    """
+                    gzip on;
+                    gzip_types
+                        application/javascript
+                        text/javascript;
+                    more_set_headers "X-XSS-Protection: 1;mode=block"
+                                    "X-Frame-Options: DENY"
+                                    "X-Content-Type-Options: nosniff"
+                                    "Access-Control-Allow-Origin: $http_origin"
+                                    "Access-Control-Allow-Headers: Content-Type"
+                                    "Access-Control-Allow-Credentials: true"
+                                    "Access-Control-Max-Age: 7200"
+                                    "Access-Control-Allow-Methods: GET,POST,PATCH,OPTIONS,DELETE"
+                                    "Referrer-Policy: strict-origin-when-cross-origin"
+                                    ;
+                    """  # noqa
+                ),
+                "nginx.ingress.kubernetes.io/proxy-buffer-size": "64k",
+                "nginx.ingress.kubernetes.io/ssl-redirect": "true",
+            },
+        ),
+        spec=V1IngressSpec(
+            rules=[
+                V1IngressRule(
+                    host=hostname,
+                    http=V1HTTPIngressRuleValue(
+                        paths=[
+                            V1HTTPIngressPath(
+                                path="/api",
+                                path_type="ImplementationSpecific",
+                                backend=V1IngressBackend(
+                                    service=V1IngressServiceBackend(
+                                        port=V1ServiceBackendPort(
+                                            number=GRAND_CENTRAL_BACKEND_API_PORT,
+                                        ),
+                                        name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+                                    )
+                                ),
+                            ),
+                            V1HTTPIngressPath(
+                                path="/socket.io",
+                                path_type="ImplementationSpecific",
+                                backend=V1IngressBackend(
+                                    service=V1IngressServiceBackend(
+                                        port=V1ServiceBackendPort(
+                                            number=GRAND_CENTRAL_BACKEND_API_PORT,
+                                        ),
+                                        name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+                                    )
+                                ),
+                            ),
+                        ]
+                    ),
+                ),
+            ],
+            tls=[
+                V1IngressTLS(
+                    hosts=[hostname],
+                    secret_name="keystore-certificate-grandcentral-wildcard",
+                )
+            ],
+        ),
+    )
+
+
+async def create_grand_central_backend(
+    owner_references: Optional[List[V1OwnerReference]],
+    namespace: str,
+    name: str,
+    spec: kopf.Spec,
+    image_pull_secrets: Optional[List[V1LocalObjectReference]],
+    labels: LabelType,
+    hostname: str,
+    logger: logging.Logger,
+) -> None:
+    async with ApiClient() as api_client:
+        apps = AppsV1Api(api_client)
+        core = CoreV1Api(api_client)
+        networking = NetworkingV1Api(api_client)
+
+        await call_kubeapi(
+            apps.create_namespaced_deployment,
+            logger,
+            continue_on_conflict=True,
+            namespace=namespace,
+            body=get_grand_central_deployment(
+                owner_references,
+                name,
+                labels,
+                image_pull_secrets,
+                spec,
+            ),
+        )
+        await call_kubeapi(
+            core.create_namespaced_service,
+            logger,
+            continue_on_conflict=True,
+            namespace=namespace,
+            body=get_grand_central_service(owner_references, name, labels),
+        )
+        await call_kubeapi(
+            networking.create_namespaced_ingress,
+            logger,
+            continue_on_conflict=True,
+            namespace=namespace,
+            body=get_grand_central_ingress(owner_references, name, labels, hostname),
+        )
+
+
+async def update_grand_central_deployment_image(
+    namespace: str, name: str, image: str, logger: logging.Logger
+):
+    async with ApiClient() as api_client:
+        apps = AppsV1Api(api_client)
+        # This also runs on creation events, so we need to double check that the
+        # deployment exists before attempting to do anything.
+        deployments = await apps.list_namespaced_deployment(namespace=namespace)
+        deployment = next(
+            (
+                deploy
+                for deploy in deployments.items
+                if deploy.metadata.name == f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}"
+            ),
+            None,
+        )
+        if not deployment:
+            return
+
+        api_container: V1Container = next(
+            container
+            for container in deployment.spec.template.spec.containers
+            if container.name == f"{GRAND_CENTRAL_RESOURCE_PREFIX}-api"
+        )
+        api_container.image = image
+
+        await apps.patch_namespaced_deployment(
+            namespace=namespace,
+            name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+            body=deployment,
+        )
+
+
+class CreateGrandCentralBackendSubHandler(StateBasedSubHandler):
+    @crate.on.error(error_handler=crate.send_create_failed_notification)
+    async def handle(  # type: ignore
+        self,
+        namespace: str,
+        name: str,
+        spec: kopf.Spec,
+        owner_references: Optional[List[V1OwnerReference]],
+        image_pull_secrets: Optional[List[V1LocalObjectReference]],
+        grand_central_labels: LabelType,
+        grand_central_hostname: str,
+        logger: logging.Logger,
+        **_kwargs: Any,
+    ):
+        await create_grand_central_backend(
+            owner_references,
+            namespace,
+            name,
+            spec,
+            image_pull_secrets,
+            grand_central_labels,
+            grand_central_hostname,
+            logger,
+        )

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -31,6 +31,7 @@ from crate.operator.config import config
 from crate.operator.constants import (
     API_GROUP,
     CLUSTER_CREATE_ID,
+    GRAND_CENTRAL_RESOURCE_PREFIX,
     LABEL_COMPONENT,
     LABEL_MANAGED_BY,
     LABEL_NAME,
@@ -43,6 +44,7 @@ from crate.operator.create import (
     CreateStatefulsetSubHandler,
     CreateSystemUserSubHandler,
 )
+from crate.operator.grand_central import CreateGrandCentralBackendSubHandler
 from crate.operator.operations import get_master_nodes_names, get_total_nodes_count
 
 
@@ -229,4 +231,24 @@ async def create_cratedb(
                 ),
                 id="backup",
             )
+
+    if spec.get("grandCentral", {}).get("backendEnabled"):
+        grand_central_labels = base_labels.copy()
+        grand_central_labels[LABEL_COMPONENT] = "grand-central"
+        grand_central_labels[LABEL_NAME] = f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}"
+        grand_central_labels.update(meta.get("labels", {}))
+        external_dns = spec["cluster"]["externalDNS"]
+        grand_central_hostname = external_dns.replace(
+            cluster_name, f"{cluster_name}.gc"
+        ).rstrip(".")
+        kopf.register(
+            fn=CreateGrandCentralBackendSubHandler(namespace, name, hash, context)(
+                owner_references=owner_references,
+                image_pull_secrets=image_pull_secrets,
+                grand_central_labels=grand_central_labels,
+                grand_central_hostname=grand_central_hostname,
+            ),
+            id="grand_central",
+        )
+
     patch.status[CLUSTER_CREATE_ID] = context

--- a/crate/operator/handlers/handle_upgrade_grand_central.py
+++ b/crate/operator/handlers/handle_upgrade_grand_central.py
@@ -1,0 +1,43 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+import logging
+
+import kopf
+
+from crate.operator.grand_central import update_grand_central_deployment_image
+
+
+async def upgrade_grand_central(
+    namespace: str,
+    name: str,
+    diff: kopf.Diff,
+    logger: logging.Logger,
+    **_kwargs,
+):
+    if len(diff) == 0:
+        return
+
+    op: kopf.DiffItem = diff[0]
+
+    if not op.new:
+        return
+
+    await update_grand_central_deployment_image(namespace, name, op.new, logger)

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -51,6 +51,7 @@ from crate.operator.handlers.handle_update_cratedb import update_cratedb
 from crate.operator.handlers.handle_update_user_password_secret import (
     update_user_password_secret,
 )
+from crate.operator.handlers.handle_upgrade_grand_central import upgrade_grand_central
 from crate.operator.kube_auth import login_via_kubernetes_asyncio
 from crate.operator.operations import (
     is_namespace_terminating,
@@ -283,6 +284,27 @@ async def service_backup_schedule_update(
     """
     await raise_on_namespace_terminating(namespace)
     await update_backup_schedule(namespace, name, diff, logger)
+
+
+@kopf.on.field(
+    API_GROUP,
+    "v1",
+    RESOURCE_CRATEDB,
+    field="spec.grandCentral.backendImage",
+    annotations=annotation_filter(),
+)
+async def grand_central_upgrade(
+    namespace: str,
+    name: str,
+    diff: kopf.Diff,
+    logger: logging.Logger,
+    **_kwargs,
+):
+    """
+    Handles updates to the backend image of grand central.
+    """
+    await raise_on_namespace_terminating(namespace)
+    await upgrade_grand_central(namespace, name, diff, logger)
 
 
 @kopf.timer(

--- a/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
+++ b/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
@@ -415,6 +415,28 @@ spec:
                 - name
                 - version
                 type: object
+              grandCentral:
+                properties:
+                  backendImage:
+                    description: The image of the grand central backend.
+                    type: string
+                  backendEnabled:
+                    description: Flag indicating whether grand central backend is
+                      deployed for this cluster.
+                    type: boolean
+                  jwkUrl:
+                    description: The endpoint to retrieve the list of JWK public keys
+                      used for verifying JWT tokens.
+                    type: string
+                  apiUrl:
+                    description: The CrateDB Cloud API URL.
+                    type: string
+                required:
+                - backendImage
+                - jwkUrl
+                - apiUrl
+                - backendEnabled
+                type: object
               nodes:
                 properties:
                   data:

--- a/deploy/charts/crate-operator/templates/rbac.yaml
+++ b/deploy/charts/crate-operator/templates/rbac.yaml
@@ -31,11 +31,13 @@ rules:
   - apps
   - batch
   - policy
+  - networking.k8s.io
   resources:
   - configmaps
   - cronjobs
   - jobs
   - deployments
+  - ingresses
   - namespaces
   - persistentvolumeclaims
   - persistentvolumes

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -56,11 +56,13 @@ rules:
   - apps
   - batch
   - policy
+  - networking.k8s.io
   resources:
   - configmaps
   - cronjobs
   - jobs
   - deployments
+  - ingresses
   - namespaces
   - persistentvolumeclaims
   - persistentvolumes

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
             # Pinning this as 0.18 does not work
             "docutils==0.17.1",
             "Jinja2<3.1",
+            "alabaster==0.7.13",
         ],
         "testing": [
             "faker==18.3.1",


### PR DESCRIPTION
## Summary of changes
This adds an optional section `grandCentral` to the CrateDB CRD which (if configured) creates the resources (deployment, service, ingress) for grand-central backend when deploying a cluster. `grandCentral` section looks like this
```yaml
  grandCentral:
    backendImage: cloud.registry.cr8.net/crate/grand-central:latest
    backendEnabled: true
    apiUrl: https://console.cratedb-dev.cloud/
    jwkUrl: https://console.cratedb-dev.cloud/api/v2/meta/jwk/
```
https://github.com/crate/cloud/issues/1590

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
