### PR TITLE
Documentation: Update Sphinx dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,12 +60,9 @@ setup(
     ],
     extras_require={
         "docs": [
-            "sphinx>=5,<7",
-            "sphinx-autodoc-typehints",
-            # Pinning this as 0.18 does not work
-            "docutils==0.17.1",
-            "Jinja2<3.1",
-            "alabaster==0.7.13",
+            "alabaster<2",
+            "sphinx>=5,<9",
+            "sphinx-autodoc-typehints<3",
         ],
         "testing": [
             "faker==18.3.1",


### PR DESCRIPTION
## About
Update package versions for Sphinx and friends.
Also, make them more lenient in order to support a broader range of Python versions.

## Preview
https://crate-operator--674.org.readthedocs.build/

## References
- GH-636
