### PR TITLE
Change pytest async mode to auto

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ line_length = 88
 multi_line_output = 3
 
 [tool:pytest]
-asyncio_mode = strict
+asyncio_mode = auto
 addopts = --strict-markers
 markers =
   k8s: marks test as integration test that requires Kubernetes setup


### PR DESCRIPTION
## Summary of changes

This way we do not have to use the annoying `@pytest.mark.asyncio` annotation everywhere.

## Checklist

- [ ] Relevant changes are reflected in `CHANGES.rst` -> no visible changes
- [x] Added or changed code is covered by tests 
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
