### PR TITLE
Enable global jwt settings in CrateDB 5.10.1+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Enabled global settings for JWT authentication from CrateDB version 5.10.1 onwards.
+
 2.44.0 (2025-02-17)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -153,6 +153,9 @@ class Config:
     #: From which version onwards CrateDB supports JWT authentication
     CRATEDB_JWT_AUTH_VERSION: str = "5.7.2"
 
+    #: From which version onwards CrateDB supports global JWT config
+    CRATEDB_JWT_GLOBAL_CONFIG_VERSION: str = "5.10.1"
+
     #: Interval in seconds for which the operator will ping CrateDBs for their
     #: current health.
     CRATEDB_STATUS_CHECK_INTERVAL: Optional[int] = 60

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -102,6 +102,7 @@ async def create_cratedb(
     treat_as_master = True
     cluster_name = spec["cluster"]["name"]
     source_ranges = spec["cluster"].get("allowedCIDRs", None)
+    cloud_settings = spec.get("grandCentral", {})
     kopf.register(
         fn=CreateSqlExporterConfigSubHandler(namespace, name, hash, context)(
             owner_references=owner_references, cratedb_labels=cratedb_labels
@@ -155,6 +156,7 @@ async def create_cratedb(
                 ssl=spec["cluster"].get("ssl"),
                 cluster_settings=spec["cluster"].get("settings"),
                 image_pull_secrets=image_pull_secrets,
+                cloud_settings=cloud_settings,
             ),
             id="statefulset_master",
         )
@@ -184,6 +186,7 @@ async def create_cratedb(
                 ssl=spec["cluster"].get("ssl"),
                 cluster_settings=spec["cluster"].get("settings"),
                 image_pull_secrets=image_pull_secrets,
+                cloud_settings=cloud_settings,
             ),
             id=f"statefulset_data_{node_name}",
         )

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -102,6 +102,7 @@ def test_patch_sts_command(total, quorum, new_total, new_quorum):
         is_master=True,
         is_data=True,
         crate_version="4.7.0",
+        cloud_settings={},
     )
     new_cmd = patch_command(cmd, new_total)
     assert f"-Cgateway.recover_after_data_nodes={new_quorum}" in new_cmd
@@ -128,6 +129,7 @@ def test_patch_sts_command_deprecated(total, quorum, new_total, new_quorum):
         is_master=True,
         is_data=True,
         crate_version="4.6.3",
+        cloud_settings={},
     )
     new_cmd = patch_command(cmd, new_total)
     assert f"-Cgateway.recover_after_nodes={new_quorum}" in new_cmd

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,6 +65,7 @@ logger = logging.getLogger(__name__)
 
 CRATE_VERSION = "5.6.5"
 CRATE_VERSION_WITH_JWT = "5.7.3"
+CRATE_VERSION_WITH_GLOBAL_JWT_CONFIG = "5.10.1"
 DEFAULT_TIMEOUT = 60
 
 


### PR DESCRIPTION
## Summary of changes
This ensures that default global JWT authentication settings are added to the CrateDB command when:

- Deploying new clusters with version >= `5.10.1`
- Upgrading existing clusters to CrateDB version >= `5.10.1`

https://cratedb.com/docs/crate/reference/en/master/config/node.html#jwt-defaults

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2244
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
