### PR TITLE
Try to fix gc tests

### DIFF
--- a/tests/test_load_balancer_updates.py
+++ b/tests/test_load_balancer_updates.py
@@ -24,7 +24,6 @@ from unittest import mock
 import pytest
 from kubernetes_asyncio.client import CoreV1Api, CustomObjectsApi
 
-from crate.operator.utils.kubeapi import get_service_public_hostname
 from crate.operator.webhooks import (
     WebhookEvent,
     WebhookInfoChangedPayload,
@@ -52,8 +51,7 @@ async def test_get_external_ip(
     core = CoreV1Api(api_client)
     name = faker.domain_word()
 
-    await start_cluster(name, namespace, core, coapi, 1, wait_for_healthy=False)
-    ip = await get_service_public_hostname(core, namespace.metadata.name, name)
+    ip, _ = await start_cluster(name, namespace, core, coapi, 1, wait_for_healthy=False)
 
     await assert_wait_for(
         True,

--- a/tests/test_update_allowed_cidrs.py
+++ b/tests/test_update_allowed_cidrs.py
@@ -19,7 +19,6 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-import asyncio
 from unittest import mock
 
 import pytest
@@ -31,7 +30,6 @@ from crate.operator.constants import (
     RESOURCE_CRATEDB,
 )
 from crate.operator.grand_central import read_grand_central_ingress
-from crate.operator.utils.kubeapi import get_service_public_hostname
 from crate.operator.webhooks import (
     WebhookAction,
     WebhookEvent,
@@ -90,12 +88,6 @@ async def test_update_cidrs(
             "apiUrl": "https://my-cratedb-api.cloud/",
             "jwkUrl": "https://my-cratedb-api.cloud/api/v2/meta/jwk/",
         },
-    )
-
-    await asyncio.wait_for(
-        get_service_public_hostname(core, namespace.metadata.name, name),
-        # It takes a while to retrieve an external IP on AKS.
-        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     await assert_wait_for(


### PR DESCRIPTION
## Summary of changes
This fixes the failing tests when starting a cluster with gc enabled is blocked and hence timing out.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1724
- [ ] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
