### PR TITLE
Limit system user login

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Unreleased
 
 * Added the Prometheus annotations to ``grandCentral`` to allow metrics scrapping on it.
 
-* system user login restricted to 10.0.0.0/8
+* Restricted system user login to 10.0.0.0/8
 
 
 2.33.0 (2023-11-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
 
 * Added the Prometheus annotations to ``grandCentral`` to allow metrics scrapping on it.
 
+* system user login restricted to 10.0.0.0/8
+
 
 2.33.0 (2023-11-14)
 -------------------

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -158,6 +158,9 @@ class Config:
     #: backup when restoring a snapshot.
     RESTORE_BACKUP_SECRET_NAME = "restore-from-backup-{name}"
 
+    #: CIDR the system user is allowed to login from.
+    ALLOWED_SYSTEM_USER_CIDR = "10.0.0.0/8"
+
     def __init__(self, *, prefix: str):
         self._prefix = prefix
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -421,7 +421,7 @@ def get_statefulset_crate_command(
         "-Cauth.host_based.config.0.address": "_local_",
         "-Cauth.host_based.config.0.method": "trust",
         "-Cauth.host_based.config.1.user": "system",
-        "-Cauth.host_based.config.1.address": "10.0.0.0/8",
+        "-Cauth.host_based.config.1.address": config.ALLOWED_SYSTEM_USER_CIDR,
         "-Cauth.host_based.config.99.method": "password",
         "-Cpath.data": ",".join(
             f"/data/data{i}" for i in range(node_spec["resources"]["disk"]["count"])

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -420,6 +420,8 @@ def get_statefulset_crate_command(
         "-Cauth.host_based.config.0.user": "crate",
         "-Cauth.host_based.config.0.address": "_local_",
         "-Cauth.host_based.config.0.method": "trust",
+        "-Cauth.host_based.config.1.user": "system",
+        "-Cauth.host_based.config.1.address": "10.0.0.0/8",
         "-Cauth.host_based.config.99.method": "password",
         "-Cpath.data": ",".join(
             f"/data/data{i}" for i in range(node_spec["resources"]["disk"]["count"])

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -118,6 +118,8 @@ async def update_cratedb(
             do_restart = True
         elif field_path == ("spec", "nodes", "master", "replicas"):
             do_scale = True
+        elif field_path == ("spec", "allowedSystemUserCIDR"):
+            do_restart = True
         elif field_path == ("spec", "nodes", "data"):
             for node_spec_idx in range(len(old_spec)):
                 old_spec = old_spec[node_spec_idx]

--- a/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
+++ b/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
@@ -173,6 +173,9 @@ spec:
                     items:
                       type: string
                     type: array
+                  allowedSystemUserCIDR:
+                    description: Limit system User to specific subnet
+                    type: string
                   externalDNS:
                     description: The external DNS name record that should point to
                       the CrateDB cluster.


### PR DESCRIPTION
## Summary of changes
~~Limit system user login to 10.0.0.0/8.~~

I assumed that the configuration snippet from below limits the  system  to login from 10.0.0.0/8 only. But it seems like the 99.method=password  spoils my plan!
```
 82     - -Cauth.host_based.enabled=true
 83     - -Cauth.host_based.config.0.user=crate
 84     - -Cauth.host_based.config.0.address=_local_
 85     - -Cauth.host_based.config.0.method=trust
 86     - -Cauth.host_based.config.1.user=system
 87     - -Cauth.host_based.config.1.address=10.0.0.0/8
 88     - -Cauth.host_based.config.1.method=password
 89     - -Cauth.host_based.config.99.method=password
 ```
 
In can see the real IP of the connection (=external IP) `system` can still login, due to the setting in _line 89_  where _password login from everywhere_ is allowed.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
