### PR TITLE
Update sql_exporter to 0.17.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 * Add preStop hook to the CrateDB pods to ensure that the CrateDB process is
   stopped gracefully.
 * Change nginx ``proxy-body-size`` annotation value as it has stricter validations now
+* Bump ``sql_exporter`` to ``0.17.0`` and fix ``cluster_last_user_activity`` NULL warning.
 
 2.43.1 (2025-01-08)
 -------------------

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -161,7 +161,7 @@ class Config:
     PROMETHEUS_PORT: int = 8080
 
     #: The sql_exporter image to use
-    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.16.0"
+    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.17.0"
 
     #: Name of the secret containing credentials to access the source
     #: backup when restoring a snapshot.

--- a/crate/operator/data/cratedb_cluster_last_user_activity-collector.yaml
+++ b/crate/operator/data/cratedb_cluster_last_user_activity-collector.yaml
@@ -6,7 +6,7 @@ metrics:
 - help: "Indicates when the last job occured on the cluster."
   metric_name: cratedb_cluster_last_user_activity
   query: |
-    SELECT cast(extract(epoch from max(ended)) as integer) AS cratedb_cluster_last_user_activity
+    SELECT COALESCE(cast(extract(epoch from max(ended)) as integer), 0) AS cratedb_cluster_last_user_activity
     FROM sys.jobs_log
     WHERE username NOT IN ('crate', 'system');
   type: gauge


### PR DESCRIPTION
Also fix warning about metric being NULL:

```
level=WARN source=query.go:226 msg="Value column is NULL" logContext="collector=cratedb_cluster_last_user_activity_collector,query=cratedb_cluster_last_user_activity" column=cratedb_cluster_last_user_activity-collector
```

## Summary of changes


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2402
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
