### PR TITLE
Quote schema and tables names in restore snapshot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Unreleased
 
 * Update ``-CProccessors`` on scale compute.
 
+* Added support for quoting schema and table names when generating the keyword
+  for restoring a snapshot.
+
 2.42.0 (2024-10-02)
 -------------------
 


### PR DESCRIPTION
## Summary of changes
This adds support for quoting schema and table names when generating the keyword for restoring a snapshot.

E.g. restoring a snapshot with `croud` and `... --type tables --tables doc.table-with-dashes,doc.my-table ...` results in `... TABLE "doc"."table-with-dashes","doc"."my-table" ...` in the generated command.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/1945
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
