### PR TITLE
Delayed cronjob re-enabling after cluster upgrade/resume

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Delayed cronjob re-enabling after upgrading or resuming a cluster.
+
 2.35.0 (2024-02-15)
 -------------------
 
@@ -37,7 +39,6 @@ Unreleased
 * Implemented a handler allowing changing the ``backendImage`` of ``grandCentral``.
 
 * Added the Prometheus annotations to ``grandCentral`` to allow metrics scrapping on it.
-
 
 2.33.0 (2023-11-14)
 -------------------

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -167,6 +167,9 @@ class Config:
     #: Grand Central Sentry DSN
     GC_SENTRY_DSN: Optional[str] = None
 
+    #: Delay before re-enabling cronjobs
+    RE_ENABLING_CRONJOB_DELAY = 3600
+
     def __init__(self, *, prefix: str):
         self._prefix = prefix
 
@@ -330,6 +333,22 @@ class Config:
             raise ConfigurationError(
                 f"Invalid {self._prefix}AFTER_UPDATE_TIMEOUT="
                 f"'{after_update_timeout}'. Needs to be a positive integer or 0."
+            )
+
+        re_enabling_cronjob_delay = self.env(
+            "RE_ENABLING_CRONJOB_DELAY", default=str(self.RE_ENABLING_CRONJOB_DELAY)
+        )
+        try:
+            self.RE_ENABLING_CRONJOB_DELAY = int(re_enabling_cronjob_delay)
+        except ValueError:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}RE_ENABLING_CRONJOB_DELAY="
+                f"'{re_enabling_cronjob_delay}'. Needs to be a positive integer or 0."
+            )
+        if self.RE_ENABLING_CRONJOB_DELAY < 0:
+            raise ConfigurationError(
+                f"Invalid {self._prefix}RE_ENABLING_CRONJOB_DELAY="
+                f"'{re_enabling_cronjob_delay}'. Needs to be a positive integer or 0."
             )
 
         testing = self.env("TESTING", default=str(self.TESTING))

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -58,6 +58,7 @@ from tests.utils import (
     does_grand_central_pod_exist,
     insert_test_snapshot_job,
     is_cluster_healthy,
+    is_cronjob_enabled,
     is_kopf_handler_finished,
     start_backup_metrics,
     start_cluster,
@@ -214,6 +215,7 @@ async def test_suspend_resume_cluster(
     apps = AppsV1Api(api_client)
     coapi = CustomObjectsApi(api_client)
     core = CoreV1Api(api_client)
+    batch = BatchV1Api(api_client)
     name = faker.domain_word()
 
     # Create a cluster with 1 node
@@ -360,6 +362,16 @@ async def test_suspend_resume_cluster(
         name,
         namespace.metadata.name,
         err_msg="Grand central has not been scaled up.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+
+    await assert_wait_for(
+        True,
+        is_cronjob_enabled,
+        batch,
+        namespace.metadata.name,
+        f"create-snapshot-{name}",
+        err_msg="The backup cronjob is disabled",
         timeout=DEFAULT_TIMEOUT,
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -494,3 +494,8 @@ async def does_grand_central_pod_exist(
     return any(
         p["name"].startswith(f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}") for p in pods
     )
+
+
+async def is_cronjob_enabled(batch: BatchV1Api, namespace: str, name: str) -> bool:
+    cronjob = await batch.read_namespaced_cron_job(namespace=namespace, name=name)
+    return cronjob.spec.suspend is False


### PR DESCRIPTION
## Summary of changes

The `AfterClusterUpdateSubHandler` is now split in two. The first one is as it used to be and the second one is to re-enable the cronjob.
This new handler is not added to the `depends_on` list because it can be delayed by 1h in some cases. It means that the success notification will be sent and the handler will be executed later (if an issue occur, the `error` decorator will do the trick). 
The delay is applied if `delay_cronjob=True` is in the status. It is set to True in the `upgrade` handler.


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1621
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
