### PR TITLE
Change the `crate` user HBA config to only allow access on the PG protocol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Change the `crate` user HBA config to only allow access on the PG protocol, while
+  we fix the crate vulnerability for the HTTP protocol.
+
 2.33.0 (2023-11-14)
 -------------------
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -420,6 +420,7 @@ def get_statefulset_crate_command(
         "-Cauth.host_based.config.0.user": "crate",
         "-Cauth.host_based.config.0.address": "_local_",
         "-Cauth.host_based.config.0.method": "trust",
+        "-Cauth.host_based.config.0.protocol": "pg",
         "-Cauth.host_based.config.99.method": "password",
         "-Cpath.data": ",".join(
             f"/data/data{i}" for i in range(node_spec["resources"]["disk"]["count"])


### PR DESCRIPTION
## Summary of changes

While we fix the crate vulnerability for the HTTP protocol.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
