### PR TITLE
Fix JWT auth handlers for clusters without users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 
 * Add ``minDomains`` to ``TopologySpreadConstraint`` to ensure that pods are spread across zones.
 
+* Fixed JWT auth handlers for clusters without users.
+
 2.41.1 (2024-08-30)
 -------------------
 

--- a/crate/operator/cratedb.py
+++ b/crate/operator/cratedb.py
@@ -104,8 +104,8 @@ async def create_user(
     if not user_exists:
         query = f"CREATE USER {username_ident} WITH (password = %s"
         params = [password]
-        if crate_version_supports_jwt(crate_version):
-            iss = cratedb["spec"].get("grandCentral", {}).get("jwkUrl")
+        iss = cratedb["spec"].get("grandCentral", {}).get("jwkUrl")
+        if crate_version_supports_jwt(crate_version) and iss:
             query += ', jwt = {"iss" = %s, "username" = %s, "aud" = %s}'
             params.extend([iss, username, name])
 

--- a/crate/operator/update_user_password.py
+++ b/crate/operator/update_user_password.py
@@ -104,11 +104,10 @@ async def update_user_password(
 
     async with WsApiClient() as ws_api_client:
         core_ws = CoreV1Api(ws_api_client)
-        if crate_version_supports_jwt(crate_version):
+        iss = cratedb["spec"].get("grandCentral", {}).get("jwkUrl")
+        if crate_version_supports_jwt(crate_version) and iss:
             # For users with `jwt` and `password` set, we need to reset
             # `jwt` config first to be able to update the password.
-            iss = cratedb["spec"].get("grandCentral", {}).get("jwkUrl")
-
             command_reset_user_jwt = get_curl_command(
                 {
                     "stmt": 'ALTER USER "{}" SET (jwt = NULL)'.format(username),


### PR DESCRIPTION
## Summary of changes
This includes a fix for upgrades getting stuck on clusters without a `users` config. It also adds some checks that could potentially cause issues for clusters without `grandCentral`.

## Checklist

- [ ] Link to issue this PR refers to:
- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
