### PR TITLE
Detect and re-create tables during major version upgrades

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 Unreleased
 ----------
 
+* Detect tables that require re-indexing before performing a major version upgrade.
+
+* Automatically re-create internal system tables after completing a major version
+  upgrade.
+
 2.51.0 (2025-08-06)
 -------------------
 

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -67,6 +67,20 @@ DCUTIL_BASE_URL = (
 DCUTIL_BINARY = "dc_util-linux-amd64"
 DCUTIL_CHECKSUM = f"{DCUTIL_BINARY}.sha256"
 
+INTERNAL_TABLES = [
+    "gc.alembic_version",
+    "gc.scheduled_jobs_state",
+    "gc.scheduled_jobs_log",
+    "gc.scheduled_jobs",
+    "gc.jwt_refresh_token",
+]
+
+LUCENE_MIN_VERSION_MAP = {
+    5: "7.%",  # upgrading to CrateDB 5 - Lucene 7.x
+    6: "8.%",  # upgrading to CrateDB 6 - Lucene 8.x
+    7: "9.%",  # future: upgrading to CrateDB 7 - Lucene 9.x
+}
+
 
 class CloudProvider(str, enum.Enum):
     AWS = "aws"


### PR DESCRIPTION
## Summary of changes
This PR introduces additional safety checks and maintenance steps for major CrateDB version upgrades:
- Detection of tables requiring re-indexing
  - Before performing a major version upgrade, the operator now queries the cluster to detect tables that need re-indexing based on their Lucene version. The minimum required Lucene version is determined dynamically depending on the target CrateDB version. If such tables are found, the upgrade fails with a clear error message.

- Automatic re-creation of internal tables
  - After a successful major upgrade, internal CrateDB tables that may have been created with an older major version are automatically re-created to ensure compatibility and prevent warnings in the Admin UI, where internal tables would otherwise appear as needing re-indexing before the next major upgrade.


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2687
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
