### PR TITLE
Add grand central api url env var

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 * Updated user modification operations to leverage parameterized queries and
   ``curl``, replacing direct usage of ``crash``.
 
+* Added ``GRAND_CENTRAL_API_URL`` envvar required for sending webhooks.
+
 2.34.1 (2024-02-06)
 -------------------
 

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -111,6 +111,10 @@ def get_grand_central_deployment(
             value=spec["grandCentral"]["jwkUrl"],
         ),
         V1EnvVar(
+            name="GRAND_CENTRAL_API_URL",
+            value=spec["grandCentral"]["apiUrl"],
+        ),
+        V1EnvVar(
             name="GRAND_CENTRAL_CRATEDB_PASSWORD",
             value_from=V1EnvVarSource(
                 secret_key_ref=V1SecretKeySelector(


### PR DESCRIPTION
## Summary of changes
Add `GRAND_CENTRAL_API_URL` env var to the gc deployment, required for sending webhooks.
https://github.com/crate/cloud/issues/1606

## Checklist

- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
