### PR TITLE
Suspend and resume grand central Deployment when a cluster is suspended/resumed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
             # Pinning this as 0.18 does not work
             "docutils==0.17.1",
             "Jinja2<3.1",
+            "alabaster==0.7.13",
         ],
         "testing": [
             "faker==18.3.1",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,6 +41,7 @@ from crate.operator.constants import (
     API_GROUP,
     BACKUP_METRICS_DEPLOYMENT_NAME,
     DATA_NODE_NAME,
+    GRAND_CENTRAL_RESOURCE_PREFIX,
     KOPF_STATE_STORE_PREFIX,
     LABEL_COMPONENT,
     LABEL_MANAGED_BY,
@@ -482,3 +483,14 @@ async def does_backup_metrics_pod_exist(
     backup_metrics_pods = await get_pods_in_deployment(core, namespace, name)
     backup_metrics_name = BACKUP_METRICS_DEPLOYMENT_NAME.format(name=name)
     return any(p["name"].startswith(backup_metrics_name) for p in backup_metrics_pods)
+
+
+async def does_grand_central_pod_exist(
+    core: CoreV1Api, name: str, namespace: V1Namespace
+) -> bool:
+    pods = await get_pods_in_deployment(
+        core, namespace, f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}"
+    )
+    return any(
+        p["name"].startswith(f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}") for p in pods
+    )


### PR DESCRIPTION
## Summary of changes
- Suspend and resume grand central `Deployment` when a cluster is suspended/resumed
- Use the `system` user in gc to connect to crateDB
- Increased the initial delay to avoid crashes while crateDB is starting up
- Pinned `alabaster` version, because the latest does not work with our version of `Sphinx`

https://github.com/crate/cloud/issues/1619

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
