### PR TITLE
Disallow rolling upgrades

### DIFF
--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -32,6 +32,7 @@ from kubernetes_asyncio.client import (
     V1ContainerPort,
     V1Deployment,
     V1DeploymentSpec,
+    V1DeploymentStrategy,
     V1EnvVar,
     V1EnvVarSource,
     V1HTTPGetAction,
@@ -134,6 +135,7 @@ def get_grand_central_deployment(
                     LABEL_NAME: f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
                 }
             ),
+            strategy=V1DeploymentStrategy(type="Recreate"),
             template=V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
                     annotations=annotations,


### PR DESCRIPTION
## Summary of changes

Grand Central has a scheduler running. The scheduler does not support sharing a job store, so we must wait for one GC to stop before starting another one.

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst` - no need, changes unreleased.
- [x] Added or changed code is covered by tests - implicitly
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
