### PR TITLE
Update `-Cprocessors` on scale compute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 
 * Set CORS annotations in ``grand-central`` ingress.
 
+* Update ``-CProccessors`` on scale compute.
+
 2.42.0 (2024-10-02)
 -------------------
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -156,10 +156,20 @@ async def start_cluster(
     }
 
     if resource_requests:
-        body["spec"]["nodes"]["data"][0]["resources"]["requests"] = {
-            "cpu": resource_requests["cpu"],
-            "memory": resource_requests["memory"],
-        }
+        if "limits" in resource_requests and "requests" in resource_requests:
+            body["spec"]["nodes"]["data"][0]["resources"]["limits"] = {
+                "cpu": resource_requests.get("limits", {}).get("cpu", "2"),
+                "memory": resource_requests.get("limits", {}).get("memory", "4Gi"),
+            }
+            body["spec"]["nodes"]["data"][0]["resources"]["requests"] = {
+                "cpu": resource_requests.get("requests", {}).get("cpu", "2"),
+                "memory": resource_requests.get("requests", {}).get("memory", "4Gi"),
+            }
+        else:
+            body["spec"]["nodes"]["data"][0]["resources"]["requests"] = {
+                "cpu": resource_requests.get("cpu", "2"),
+                "memory": resource_requests.get("memory", "4Gi"),
+            }
 
     if backups_spec:
         body["spec"]["backups"] = backups_spec


### PR DESCRIPTION
## Summary of changes
**Improve Resource Requests and Limits Handling** for `start_cluster` function. And also change the jvm `-CProcessor` setting which should reliably report the number of CPUs available in a docker environment. 

- **Updated `start_cluster` Function:**
  - Modified to accept both `resource_requests` and `resource_limits` as separate parameters.
  - Ensured proper handling and application of these resources when initializing clusters.

- **Refactored `utils.py`:**
  - Corrected conditional checks to accurately apply resource limits and requests.
  - Enhanced error handling for missing resource specifications.

- **Enhanced Test Cases in `test_change_compute.py`:**
  - Fixed asynchronous calls by properly awaiting the `start_cluster` coroutine, as the test now needs to pull in the crate container `commands` from the Statefulset.
  - Updated tests to verify that CPU and memory limits, requests and `-Cprocessors` are set correctly on scale compute.
  - Added assertions to ensure that resource configurations are applied as intended.

Thanks a lot to @Taliik for the help with the changes in the tests.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2277
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
