### PR TITLE
Update nginx proxy-body-size annotation value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Unreleased
 ----------
 * Add preStop hook to the CrateDB pods to ensure that the CrateDB process is
   stopped gracefully.
-
+* Change nginx ``proxy-body-size`` annotation value as it has stricter validations now
 
 2.43.1 (2025-01-08)
 -------------------

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -320,7 +320,7 @@ def get_grand_central_ingress(
             owner_references=owner_references,
             annotations={
                 "external-dns.alpha.kubernetes.io/hostname": hostname,
-                "nginx.ingress.kubernetes.io/proxy-body-size": "1Gi",
+                "nginx.ingress.kubernetes.io/proxy-body-size": "1G",
                 "nginx.ingress.kubernetes.io/configuration-snippet": (
                     """
                     gzip on;


### PR DESCRIPTION
## Summary of changes
Newer versions of Nginx [1.12+](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.0) has annotation security checks enabled, and the [sizeRegex](https://github.com/kubernetes/ingress-nginx/blob/0374af94ef9cbf2b50aa57ae8ae68c7dbafec290/internal/ingress/annotations/parser/validators.go#L57) does not allow `i` in the value.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2378
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
