### PR TITLE
add timeout to cluster update handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 
 * Added the `Authorization` header to the allowed list for GC.
 
+* Moved cluster update timeout to the handlers level.
+
 2.34.1 (2024-02-06)
 -------------------
 
@@ -32,8 +34,6 @@ Unreleased
 * Implemented a handler allowing changing the ``backendImage`` of ``grandCentral``.
 
 * Added the Prometheus annotations to ``grandCentral`` to allow metrics scrapping on it.
-
-- Moved cluster update timeout to the handlers level.
 
 
 2.33.0 (2023-11-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Unreleased
 
 * Added the Prometheus annotations to ``grandCentral`` to allow metrics scrapping on it.
 
+- Moved cluster update timeout to the handlers level.
+
 
 2.33.0 (2023-11-14)
 -------------------

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -25,6 +25,7 @@ import kopf
 from kubernetes_asyncio.client import AppsV1Api
 from kubernetes_asyncio.client.api_client import ApiClient
 
+from crate.operator.config import config
 from crate.operator.create import (
     get_statefulset_affinity,
     get_statefulset_env_crate_heap,
@@ -41,6 +42,7 @@ from crate.operator.webhooks import (
 
 class ChangeComputeSubHandler(StateBasedSubHandler):
     @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(config.CLUSTER_UPDATE_TIMEOUT))
     async def handle(  # type: ignore
         self,
         namespace: str,

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -113,6 +113,12 @@ class Config:
     #: failed.
     RESTORE_BACKUP_TIMEOUT = 3600 * 24
 
+    #: Time in seconds for which the operator will continue and wait to perform
+    #: checks before and after a cluster update. Once the threshold has passed,
+    #: an update is considered failed.
+    BEFORE_UPDATE_TIMEOUT = 3600 * 24
+    AFTER_UPDATE_TIMEOUT = 3600
+
     #: Do not scale down cluster when performing storage expansion.
     #: The underlying infrastructure must support this - i.e. Azure or AWS CSI volumes.
     NO_DOWNTIME_STORAGE_EXPANSION: bool = False
@@ -292,6 +298,38 @@ class Config:
             raise ConfigurationError(
                 f"Invalid {self._prefix}SCALING_TIMEOUT="
                 f"'{scaling_timeout}'. Needs to be a positive integer or 0."
+            )
+
+        before_update_timeout = self.env(
+            "BEFORE_UPDATE_TIMEOUT", default=str(self.BEFORE_UPDATE_TIMEOUT)
+        )
+        try:
+            self.BEFORE_UPDATE_TIMEOUT = int(before_update_timeout)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}BEFORE_UPDATE_TIMEOUT="
+                f"'{before_update_timeout}'. Needs to be a positive integer or 0."
+            )
+        if self.BEFORE_UPDATE_TIMEOUT < 0:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}BEFORE_UPDATE_TIMEOUT="
+                f"'{before_update_timeout}'. Needs to be a positive integer or 0."
+            )
+
+        after_update_timeout = self.env(
+            "AFTER_UPDATE_TIMEOUT", default=str(self.AFTER_UPDATE_TIMEOUT)
+        )
+        try:
+            self.AFTER_UPDATE_TIMEOUT = int(after_update_timeout)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}AFTER_UPDATE_TIMEOUT="
+                f"'{after_update_timeout}'. Needs to be a positive integer or 0."
+            )
+        if self.AFTER_UPDATE_TIMEOUT < 0:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}AFTER_UPDATE_TIMEOUT="
+                f"'{after_update_timeout}'. Needs to be a positive integer or 0."
             )
 
         testing = self.env("TESTING", default=str(self.TESTING))

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -153,7 +153,6 @@ async def cluster_create(
     annotations=annotation_filter(),
 )
 @crate.on.error(error_handler=crate.send_update_failed_notification)
