### PR TITLE
Added an init container for grand central

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,13 @@ Changelog
 Unreleased
 ----------
 
+* Added an init container for grand central, that explicitly waits for the associated
+  CrateDB to be started.
+
+* Changed the image pull policy for Grand Central to ``IfNotPresent``, there's no reason
+  to always pull.
+
+
 2.36.0 (2024-02-21)
 -------------------
 
@@ -13,6 +20,7 @@ Unreleased
 * Implemented a handler allowing installing ``grandCentral`` for existing clusters.
 
 * Fixed a bug that subhandlers were erroneously considered to be timed out.
+
 
 2.35.0 (2024-02-15)
 -------------------

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -164,11 +164,20 @@ def get_grand_central_deployment(
                     name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
                 ),
                 spec=V1PodSpec(
+                    init_containers=[
+                        V1Container(
+                            env=env,
+                            image=spec["grandCentral"]["backendImage"],
+                            image_pull_policy="IfNotPresent",
+                            name="wait-for-crate",
+                            command=["./wait-for-cratedb.py"],
+                        )
+                    ],
                     containers=[
                         V1Container(
                             env=env,
                             image=spec["grandCentral"]["backendImage"],
-                            image_pull_policy="Always",
+                            image_pull_policy="IfNotPresent",
                             name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-api",
                             ports=[
                                 V1ContainerPort(


### PR DESCRIPTION
## Summary of changes

... that explicitly waits for the associated CrateDB to be started.

:warning: requires latest grand central image.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1697
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
