### PR TITLE
Downgrade kopf due to compatibility issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Downgraded ``kopf`` to ``1.37.1`` due to compatibility issue.
+
 2.52.0 (2025-08-26)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "aiopg==1.4.0",
         "bitmath==1.3.3.1",
         "importlib-metadata; python_version<'3.8'",
-        "kopf==1.37.5",
+        "kopf==1.37.1",
         "kubernetes-asyncio==31.1.0",
         "PyYAML<7.0",
         "prometheus_client==0.22.1",


### PR DESCRIPTION
## Summary of changes
This PR downgrades `kopf` to `v1.37.1`. We are currently affected by a regression tracked in [nolar/kopf#1158](https://github.com/nolar/kopf/issues/1158). Until this issue is resolved upstream, our operator fails to run correctly on newer versions.

## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
