### PR TITLE
GC: increase memory to 256Mi and drop CPU limit to 500m

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ----------
+* Increase memory for grand central, reduce CPU limit.
 
 2.39.0 (2024-05-22)
 -------------------

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -192,10 +192,10 @@ def get_grand_central_deployment(
                             ],
                             resources=V1ResourceRequirements(
                                 limits={
-                                    "cpu": 2,
-                                    "memory": "150Mi",
+                                    "cpu": "500m",
+                                    "memory": "256Mi",
                                 },
-                                requests={"cpu": "100m", "memory": "150Mi"},
+                                requests={"cpu": "64m", "memory": "256Mi"},
                             ),
                             liveness_probe=V1Probe(
                                 http_get=V1HTTPGetAction(


### PR DESCRIPTION
## Summary of changes
We continue to see occasional crash due to OOMs especially on clusters with frequent scheduled jobs.
Also reduce CPU limit to 500m as we're too generous with 2 CPUs now.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1886
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
