### PR TITLE
Ensure operator overrides user-provided `managed-by` label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 
 * Bump ``sql_exporter`` to ``0.18.0``.
 
+* Always set ``app.kubernetes.io/managed-by`` to ``crate-operator`` to ensure the
+  operator can reliably identify CrateDB pods.
+
 2.48.0 (2025-06-10)
 -------------------
 

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -72,17 +72,18 @@ from crate.operator.constants import (
     GRAND_CENTRAL_INIT_CONTAINER,
     GRAND_CENTRAL_PROMETHEUS_PORT,
     GRAND_CENTRAL_RESOURCE_PREFIX,
-    LABEL_COMPONENT,
-    LABEL_MANAGED_BY,
     LABEL_NAME,
-    LABEL_PART_OF,
     SHARED_NODE_SELECTOR_KEY,
     SHARED_NODE_SELECTOR_VALUE,
     SHARED_NODE_TOLERATION_EFFECT,
     SHARED_NODE_TOLERATION_KEY,
     SHARED_NODE_TOLERATION_VALUE,
 )
-from crate.operator.create import get_gc_user_secret, get_owner_references
+from crate.operator.create import (
+    build_cratedb_labels,
+    get_gc_user_secret,
+    get_owner_references,
+)
 from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kubeapi import call_kubeapi
 from crate.operator.utils.secrets import get_image_pull_secrets
@@ -90,15 +91,12 @@ from crate.operator.utils.typing import LabelType
 
 
 def get_grand_central_labels(name: str, meta: kopf.Meta) -> Dict[str, Any]:
-    labels = {
-        LABEL_MANAGED_BY: "crate-operator",
-        LABEL_NAME: f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
-        LABEL_PART_OF: "cratedb",
-        LABEL_COMPONENT: "grand-central",
-    }
-    labels.update(meta.get("labels", {}))
-
-    return labels
+    return build_cratedb_labels(
+        name=name,
+        meta=meta,
+        component="grand-central",
+        label_name=f"{GRAND_CENTRAL_RESOURCE_PREFIX}-{name}",
+    )
 
 
 def get_grand_central_deployment(


### PR DESCRIPTION
## Summary of changes

This change ensures that the `app.kubernetes.io/managed-by` label is always set to `"crate-operator"`, even if a conflicting value is provided via the CrateDB CRD.

- Introduced `build_cratedb_labels()` helper function to standardize labels across CrateDB components.
- Replaced ad-hoc label dict creation in `handle_create_cratedb.py`, `grand_central.py`, and other places with calls to `build_cratedb_labels()`.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2654
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
