### PR TITLE
Changed the CrateDB parameter node.attr.zone for AWS to support IMDSv2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 
 Unreleased
 ----------
+
 * Increase memory for grand central, reduce CPU limit.
+
+* Changed the ``node.attr.zone`` parameter for AWS to use IMDSv2.
 
 2.39.0 (2024-05-22)
 -------------------


### PR DESCRIPTION
## Summary of changes
Please note this branch does not disable the node.attr.zone as originally intended as a security mitigation, but rather
fixes the issue by adding support to AWS IMDSv2, which requires a token and a header in order to successfully perform
HTTP requests on the magic IP ``169.254.169.254``.

Also note the change made still supports IMDSv1, so a smooth transition in the infrastructure side can be done once all
CrateDB clusters have been patched.

Additionally, added a missing test for GCP for the ``node.attr.zone`` generation.

## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
