### PR TITLE
TopologySpreadConstraints: add minDomains=3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Add ``minDomains`` to ``TopologySpreadConstraint`` to ensure that pods are spread across zones.
+
+* Upgrade ``kubernetes`` client to ``31.1.0`` to support ``TopologySpreadConstraint``.
+
 2.41.1 (2024-08-30)
 -------------------
 
@@ -14,8 +18,8 @@ Unreleased
 -------------------
 
 * Added configuration for JWT authentication from CrateDB version 5.7.2 onwards.
+
 * Bumped version of the JMX Exporter to ``1.2.0``
-* Add ``minDomains`` to ``TopologySpreadConstraint`` to ensure that pods are spread across zones.
 
 2.40.2 (2024-08-01)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
 
 * Added configuration for JWT authentication from CrateDB version 5.7.2 onwards.
 * Bumped version of the JMX Exporter to ``1.2.0``
+* Add ``minDomains`` to ``TopologySpreadConstraint`` to ensure that pods are spread across zones.
 
 2.40.2 (2024-08-01)
 -------------------

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -270,6 +270,7 @@ def get_topology_spread(
         topology_spread = [
             V1TopologySpreadConstraint(
                 max_skew=1,
+                min_domains=3,
                 topology_key="topology.kubernetes.io/zone",
                 when_unsatisfiable="DoNotSchedule",
                 label_selector=V1LabelSelector(

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,7 @@ setup(
         "aiopg==1.4.0",
         "bitmath==1.3.3.1",
         "kopf==1.35.6",
-        # Careful with 22+ - it is currently not compatible
-        # and results in various "permission denied" errors.
-        "kubernetes-asyncio==21.7.1",
+        "kubernetes-asyncio==31.1.0",
         "PyYAML<7.0",
         "prometheus_client==0.20.0",
         "aiohttp==3.10.5",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -144,7 +144,7 @@ async def test_bootstrap_users(
             mock.ANY,
         ),
         err_msg="Did not notify cluster creation status update.",
-        timeout=DEFAULT_TIMEOUT,
+        timeout=DEFAULT_TIMEOUT * 3,
     )
     await assert_wait_for(
         True,

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -341,6 +341,7 @@ class TestStatefulSetContainers:
         assert c_crate.image == "foo/bar:1.2.3"
         assert c_crate.name == "crate"
         assert c_crate.resources.to_dict() == {
+            "claims": None,
             "limits": {"cpu": str(cpus), "memory": memory},
             "requests": {"cpu": str(cpus), "memory": memory},
         }

--- a/tests/test_update_grand_central.py
+++ b/tests/test_update_grand_central.py
@@ -106,7 +106,7 @@ async def test_update_grand_central(
         namespace.metadata.name,
         "cloud.registry.cr8.net/crate/grand-central:latest",
         err_msg="Container image has not been updated.",
-        timeout=DEFAULT_TIMEOUT,
+        timeout=DEFAULT_TIMEOUT * 3,
     )
 
     await assert_wait_for(
@@ -117,7 +117,7 @@ async def test_update_grand_central(
         namespace.metadata.name,
         "cloud.registry.cr8.net/crate/grand-central:latest",
         err_msg="InitContainer image has not been updated.",
-        timeout=DEFAULT_TIMEOUT,
+        timeout=DEFAULT_TIMEOUT * 3,
     )
 
 

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -122,7 +122,7 @@ async def test_update_cluster_password(
             mock.ANY,
         ),
         err_msg="Did not notify cluster creation status update.",
-        timeout=DEFAULT_TIMEOUT,
+        timeout=DEFAULT_TIMEOUT * 3,
     )
 
     await core.patch_namespaced_secret(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -292,13 +292,19 @@ async def is_cluster_healthy(
 async def is_kopf_handler_finished(
     coapi: CustomObjectsApi, name, namespace: str, handler_name: str
 ):
-    cratedb = await coapi.get_namespaced_custom_object(
-        group=API_GROUP,
-        version="v1",
-        plural=RESOURCE_CRATEDB,
-        namespace=namespace,
-        name=name,
-    )
+    try:
+        cratedb = await coapi.get_namespaced_custom_object(
+            group=API_GROUP,
+            version="v1",
+            plural=RESOURCE_CRATEDB,
+            namespace=namespace,
+            name=name,
+        )
+    except Exception as e:
+        logger.error(
+            f"Error checking handler for '{name}' in namespace '{namespace}': {e}"
+        )
+        return False
 
     handler_status = cratedb["metadata"].get("annotations", {}).get(handler_name, None)
     return handler_status is None


### PR DESCRIPTION
## Summary of changes
This help Cluster Autoscaler to provision nodes in zones which are set to 0 nodes.

Require at least 3 nodes (as we have 3 zones)

https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/#kep-3022-min-domains-in-pod-topology-spread

Tested with https://gist.github.com/goat-ssh/612dc0e2931fd1889428cf18fb71b268 by scaling it to 3+ replicas afterwards

I've also upgraded the k8s client to latest and fixed a test.
 
## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2054 ; https://github.com/crate/cloud/issues/2069
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
