### PR TITLE
Fixed get_cluster_admin_username when grand-central is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+- Fixed ``get_cluster_admin_username`` when grand-central is enabled.
+
 2.43.0 (2024-12-18)
 -------------------
 

--- a/crate/operator/cratedb.py
+++ b/crate/operator/cratedb.py
@@ -319,10 +319,12 @@ async def get_cluster_admin_username(conn_factory, logger) -> Optional[str]:
         async with conn.cursor() as cursor:
             try:
                 # Retrieve the admin username.
-                # It should be the only admin that was created by system.
+                # Except gc_admin, it should be the only admin that was created
+                # by system.
                 await cursor.execute(
                     "SELECT grantee FROM sys.privileges"
-                    " where grantor = 'system' limit 1"
+                    " where grantor = 'system'"
+                    f" and grantee != '{GC_USERNAME}' limit 1"
                 )
                 row = await cursor.fetchone()
                 return row[0] if row else None


### PR DESCRIPTION
## Summary of changes

`SELECT grantee FROM sys.privileges where grantor = 'system' limit 1`
has been replaced by
`SELECT grantee FROM sys.privileges where grantor = 'system' and grantee != '{GC_USERNAME}' limit 1"`
in order to never return the GC username instead of the admin one.

It will need to be changed in the future when some new roles will be added (e.g. `developer`, `viewer`, etc).

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2056
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
