### PR TITLE
Fix password update for users with jwt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Fixed password update for users who have ``jwt`` configured.
+
 2.41.0 (2024-08-22)
 -------------------
 

--- a/tests/test_update_password.py
+++ b/tests/test_update_password.py
@@ -46,6 +46,7 @@ from crate.operator.webhooks import (
 )
 
 from .utils import (
+    CRATE_VERSION,
     DEFAULT_TIMEOUT,
     assert_wait_for,
     start_cluster,
@@ -182,12 +183,18 @@ async def test_update_cluster_password(
     )
 
 
+@mock.patch("crate.operator.update_user_password.get_cratedb_resource")
 @mock.patch("crate.operator.webhooks.webhook_client.send_notification")
 @mock.patch("kubernetes_asyncio.client.CoreV1Api.connect_get_namespaced_pod_exec")
 async def test_update_cluster_password_errors(
-    mock_pod_exec, mock_send_notification: mock.AsyncMock
+    mock_pod_exec,
+    mock_send_notification: mock.AsyncMock,
+    mock_get_cratedb_resource: mock.AsyncMock,
 ):
     mock_pod_exec.side_effect = Exception("test-exception")
+    mock_get_cratedb_resource.return_value = {
+        "spec": {"cluster": {"version": CRATE_VERSION}}
+    }
     with pytest.raises(Exception) as e:
         await update_user_password(
             namespace="a-namespace",


### PR DESCRIPTION
## Summary of changes
This is a workaround for updating user passwords for crateDB versions that support JWT authentication (>= `5.7.2`).

First, the user's JWT config is reset with `ALTER USER "{username}" SET (jwt = NULL);` and after that it is set back to what it was before (`iss` is retrieved from the CRD) together with the updated password.

For older crateDB versions the password update remains unchanged.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2080
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
