### PR TITLE
TopologySpreadConstraints: add minDomains=3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 * Upgrade to kubernetes-asyncio 31.1.0
 
+* Add ``minDomains`` to ``TopologySpreadConstraint`` to ensure that pods are spread across zones.
+
 2.41.1 (2024-08-30)
 -------------------
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -270,6 +270,7 @@ def get_topology_spread(
         topology_spread = [
             V1TopologySpreadConstraint(
                 max_skew=1,
+                min_domains=3,
                 topology_key="topology.kubernetes.io/zone",
                 when_unsatisfiable="DoNotSchedule",
                 label_selector=V1LabelSelector(


### PR DESCRIPTION
This help Cluster Autoscaler to provision nodes in zone which are set to 0 nodes.

Require at least 3 nodes (as we have 3 zones)

https://kubernetes.io/blog/2023/04/17/fine-grained-pod-topology-spread-features-beta/#kep-3022-min-domains-in-pod-topology-spread

## Summary of changes


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2069
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
