### PR TITLE
Change sql_exporter min_interval

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Unreleased
 * Added support for quoting schema and table names when generating the keyword
   for restoring a snapshot.
 
+* Change sql_exporter ``min_interval`` to 60s to avoid scraping every 15s.
+
 2.42.0 (2024-10-02)
 -------------------
 

--- a/crate/operator/data/sql-exporter.yaml
+++ b/crate/operator/data/sql-exporter.yaml
@@ -9,7 +9,7 @@ global:
   # Maximum number of idle connections to any one target.
   max_idle_connections: 3
   # Minimum interval between collector runs: by default (0s) collectors are executed on every scrape.
-  min_interval: 0s
+  min_interval: 60s
   # Subtracted from Prometheus' scrape_timeout to give us some headroom and prevent Prometheus from
   # timing out first.
   scrape_timeout_offset: 500ms


### PR DESCRIPTION
## Summary of changes
`min_interval` set `0` runs the queries on every scrape. Setting it to `60s` avoids to run them too often and results are returned from cache.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2324
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
