### PR TITLE
kubernetes-asyncio upgrade to 31.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Upgrade to kubernetes-asyncio 31.1.0
+
 2.41.1 (2024-08-30)
 -------------------
 

--- a/crate/operator/kube_auth.py
+++ b/crate/operator/kube_auth.py
@@ -41,6 +41,7 @@ async def login_via_kubernetes_asyncio(
     will be made to use that config file. In other cases, an in-cluster
     authentication will be tried.
     """
+
     if config.KUBECONFIG:
         logger.info("Authenticating with KUBECONFIG='%s'", config.KUBECONFIG)
         await load_kube_config(config_file=config.KUBECONFIG)
@@ -59,7 +60,7 @@ async def login_via_kubernetes_asyncio(
     # We need the actual auth-provider's token, so we call it instead of
     # accessing api_key.
     # Other keys (token, tokenFile) also end up being retrieved via this method.
-    header: Optional[str] = k8s_config.get_api_key_with_prefix("authorization")
+    header: Optional[str] = k8s_config.get_api_key_with_prefix("BearerToken")
     parts: Sequence[str] = header.split(" ", 1) if header else []
     scheme, token = (
         (None, None)

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,7 @@ setup(
         "aiopg==1.4.0",
         "bitmath==1.3.3.1",
         "kopf==1.35.6",
-        # Careful with 22+ - it is currently not compatible
-        # and results in various "permission denied" errors.
-        "kubernetes-asyncio==21.7.1",
+        "kubernetes-asyncio==31.1.0",
         "PyYAML<7.0",
         "prometheus_client==0.20.0",
         "aiohttp==3.10.5",

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -341,6 +341,7 @@ class TestStatefulSetContainers:
         assert c_crate.image == "foo/bar:1.2.3"
         assert c_crate.name == "crate"
         assert c_crate.resources.to_dict() == {
+            "claims": None,
             "limits": {"cpu": str(cpus), "memory": memory},
             "requests": {"cpu": str(cpus), "memory": memory},
         }


### PR DESCRIPTION
## Summary of changes
Upgrade kubernetes-asyncio to `31.1.0`.


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2069
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
