### PR TITLE
Upgrade aiohttp to 3.9.5 for CVE-2024-30251

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 
 * Set an explicit ingress class for GC ingresses.
 
+* Bumped aiohttp to latest to fix CVE-2024-30251
+
 2.38.1 (2024-03-14)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "kubernetes-asyncio==21.7.1",
         "PyYAML<7.0",
         "prometheus_client==0.20.0",
-        "aiohttp==3.9.1",
+        "aiohttp==3.9.5",
         "wrapt==1.16.0",
     ],
     extras_require={


### PR DESCRIPTION
## Summary of changes
trivy scan was failing recently https://jenkins.crate.io/job/devops/job/docker-build-publish/4956//console

## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
