### PR TITLE
Fixed compatibility with CrateDB 5.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Fixed compatibility with CrateDB 5.6, which returns a slightly different version of
+  ``UserAlreadyExistsException`` (``RoleAlreadyExistsException``) and breaks bootstrap.
+
 2.34.0 (2024-02-05)
 -------------------
 

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -132,7 +132,7 @@ async def bootstrap_system_user(
         else:
             if "CREATE OK" in result:
                 logger.info("... success")
-            elif "UserAlreadyExistsException" in result:
+            elif "AlreadyExistsException" in result:
                 needs_update = True
                 logger.info("... success. Already present")
             else:


### PR DESCRIPTION
## Summary of changes

... which returns a slightly different version of `UserAlreadyExistsException` (`RoleAlreadyExistsException`) and breaks bootstrap.


## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
