### PR TITLE
Add configuration for JWT authentication

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Added configuration for JWT authentication from CrateDB version 5.7.2 onwards.
+
 2.40.2 (2024-08-01)
 -------------------
 

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -207,7 +207,7 @@ async def bootstrap_gc_admin_user(core: CoreV1Api, namespace: str, name: str):
             password = await resolve_secret_key_ref(
                 core, namespace, {"key": "password", "name": f"user-gc-{name}"}
             )
-            await create_user(cursor, GC_USERNAME, password)
+            await create_user(cursor, namespace, name, GC_USERNAME, password)
 
 
 async def bootstrap_users(
@@ -239,7 +239,7 @@ async def bootstrap_users(
                 await ensure_user_password_label(
                     core, namespace, secret_key_ref["name"]
                 )
-                await create_user(cursor, username, password)
+                await create_user(cursor, namespace, name, username, password)
 
 
 async def create_users(

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -150,6 +150,9 @@ class Config:
     #: and `recover_after_nodes`
     GATEWAY_SETTINGS_DATA_NODES_VERSION: str = "4.7.0"
 
+    #: From which version onwards CrateDB supports JWT authentication
+    CRATEDB_JWT_AUTH_VERSION: str = "5.7.2"
+
     #: Interval in seconds for which the operator will ping CrateDBs for their
     #: current health.
     CRATEDB_STATUS_CHECK_INTERVAL: Optional[int] = 60

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -98,6 +98,7 @@ from crate.operator.constants import (
 )
 from crate.operator.utils import crate, quorum
 from crate.operator.utils.formatting import b64encode, format_bitmath
+from crate.operator.utils.jwt import crate_version_supports_jwt
 from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import call_kubeapi
@@ -454,6 +455,15 @@ def get_statefulset_crate_command(
                 "-Cssl.keystore_password": "${KEYSTORE_PASSWORD}",
                 "-Cssl.keystore_key_password": "${KEYSTORE_KEY_PASSWORD}",
                 "-Cauth.host_based.config.99.ssl": "on",
+            }
+        )
+
+    if crate_version_supports_jwt(crate_version):
+        settings.update(
+            {
+                "-Cauth.host_based.config.98.method": "jwt",
+                "-Cauth.host_based.config.98.protocol": "http",
+                "-Cauth.host_based.config.98.ssl": "on",
             }
         )
 

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -462,7 +462,7 @@ async def update_grand_central_deployment_image(
         # This also runs on creation events, so we need to double check that the
         # deployment exists before attempting to do anything.
         deployments = await apps.list_namespaced_deployment(namespace=namespace)
-        deployment = next(
+        deployment: V1Deployment = next(
             (
                 deploy
                 for deploy in deployments.items

--- a/crate/operator/handlers/handle_create_grand_central.py
+++ b/crate/operator/handlers/handle_create_grand_central.py
@@ -28,8 +28,8 @@ from crate.operator.grand_central import (
     create_grand_central_backend,
     create_grand_central_user,
 )
-from crate.operator.operations import get_cratedb_resource
 from crate.operator.utils.kopf import subhandler_partial
+from crate.operator.utils.kubeapi import get_cratedb_resource
 
 logger = logging.getLogger(__name__)
 

--- a/crate/operator/restore_backup.py
+++ b/crate/operator/restore_backup.py
@@ -26,10 +26,8 @@ import re
 from typing import Any, Dict, List, Optional
 
 import kopf
-from aiohttp.client_exceptions import WSServerHandshakeError
 from aiopg import Cursor
 from kubernetes_asyncio.client import ApiException, CoreV1Api, CustomObjectsApi
-from kubernetes_asyncio.stream import WsApiClient
 from psycopg2 import DatabaseError, ProgrammingError
 from psycopg2.errors import DuplicateTable
 from psycopg2.extensions import AsIs, QuotedString, quote_ident
@@ -48,13 +46,16 @@ from crate.operator.cratedb import (
     set_cluster_setting,
 )
 from crate.operator.operations import (
-    get_cratedb_resource,
+    get_crash_pod_name,
+    get_crash_scheme,
+    run_crash_command,
     scale_backup_metrics_deployment,
 )
 from crate.operator.utils import crate
 from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler, subhandler_partial
 from crate.operator.utils.kubeapi import (
+    get_cratedb_resource,
     get_host,
     get_system_user_password,
     resolve_secret_key_ref,
@@ -97,30 +98,6 @@ def is_valid_snapshot(new: kopf.Body, **kwargs) -> bool:
         return False
 
 
-def get_crash_pod_name(spec: dict, name: str) -> str:
-    """
-    Returns the pod name where crash commands should be run.
-
-    :param spec: The CrateDB custom resource definition.
-    :param name: The CrateDB custom resource name defining the CrateDB cluster.
-    """
-    has_master_nodes = "master" in spec["spec"]["nodes"]
-    if has_master_nodes:
-        return f"crate-master-{name}-0"
-    else:
-        node_name = spec["spec"]["nodes"]["data"][0]["name"]
-        return f"crate-data-{node_name}-{name}-0"
-
-
-def get_crash_scheme(spec: dict) -> str:
-    """
-    Return the host scheme for running crash commands.
-
-    :param spec: The CrateDB custom resource definition.
-    """
-    return "https" if "ssl" in spec["spec"]["cluster"] else "http"
-
-
 async def drop_repository(cursor: Cursor, repository: str, logger: logging.Logger):
     """
     Drops a backup repository if it exists.
@@ -139,63 +116,6 @@ async def drop_repository(cursor: Cursor, repository: str, logger: logging.Logge
             await cursor.execute(f"DROP REPOSITORY {repository_ident}")
     except ProgrammingError as e:
         logger.warning("Failed to drop repository", exc_info=e)
-
-
-async def run_crash_command(
-    namespace: str,
-    pod_name: str,
-    scheme: str,
-    command: str,
-    logger,
-    delay: int = CRASH_COMMAND_DELAY,
-):
-    """
-    This connects to a CrateDB pod and executes a crash command in the
-    ``crate`` container. It returns the result of the execution.
-
-    :param namespace: The Kubernetes namespace of the CrateDB cluster.
-    :param pod_name: The pod name where the command should be run.
-    :param scheme: The host scheme for running the command.
-    :param command: The SQL query that should be run.
-    :param logger: the logger on which we're logging
-    :param delay: Time in seconds between the retries when executing
-        the query.
-    """
-    async with WsApiClient() as ws_api_client:
-        core_ws = CoreV1Api(ws_api_client)
-        try:
-            exception_logger = logger.exception if config.TESTING else logger.error
-            crash_command = [
-                "crash",
-                "--verify-ssl=false",
-                f"--host={scheme}://localhost:4200",
-                "-c",
-                command,
-            ]
-            result = await core_ws.connect_get_namespaced_pod_exec(
-                namespace=namespace,
-                name=pod_name,
-                command=crash_command,
-                container="crate",
-                stderr=True,
-                stdin=False,
-                stdout=True,
-                tty=False,
-            )
-        except ApiException as e:
-            # We don't use `logger.exception()` to not accidentally include sensitive
-            # data in the log messages which might be part of the string
-            # representation of the exception.
-            exception_logger("... failed. Status: %s Reason: %s", e.status, e.reason)
-            raise kopf.TemporaryError(delay=delay)
-        except WSServerHandshakeError as e:
-            # We don't use `logger.exception()` to not accidentally include sensitive
-            # data in the log messages which might be part of the string
-            # representation of the exception.
-            exception_logger("... failed. Status: %s Message: %s", e.status, e.message)
-            raise kopf.TemporaryError(delay=delay)
-        else:
-            return result
 
 
 async def ensure_no_restore_in_progress(

--- a/crate/operator/utils/jwt.py
+++ b/crate/operator/utils/jwt.py
@@ -1,0 +1,28 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+
+from crate.operator.config import config
+from crate.operator.utils.version import CrateVersion
+
+
+def crate_version_supports_jwt(crate_version: str) -> bool:
+    return CrateVersion(crate_version) >= config.CRATEDB_JWT_AUTH_VERSION

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -63,7 +63,8 @@ from crate.operator.utils.kubeapi import (
 
 logger = logging.getLogger(__name__)
 
-CRATE_VERSION = "5.2.6"
+CRATE_VERSION = "5.6.5"
+CRATE_VERSION_WITH_JWT = "5.7.3"
 DEFAULT_TIMEOUT = 60
 
 


### PR DESCRIPTION
## Summary of changes
This change enables JWT authentication for crateDB version `5.7.2` and above

- adds the following settings to the crate command in the StatefulSet

```
                "-Cauth.host_based.config.98.method": "jwt",
                "-Cauth.host_based.config.98.protocol": "http",
                "-Cauth.host_based.config.98.ssl": "on",
```

- sets the JWT config for the `admin` user when a new cluster is deployed

- restricts access for the `admin` user to the `gc` schema

- updates the JWT config for the `admin` user after upgrading (or restoring a snapshot) to a version that supports JWT by running an `ALTER USER` with `crash`




## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1912
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
