### PR TITLE
Set a hard limit for max TCP connections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Set a hard limit for max TCP connections
+
+* Use a global Kubernetes API client.
+
 2.38.1 (2024-03-14)
 -------------------
 

--- a/crate/operator/backup.py
+++ b/crate/operator/backup.py
@@ -44,7 +44,6 @@ from kubernetes_asyncio.client import (
     V1SecretKeySelector,
 )
 from kubernetes_asyncio.client.api.batch_v1_api import BatchV1Api
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import (
@@ -54,6 +53,7 @@ from crate.operator.constants import (
     SYSTEM_USERNAME,
 )
 from crate.operator.utils import crate
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import call_kubeapi
 from crate.operator.utils.typing import LabelType
@@ -281,7 +281,7 @@ async def create_backups(
     logger: logging.Logger,
 ) -> None:
     backup_aws = backups.get("aws")
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         apps = AppsV1Api(api_client)
         batch = BatchV1Api(api_client)
         if backup_aws:
@@ -319,7 +319,7 @@ async def create_backups(
 
 
 async def update_backup_schedule_in_cronjob(namespace, name, new_value):
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
 
         patch = {"spec": {"schedule": new_value}}
 

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -26,13 +26,13 @@ from typing import Any, Dict, List, Optional
 from aiohttp.client_exceptions import WSServerHandshakeError
 from kopf import TemporaryError
 from kubernetes_asyncio.client import ApiException, CoreV1Api
-from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.stream import WsApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import CONNECT_TIMEOUT, GC_USERNAME, SYSTEM_USERNAME
 from crate.operator.cratedb import create_user, get_connection
 from crate.operator.utils import crate
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import (
     ensure_user_password_label,
@@ -301,7 +301,7 @@ class CreateUsersSubHandler(StateBasedSubHandler):
         logger: logging.Logger,
         **kwargs: Any,
     ):
-        async with ApiClient() as api_client:
+        async with GlobalApiClient() as api_client:
             core = CoreV1Api(api_client)
             await create_users(
                 core, namespace, name, master_node_pod, has_ssl, users, logger

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -23,7 +23,6 @@ from typing import Any
 
 import kopf
 from kubernetes_asyncio.client import AppsV1Api
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.create import (
@@ -32,6 +31,7 @@ from crate.operator.create import (
     get_tolerations,
 )
 from crate.operator.utils import crate
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.webhooks import (
     WebhookChangeComputePayload,
@@ -53,7 +53,7 @@ class ChangeComputeSubHandler(StateBasedSubHandler):
         **kwargs: Any,
     ):
         webhook_payload = generate_change_compute_payload(old, body)
-        async with ApiClient() as api_client:
+        async with GlobalApiClient() as api_client:
             apps = AppsV1Api(api_client)
             await change_cluster_compute(apps, namespace, name, webhook_payload, logger)
 

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -45,7 +45,6 @@ CLUSTER_CREATE_ID = "cluster_create"
 BACKUP_METRICS_DEPLOYMENT_NAME = "backup-metrics-{name}"
 DATA_NODE_NAME = "hot"
 DATA_PVC_NAME_PREFIX = "data"
-SQL_EXPORTER_CONFIGMAP_PREFIX = "crate-sql-exporter"
 
 SHARED_NODE_SELECTOR_KEY = "cratedb"
 SHARED_NODE_SELECTOR_VALUE = "shared"

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -76,7 +76,6 @@ from kubernetes_asyncio.client import (
     V1Volume,
     V1VolumeMount,
 )
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import (
@@ -98,6 +97,7 @@ from crate.operator.constants import (
 )
 from crate.operator.utils import crate, quorum
 from crate.operator.utils.formatting import b64encode, format_bitmath
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import call_kubeapi
 from crate.operator.utils.secrets import gen_password
@@ -160,7 +160,7 @@ async def create_sql_exporter_config(
     labels: LabelType,
     logger: logging.Logger,
 ) -> None:
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         core = CoreV1Api(api_client)
         await call_kubeapi(
             core.create_namespaced_config_map,
@@ -833,7 +833,7 @@ async def create_statefulset(
     image_pull_secrets: Optional[List[V1LocalObjectReference]],
     logger: logging.Logger,
 ) -> None:
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         apps = AppsV1Api(api_client)
         await call_kubeapi(
             apps.create_namespaced_stateful_set,
@@ -1003,7 +1003,7 @@ async def create_services(
     source_ranges: Optional[List[str]] = None,
     additional_annotations: Optional[Dict] = None,
 ) -> None:
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         core = CoreV1Api(api_client)
 
         # Create the load balancer service
@@ -1130,7 +1130,7 @@ async def create_system_user(
     cluster. For that, it will use a ``system`` user who's credentials are
     created here.
     """
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         core = CoreV1Api(api_client)
         await call_kubeapi(
             core.create_namespaced_secret,

--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -24,13 +24,13 @@ from typing import Any, Dict, List, Optional
 
 import kopf
 from kubernetes_asyncio.client import CoreV1Api
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import DATA_NODE_NAME, DATA_PVC_NAME_PREFIX
 from crate.operator.operations import get_pvcs_in_namespace
 from crate.operator.utils import crate
 from crate.operator.utils.formatting import convert_to_bytes
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.notifications import send_operation_progress_notification
 from crate.operator.webhooks import (
@@ -169,7 +169,7 @@ class ExpandVolumeSubHandler(StateBasedSubHandler):
                 logger.info("Ignoring operation %s on field %s", operation, field_path)
 
         if expand_data_diff_items:
-            async with ApiClient() as api_client:
+            async with GlobalApiClient() as api_client:
                 core = CoreV1Api(api_client)
 
                 await expand_volume(

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -63,7 +63,6 @@ from kubernetes_asyncio.client import (
     V1ServiceSpec,
     V1Toleration,
 )
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.bootstrap import bootstrap_gc_admin_user
 from crate.operator.config import config
@@ -83,6 +82,7 @@ from crate.operator.constants import (
     SHARED_NODE_TOLERATION_VALUE,
 )
 from crate.operator.create import get_gc_user_secret, get_owner_references
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kubeapi import call_kubeapi
 from crate.operator.utils.secrets import get_image_pull_secrets
 from crate.operator.utils.typing import LabelType
@@ -271,7 +271,7 @@ def get_grand_central_service(
 
 
 async def read_grand_central_ingress(namespace: str, name: str) -> Optional[V1Ingress]:
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         networking = NetworkingV1Api(api_client)
 
         ingresses = await networking.list_namespaced_ingress(namespace=namespace)
@@ -288,7 +288,7 @@ async def read_grand_central_ingress(namespace: str, name: str) -> Optional[V1In
 async def read_grand_central_deployment(
     namespace: str, name: str
 ) -> Optional[V1Deployment]:
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         apps = AppsV1Api(api_client)
         deployments = await apps.list_namespaced_deployment(namespace=namespace)
         return next(
@@ -395,7 +395,7 @@ async def create_grand_central_backend(
     hostname = external_dns.replace(cluster_name, f"{cluster_name}.gc").rstrip(".")
     labels = get_grand_central_labels(name, meta)
 
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         apps = AppsV1Api(api_client)
         core = CoreV1Api(api_client)
         networking = NetworkingV1Api(api_client)
@@ -438,7 +438,7 @@ async def create_grand_central_user(
     owner_references = get_owner_references(name, meta)
     labels = get_grand_central_labels(name, meta)
 
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         core = CoreV1Api(api_client)
 
         await call_kubeapi(
@@ -455,7 +455,7 @@ async def create_grand_central_user(
 async def update_grand_central_deployment_image(
     namespace: str, name: str, image: str, logger: logging.Logger
 ):
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         apps = AppsV1Api(api_client)
         # This also runs on creation events, so we need to double check that the
         # deployment exists before attempting to do anything.

--- a/crate/operator/handlers/handle_ping_cratedb_status.py
+++ b/crate/operator/handlers/handle_ping_cratedb_status.py
@@ -23,11 +23,10 @@ import logging
 
 import kopf
 from kubernetes_asyncio.client import CoreV1Api
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.cratedb import connection_factory, get_healthiness
-from crate.operator.operations import get_desired_nodes_count
 from crate.operator.prometheus import PrometheusClusterStatus, report_cluster_status
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kubeapi import get_host, get_system_user_password
 from crate.operator.webhooks import (
     WebhookClusterHealthPayload,
@@ -49,42 +48,42 @@ async def ping_cratedb_status(
     namespace: str,
     name: str,
     cluster_name: str,
+    desired_instances: int,
     patch: kopf.Patch,
     logger: logging.Logger,
 ) -> None:
-    desired_instances = await get_desired_nodes_count(namespace, name)
     # When the cluster is meant to be suspended do not ping it
     if desired_instances == 0:
         patch.status[CLUSTER_STATUS_KEY] = {"health": "SUSPENDED"}
         return
 
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         core = CoreV1Api(api_client)
         host = await get_host(core, namespace, name)
         password = await get_system_user_password(core, namespace, name)
-        conn_factory = connection_factory(host, password)
+    conn_factory = connection_factory(host, password)
 
-        try:
-            async with conn_factory() as conn:
-                async with conn.cursor() as cursor:
-                    healthiness = await get_healthiness(cursor)
-                    # If there are no tables in the cluster, get_healthiness returns
-                    # none: default to `Green`, as cluster is reachable
-                    status = HEALTHINESS_TO_STATUS.get(
-                        healthiness, PrometheusClusterStatus.GREEN
-                    )
-        except Exception as e:
-            logger.warning("Failed to ping cluster.", exc_info=e)
-            status = PrometheusClusterStatus.UNREACHABLE
+    try:
+        async with conn_factory() as conn:
+            async with conn.cursor() as cursor:
+                healthiness = await get_healthiness(cursor)
+                # If there are no tables in the cluster, get_healthiness returns
+                # none: default to `Green`, as cluster is reachable
+                status = HEALTHINESS_TO_STATUS.get(
+                    healthiness, PrometheusClusterStatus.GREEN
+                )
+    except Exception as e:
+        logger.warning("Failed to ping cluster.", exc_info=e)
+        status = PrometheusClusterStatus.UNREACHABLE
 
-        report_cluster_status(name, cluster_name, namespace, status)
-        patch.status[CLUSTER_STATUS_KEY] = {"health": status.name}
+    report_cluster_status(name, cluster_name, namespace, status)
+    patch.status[CLUSTER_STATUS_KEY] = {"health": status.name}
 
-        await webhook_client.send_notification(
-            namespace,
-            name,
-            WebhookEvent.HEALTH,
-            WebhookClusterHealthPayload(status=status.name),
-            WebhookStatus.SUCCESS,
-            logger,
-        )
+    await webhook_client.send_notification(
+        namespace,
+        name,
+        WebhookEvent.HEALTH,
+        WebhookClusterHealthPayload(status=status.name),
+        WebhookStatus.SUCCESS,
+        logger,
+    )

--- a/crate/operator/handlers/handle_update_allowed_cidrs.py
+++ b/crate/operator/handlers/handle_update_allowed_cidrs.py
@@ -24,10 +24,10 @@ import logging
 import kopf
 from kopf import DiffItem
 from kubernetes_asyncio.client import CoreV1Api, NetworkingV1Api
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.constants import GRAND_CENTRAL_RESOURCE_PREFIX
 from crate.operator.grand_central import read_grand_central_ingress
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.notifications import send_operation_progress_notification
 from crate.operator.webhooks import WebhookAction, WebhookOperation, WebhookStatus
 
@@ -51,7 +51,7 @@ async def update_service_allowed_cidrs(
         action=WebhookAction.ALLOWED_CIDR_UPDATE,
     )
 
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         core = CoreV1Api(api_client)
         networking = NetworkingV1Api(api_client)
         # This also runs on creation events, so we want to double check that the service

--- a/crate/operator/handlers/handle_update_user_password_secret.py
+++ b/crate/operator/handlers/handle_update_user_password_secret.py
@@ -24,11 +24,11 @@ import re
 
 import kopf
 from kubernetes_asyncio.client import CustomObjectsApi
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.constants import API_GROUP, RESOURCE_CRATEDB
 from crate.operator.update_user_password import update_user_password
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import subhandler_partial
 from crate.operator.utils.notifications import send_operation_progress_notification
 from crate.operator.webhooks import WebhookAction, WebhookOperation, WebhookStatus
@@ -53,7 +53,7 @@ async def update_user_password_secret(
         operation=WebhookOperation.UPDATE,
         action=WebhookAction.PASSWORD_UPDATE,
     )
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         coapi = CustomObjectsApi(api_client)
 
         for operation, field_path, old_value, new_value in diff:

--- a/crate/operator/prometheus.py
+++ b/crate/operator/prometheus.py
@@ -26,8 +26,10 @@ from typing import Optional
 
 from prometheus_client import REGISTRY, Info
 from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.metrics_core import CounterMetricFamily
 
 from crate.operator import __version__
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 
 i = Info("svc", "Service Info")
 i.info(
@@ -91,6 +93,25 @@ class ClusterCollector:
 
         yield cloud_clusters_health
         yield cloud_clusters_last_seen
+
+        k8s_api_sessions = GaugeMetricFamily(
+            "crate_operator_open_k8s_api_sessions",
+            "Number of sessions open to the k8s api",
+        )
+        k8s_api_sessions_created = CounterMetricFamily(
+            "crate_operator_k8s_api_sessions_created",
+            "Number of sessions open to the k8s api",
+        )
+        k8s_api_sessions_removed = CounterMetricFamily(
+            "crate_operator_k8s_api_sessions_removed",
+            "Number of sessions open to the k8s api",
+        )
+        k8s_api_sessions.add_metric([], GlobalApiClient.get_instance_count())
+        k8s_api_sessions_created.add_metric([], GlobalApiClient.get_created_instances())
+        k8s_api_sessions_removed.add_metric([], GlobalApiClient.get_removed_instances())
+        yield k8s_api_sessions
+        yield k8s_api_sessions_created
+        yield k8s_api_sessions_removed
 
 
 REGISTRY.register(ClusterCollector())

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -34,13 +34,13 @@ from kubernetes_asyncio.client import (
     V1StatefulSet,
     V1StatefulSetList,
 )
-from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.stream import WsApiClient
 
 from crate.operator.config import config
 from crate.operator.cratedb import connection_factory, is_cluster_healthy
 from crate.operator.operations import get_total_nodes_count, suspend_or_start_cluster
 from crate.operator.utils import crate, quorum
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import get_host, get_system_user_password
 from crate.operator.utils.notifications import send_operation_progress_notification
@@ -671,7 +671,7 @@ class ScaleSubHandler(StateBasedSubHandler):
             else:
                 logger.info("Ignoring operation %s on field %s", operation, field_path)
 
-        async with ApiClient() as api_client:
+        async with GlobalApiClient() as api_client:
             apps = AppsV1Api(api_client)
             core = CoreV1Api(api_client)
 

--- a/crate/operator/upgrade.py
+++ b/crate/operator/upgrade.py
@@ -25,12 +25,12 @@ from typing import Any, Dict, List
 
 import kopf
 from kubernetes_asyncio.client import AppsV1Api
-from kubernetes_asyncio.client.api_client import ApiClient
 
 from crate.operator.config import config
 from crate.operator.operations import get_total_nodes_count
 from crate.operator.scale import get_container
 from crate.operator.utils import crate, quorum
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.version import CrateVersion
 from crate.operator.webhooks import WebhookEvent, WebhookStatus, WebhookUpgradePayload
@@ -180,7 +180,7 @@ class UpgradeSubHandler(StateBasedSubHandler):
         logger: logging.Logger,
         **kwargs: Any,
     ):
-        async with ApiClient() as api_client:
+        async with GlobalApiClient() as api_client:
             apps = AppsV1Api(api_client)
             await upgrade_cluster(apps, namespace, name, body, old, logger)
 

--- a/crate/operator/utils/k8s_api_client.py
+++ b/crate/operator/utils/k8s_api_client.py
@@ -1,0 +1,40 @@
+import asyncio
+from typing import List
+
+from kubernetes_asyncio.client import ApiClient
+
+
+class GlobalApiClient(ApiClient):
+
+    _semaphore = asyncio.Semaphore(10)
+
+    _instance_track: List["GlobalApiClient"] = []
+    _instance_creation_track = 0
+    _instance_removal_track = 0
+
+    def __init__(self):
+        super().__init__()
+
+    @classmethod
+    def get_instance_count(cls):
+        return len(cls._instance_track)
+
+    @classmethod
+    def get_created_instances(cls):
+        return cls._instance_creation_track
+
+    @classmethod
+    def get_removed_instances(cls):
+        return cls._instance_removal_track
+
+    async def __aenter__(self):
+        await GlobalApiClient._semaphore.acquire()
+        GlobalApiClient._instance_track.append(self)
+        GlobalApiClient._instance_creation_track += 1
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        GlobalApiClient._semaphore.release()
+        GlobalApiClient._instance_track.remove(self)
+        GlobalApiClient._instance_removal_track += 1
+        await super().__aexit__(exc_type, exc_value, traceback)

--- a/crate/operator/webhooks.py
+++ b/crate/operator/webhooks.py
@@ -25,6 +25,7 @@ from typing import List, Optional, TypedDict
 
 import aiohttp
 import kopf
+from aiohttp import TCPConnector
 from pkg_resources import get_distribution
 
 from crate.operator.utils.crd import has_compute_changed
@@ -233,6 +234,7 @@ class WebhookClient:
             },
             auth=aiohttp.BasicAuth(username, password),
             raise_for_status=False,
+            connector=TCPConnector(limit=10),
         )
 
         self._configured = True
@@ -318,8 +320,7 @@ class WebhookClient:
             status,
         )
         try:
-            response = await self._session.post(self._url, json=payload)
-            async with response:
+            async with self._session.post(self._url, json=payload) as response:
                 response_text = await response.text()
                 response.raise_for_status()
         except aiohttp.ClientResponseError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ from kubernetes_asyncio.client.api_client import ApiClient
 from kubernetes_asyncio.config import load_kube_config
 
 from crate.operator.config import config
+from crate.operator.utils.k8s_api_client import GlobalApiClient
 
 from .utils import assert_wait_for, does_namespace_exist
 
@@ -133,7 +134,7 @@ async def kube_config(request, load_config):
 
 @pytest_asyncio.fixture(name="api_client")
 async def k8s_asyncio_api_client(kube_config) -> ApiClient:
-    async with ApiClient() as api_client:
+    async with GlobalApiClient() as api_client:
         yield api_client
 
 


### PR DESCRIPTION
## Summary of changes
- Share k8s api client and set a hard limit for max TCP connections
- Remove the `sql-exporter` configmap check on resume
- Remove requests to retrieve the sts and ns in the health pings

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1718
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
