### PR TITLE
Add translog size monitoring collector to sql_exporter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
   CrateDB resources after receiving a ``429 Too Many Requests`` response from the
   Kubernetes API.
 
+* Add collector for translog size monitoring to the sql_exporter.
+
 2.45.0 (2025-02-19)
 -------------------
 

--- a/crate/operator/data/cratedb_large_translogs-collector.yaml
+++ b/crate/operator/data/cratedb_large_translogs-collector.yaml
@@ -1,0 +1,15 @@
+---
+collector_name: cratedb_large_translogs_collector
+# Detect unusually large translogs. In these cases, upgrades
+# should only proceed in a controlled manner,
+# as they are likely to result in prolonged recovery times.
+metrics:
+- help: "Number of translogs larger than 1GB."
+  metric_name: cratedb_num_large_translogs
+  query: |-
+    SELECT COUNT(*) as cratedb_num_large_translogs
+    FROM sys.shards
+    where "translog_stats"['size'] > POWER(1024,3);
+  type: gauge
+  values: [cratedb_num_large_translogs]
+min_interval: 60m

--- a/crate/operator/data/sql-exporter.yaml
+++ b/crate/operator/data/sql-exporter.yaml
@@ -14,7 +14,7 @@ global:
   # timing out first.
   scrape_timeout_offset: 500ms
 target:
-  collectors: [responsivity_collector, cratedb_max_shards_collector, cratedb_cluster_last_user_activity_collector, cratedb_unreplicated_tables_collector]
+  collectors: [responsivity_collector, cratedb_max_shards_collector, cratedb_cluster_last_user_activity_collector, cratedb_unreplicated_tables_collector, cratedb_large_translogs_collector]
   # To test sql exporter against a local crateDB service you can add "&sslmode=disable" to the data_source_name.
   # Please do not use sslmode=disable in production as it hinders security.
   data_source_name: "postgres://crate@localhost:5432/?connect_timeout=5"


### PR DESCRIPTION
## Summary of changes
Implement logic to monitor shards with unexpectedly large translogs. By default, the [translog.flush_threshold_size](https://cratedb.com/docs/crate/reference/en/latest/sql/statements/create-table.html#translog-flush-threshold-size) is set to 512 MiB. Under normal operations, translogs should not grow (significantly) larger than this.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2318
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
