### PR TITLE
Fix calculation of subhandler runtime

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 
 * Implemented a handler allowing installing ``grandCentral`` for existing clusters.
 
+* Fixed a bug that subhandlers were erroneously considered to be timed out.
+
 2.35.0 (2024-02-15)
 -------------------
 

--- a/crate/operator/utils/crate/on.py
+++ b/crate/operator/utils/crate/on.py
@@ -105,7 +105,12 @@ def timeout(*, timeout: float) -> Callable:
                         .get("subhandlerStartedAt", {})
                         .get(instance.__class__.__name__)
                     )
-                    if status and status.get("started"):
+                    # calculate runtime for the current execution run
+                    if (
+                        status
+                        and status.get("started")
+                        and status.get("ref") == getattr(instance, "ref", None)
+                    ):
                         runtime = now - status["started"]
                     return runtime >= timeout
                 else:


### PR DESCRIPTION
## Summary of changes
This fixes a bug that subhandlers were erroneously considered to be timed out because the check if a handler has timed out did not consider the handler's ref when fetching the start time. So e.g. operations like suspend/resume which both use the `ScaleSubHandler` were immediately marked as timed out and failed.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1692
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
