### PR TITLE
Increase timeouts for rolling restarts, scaling, and updates to 4h

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Unreleased
 
 * Added support to restore a snapshot from a Azure storage.
 
+* Increased rolling restart, scaling, and cluster update timeouts to 4 hours to support
+  longer node shutdown durations introduced by CrateDB decommissioning logic.
+
 2.47.1 (2025-05-14)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -88,19 +88,19 @@ class Config:
     #: Time in seconds for which the operator will continue and wait to perform
     #: a rolling restart of a cluster. Once this threshold has passed, a
     #: restart is considered failed.
-    ROLLING_RESTART_TIMEOUT = 3600
+    ROLLING_RESTART_TIMEOUT = 3600 * 4
 
     #: Time in seconds for which the operator will continue and wait to scale a
     #: cluster up or down, including deallocating nodes before turning them
     #: off. Once the threshold has passed, a scaling operation is considered
     #: failed.
-    SCALING_TIMEOUT = 3600
+    SCALING_TIMEOUT = 3600 * 4
 
     #: Time in seconds for which the operator will continue and wait to perform
     #: an update of a cluster, either scaling a cluster up or down or upgrading
     #: a cluster. Once this threshold has passed, an update is considered
     #: failed.
-    CLUSTER_UPDATE_TIMEOUT = 7200
+    CLUSTER_UPDATE_TIMEOUT = 3600 * 4
 
     #: Time in seconds for which the operator will continue and wait to perform
     #: a check if volume expansion has finished successfully. Once this threshold


### PR DESCRIPTION
## Summary of changes
With the introduction of CrateDB node decommissioning, node shutdown can take significantly longer. To prevent premature failure of rolling restarts or scaling operations, the following operator timeouts have been increased to 4 hours:

- `ROLLING_RESTART_TIMEOUT`
- `SCALING_TIMEOUT`
- `CLUSTER_UPDATE_TIMEOUT`

This ensures sufficient time for cluster operations that involve decommissioning nodes before shutdown, especially under higher load or larger cluster sizes.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2586
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
