### PR TITLE
Update dependabot.yml to schedule monthly instead of weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: weekly
-    day: tuesday
+    interval: monthly
   open-pull-requests-limit: 10
   allow:
   - dependency-type: direct


### PR DESCRIPTION
## Summary of changes

To align with the schedule of other dependecy changes in other repos