### PR TITLE
Increase backoff interval between watching requests

### DIFF
--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -98,12 +98,14 @@ async def startup(settings: kopf.OperatorSettings, **_kwargs):
     settings.watching.server_timeout = 300
     # Total number of seconds for a whole watch request per aiohttp:
     # https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout.total
-    settings.watching.client_timeout = 300
+    settings.watching.client_timeout = (
+        310  # slightly higher to avoid early disconnection
+    )
     # Timeout for attempting to connect to the peer per aiohttp:
     # https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout.sock_connect
     settings.watching.connect_timeout = 30
     # Wait for that many seconds between watching events
-    settings.watching.reconnect_backoff = 1
+    settings.watching.reconnect_backoff = 2.0
 
     # Only start the prometheus server in non-testing mode.
     if not config.TESTING:


### PR DESCRIPTION
## Summary of changes
Attempt to fix 429 TooManyRequests errors from the Kubernetes API. 

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2459
- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
