### PR TITLE
Downgrade Python to 3.12 due to SSL issues

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.13"
+    python: "3.12"
 
 python:
   install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Downgraded Python version from ``3.13`` to ``3.12`` to avoid SSL certificate
+  verification issues caused by stricter behavior in ``urllib3``, which is used
+  indirectly by project dependencies.
+
 2.47.0 (2025-05-12)
 -------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM python:3.13-slim AS build
+FROM python:3.12-slim AS build
 
 RUN mkdir -pv /src
 
@@ -14,7 +14,7 @@ RUN python -m pip install -U setuptools==70.3.0 && \
 
 
 # Run container
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 LABEL license="Apache License 2.0" \
     maintainer="Crate.IO GmbH <office@crate.io>" \

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -473,7 +473,7 @@ class Config:
             if default is UNDEFINED:
                 # raise from None - so that the traceback of the original
                 # exception (KeyError) is not printed
-                # https://docs.python.org/3.13/reference/simple_stmts.html#the-raise-statement
+                # https://docs.python.org/3.12/reference/simple_stmts.html#the-raise-statement
                 raise ConfigurationError(
                     f"Required environment variable '{full_name}' is not set."
                 ) from None

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,6 +80,6 @@ intersphinx_mapping = {
     "bitmath": ("https://bitmath.readthedocs.io/en/stable/", None),
     "cratedb": ("https://crate.io/docs/crate/reference/en/stable/", None),
     "kopf": ("https://kopf.readthedocs.io/en/stable/", None),
-    "python": ("https://docs.python.org/3.13/", None),
+    "python": ("https://docs.python.org/3.12/", None),
 }
 always_document_param_types = True

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -4,7 +4,7 @@ Working on the operator
 Local installation
 ------------------
 
-The ``crate-operator`` package requires **Python 3.13**.
+The ``crate-operator`` package requires **Python 3.12**.
 
 It is recommended to use a virtual environment to the operator and its
 dependencies for local development.
@@ -17,7 +17,7 @@ dependencies for local development.
 
 .. code-block:: console
 
-   $ python3.13 -m venv env
+   $ python3.12 -m venv env
    $ source env/bin/activate
    (env)$ python -m pip install -e .
 
@@ -57,7 +57,7 @@ test dependencies. This is typically done inside a Python virtual environment:
 
 .. code-block:: console
 
-   $ python3.13 -m venv env
+   $ python3.12 -m venv env
    $ source env/bin/activate
    (env)$ python -m pip install -e '.[testing]'
    Successfully installed ... crate-operator ...

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
     ],
     use_scm_version=True,
 )


### PR DESCRIPTION
## Summary of changes
This PR downgrades the project’s Python version from 3.13 to 3.12 to work around SSL certificate verification issues with AKS k8s API introduced in Python 3.13. The issue appears to stem from stricter behavior in urllib3, which is pulled in indirectly by dependencies

```
SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier
```

## Checklist

- [ ] Link to issue this PR refers to:
- [ ] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
