### PR TITLE
Update to Python 3.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.11"
 
 python:
   install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Updated Python version to ``3.11``.
+
 2.45.0 (2025-02-19)
 -------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM python:3.10-slim AS build
+FROM python:3.11-slim AS build
 
 RUN mkdir -pv /src
 
@@ -14,12 +14,12 @@ RUN python -m pip install -U setuptools==70.3.0 && \
 
 
 # Run container
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 LABEL license="Apache License 2.0" \
-      maintainer="Crate.IO GmbH <office@crate.io>" \
-      name="CrateDB Kubernetes Operator" \
-      repository="crate/crate-operator"
+    maintainer="Crate.IO GmbH <office@crate.io>" \
+    name="CrateDB Kubernetes Operator" \
+    repository="crate/crate-operator"
 
 WORKDIR /etc/cloud
 RUN useradd -U -M crate-operator

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -473,7 +473,7 @@ class Config:
             if default is UNDEFINED:
                 # raise from None - so that the traceback of the original
                 # exception (KeyError) is not printed
-                # https://docs.python.org/3.10/reference/simple_stmts.html#the-raise-statement
+                # https://docs.python.org/3.11/reference/simple_stmts.html#the-raise-statement
                 raise ConfigurationError(
                     f"Required environment variable '{full_name}' is not set."
                 ) from None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,6 +79,6 @@ intersphinx_mapping = {
     "bitmath": ("https://bitmath.readthedocs.io/en/stable/", None),
     "cratedb": ("https://crate.io/docs/crate/reference/en/stable/", None),
     "kopf": ("https://kopf.readthedocs.io/en/stable/", None),
-    "python": ("https://docs.python.org/3.10/", None),
+    "python": ("https://docs.python.org/3.11/", None),
 }
 always_document_param_types = True

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -4,7 +4,7 @@ Working on the operator
 Local installation
 ------------------
 
-The ``crate-operator`` package requires **Python 3.10**.
+The ``crate-operator`` package requires **Python 3.11**.
 
 It is recommended to use a virtual environment to the operator and its
 dependencies for local development.
@@ -17,7 +17,7 @@ dependencies for local development.
 
 .. code-block:: console
 
-   $ python3.10 -m venv env
+   $ python3.11 -m venv env
    $ source env/bin/activate
    (env)$ python -m pip install -e .
 
@@ -57,7 +57,7 @@ test dependencies. This is typically done inside a Python virtual environment:
 
 .. code-block:: console
 
-   $ python3.10 -m venv env
+   $ python3.11 -m venv env
    $ source env/bin/activate
    (env)$ python -m pip install -e '.[testing]'
    Successfully installed ... crate-operator ...


### PR DESCRIPTION
## Summary of changes
This PR upgrades Python to `3.11` to stay in line with the kopf `1.36.2` upgrade, which also moves to Python `3.11`
## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/crate-operator/issues/720
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