-@crate.timeout(timeout=float(config.CLUSTER_UPDATE_TIMEOUT))
 async def cluster_update(
     namespace: str,
     name: str,

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -933,6 +933,7 @@ CRONJOB_NAME = "cronjob_name"
 
 class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
     @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(config.BEFORE_UPDATE_TIMEOUT))
     async def handle(  # type: ignore
         self,
         namespace: str,
@@ -1082,6 +1083,7 @@ class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
 
 class AfterClusterUpdateSubHandler(StateBasedSubHandler):
     @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(config.AFTER_UPDATE_TIMEOUT))
     async def handle(  # type: ignore
         self,
         namespace: str,

--- a/crate/operator/upgrade.py
+++ b/crate/operator/upgrade.py
@@ -170,6 +170,7 @@ async def upgrade_cluster(
 
 class UpgradeSubHandler(StateBasedSubHandler):
     @crate.on.error(error_handler=crate.send_update_failed_notification)
+    @crate.timeout(timeout=float(config.CLUSTER_UPDATE_TIMEOUT))
     async def handle(  # type: ignore
         self,
         namespace: str,

--- a/crate/operator/utils/crate/on.py
+++ b/crate/operator/utils/crate/on.py
@@ -20,6 +20,7 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import logging
+from datetime import datetime
 from typing import Callable
 
 import kopf
@@ -91,7 +92,26 @@ def timeout(*, timeout: float) -> Callable:
     def decorator(fn: Callable) -> Callable:
         @wrapt.decorator
         async def _async_timeout(wrapped, instance, args, kwargs):
-            if kwargs["runtime"].total_seconds() >= timeout:
+            def _handler_has_timed_out_working(instance, timeout, kwargs) -> bool:
+                """
+                This checks the runtime of StateBasedSubHandlers based on the
+                real start time stored in `status.subhandlerStartedAt`.
+                """
+                if instance:
+                    now = int(datetime.utcnow().timestamp())
+                    runtime = 0
+                    status = (
+                        kwargs["status"]
+                        .get("subhandlerStartedAt", {})
+                        .get(instance.__class__.__name__)
+                    )
+                    if status and status.get("started"):
+                        runtime = now - status["started"]
+                    return runtime >= timeout
+                else:
+                    return kwargs["runtime"].total_seconds() >= timeout
+
+            if _handler_has_timed_out_working(instance, timeout, kwargs):
                 _handler = (
                     f"{instance.__class__.__name__}.{wrapped.__name__}"
                     if instance

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -76,7 +76,15 @@ async def test_upgrade_cluster_timeout(
             await handler._subhandler(
                 logger=logging.getLogger(__name__),
                 runtime=datetime.timedelta(seconds=runtime),
-                status={},
+                status={
+                    "subhandlerStartedAt": {
+                        "ActionSubhandler": {
+                            "started": int(datetime.datetime.utcnow().timestamp())
+                            - runtime,
+                            "ref": hash,
+                        }
+                    }
+                },
                 annotations={},
                 diff=(
                     kopf.DiffItem(
@@ -86,6 +94,7 @@ async def test_upgrade_cluster_timeout(
                         "4.6.4",
                     ),
                 ),
+                patch={},
             )
         await assert_wait_for(
             True,
@@ -113,8 +122,17 @@ async def test_upgrade_cluster_timeout(
         res = await handler._subhandler(
             logger=logging.getLogger(__name__),
             runtime=datetime.timedelta(seconds=runtime),
-            status={},
+            status={
+                "subhandlerStartedAt": {
+                    "ActionSubhandler": {
+                        "started": int(datetime.datetime.utcnow().timestamp())
+                        - runtime,
+                        "ref": hash,
+                    }
+                }
+            },
             annotations={},
+            patch={},
         )
         assert res["result"] == {"success": True}
 
@@ -274,6 +292,7 @@ async def test_get_action_for_diff(
     name = faker.domain_word()
     hash = faker.md5()
     namespace = faker.uuid4()
+    runtime = 30
 
     handler = ActionSubhandler(
         namespace,
@@ -285,9 +304,18 @@ async def test_get_action_for_diff(
         await handler._subhandler(
             logger=logging.getLogger(__name__),
             runtime=datetime.timedelta(seconds=30),
-            status={},
+            status={
+                "subhandlerStartedAt": {
+                    "ActionSubhandler": {
+                        "started": int(datetime.datetime.utcnow().timestamp())
+                        - runtime,
+                        "ref": hash,
+                    }
+                }
+            },
             annotations={},
             diff=(kopf.DiffItem(*diff_item),),
+            patch={},
         )
     await assert_wait_for(
         True,


### PR DESCRIPTION
## Summary of changes

Moved timeout handling from the main `cluster_update` handler to the individual subhandlers. Therefore it is necessary to store the timestamp when each subhandler really started working somewhere (in the status object in this case).
It has a better granularity and allows to have for example a timeout after 24h for the pre-upgrade tasks and I kept 2 hours for the upgrade itself).
Code based on https://github.com/crate/crate-operator/pull/473

https://github.com/crate/cloud/issues/1621

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
