### PR TITLE
Update cors annotations in grand-central ingress

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 
 * Bump ``sql_exporter`` to ``0.16.0``
 
+* Set CORS annotations in ``grand-central`` ingress.
+
 2.42.0 (2024-10-02)
 -------------------
 

--- a/tests/test_create_grand_central.py
+++ b/tests/test_create_grand_central.py
@@ -168,6 +168,32 @@ async def test_create_grand_central(faker, namespace, kopf_runner, api_client):
         ingress.metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
         == "my-crate-cluster.gc.aks1.eastus.azure.cratedb-dev.net"
     )
+    assert (
+        ingress.metadata.annotations[
+            "nginx.ingress.kubernetes.io/cors-allow-credentials"
+        ]
+        == "true"
+    )
+    assert (
+        ingress.metadata.annotations["nginx.ingress.kubernetes.io/enable-cors"]
+        == "true"
+    )
+    assert (
+        ingress.metadata.annotations["nginx.ingress.kubernetes.io/cors-allow-origin"]
+        == "$http_origin"
+    )
+    assert (
+        ingress.metadata.annotations["nginx.ingress.kubernetes.io/cors-allow-methods"]
+        == "GET,POST,PUT,PATCH,OPTIONS,DELETE"
+    )
+    assert (
+        ingress.metadata.annotations["nginx.ingress.kubernetes.io/cors-allow-headers"]
+        == "Content-Type,Authorization"
+    )
+    assert (
+        ingress.metadata.annotations["nginx.ingress.kubernetes.io/cors-max-age"]
+        == "7200"
+    )
 
     await assert_wait_for(
         True,


### PR DESCRIPTION
## Summary of changes
This change sets CORS annotations for ingress-nginx in the `grand-central` ingress to the same values we also use in the crate command in the StatefulSet. This is for
- dev: `https://console.cratedb-dev.cloud,http://localhost:8000`
- prod `https://console.cratedb.cloud`

## Checklist

- [x] Link to issue this PR refers to:https://github.com/crate/cloud/issues/1932
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
