### PR TITLE
CI: Update GHA configuration to also run on the `master` branch, and stacked PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,9 +1,10 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - master
+  push:
+    branches: [ master ]
+  pull_request: ~
+  workflow_dispatch:
 
 concurrency:
   cancel-in-progress: true


### PR DESCRIPTION
## About
Intended to toggle the badge on the Build Status page [^1] into green.

[^1]: https://cratedb.com/docs/crate/clients-tools/en/latest/status.html
