### PR TITLE
Switch to awk for zone and node name extraction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
   stopped gracefully.
 * Change nginx ``proxy-body-size`` annotation value as it has stricter validations now
 * Bump ``sql_exporter`` to ``0.17.0`` and fix ``cluster_last_user_activity`` NULL warning.
+* Switch to ``awk`` for zone and node name extraction.
 
 2.43.1 (2025-01-08)
 -------------------

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -430,7 +430,7 @@ class TestStatefulSetCrateCommand:
             crate_version="4.6.3",
         )
         assert (
-            f"-Cnode.name={crate_node_name_prefix}$(hostname | rev | cut -d- -f1 | rev)"
+            f"-Cnode.name={crate_node_name_prefix}$(hostname | awk -F- '{{print $NF}}')"
             in cmd
         )
         assert f"-Cnode.attr.node_name={node_name}" in cmd
@@ -661,7 +661,7 @@ class TestStatefulSetCrateCommand:
             (
                 CloudProvider.GCP,
                 "'http://169.254.169.254/computeMetadata/v1/instance/zone'",
-                " -H 'Metadata-Flavor: Google' | rev | cut -d '/' -f 1 | rev",
+                " -H 'Metadata-Flavor: Google' | awk -F'/' '{print $NF}'",
             ),
         ],
     )


### PR DESCRIPTION
## Summary of changes
With the move to AlmaLinux 10 base image the `rev` util is not present anymore.

## Checklist
- [x] Link to issue this PR refers to: https://github.com/crate/crate-operator/issues/710
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
