### PR TITLE
Upgrade SQL Exporter to 0.22.2- GHSA-xmrv-pmrh-hhx2 CVE-2026-34986

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Bumped sql_exporter to ``0.22.2`` - ``GHSA-xmrv-pmrh-hhx2`` and ``CVE-2026-34986``
+
 2.59.0 (2026-03-17)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -167,7 +167,7 @@ class Config:
     PROMETHEUS_PORT: int = 8080
 
     #: The sql_exporter image to use
-    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.20.0"
+    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.22.2"
 
     #: Name of the secret containing credentials to access the source
     #: backup when restoring a snapshot.


### PR DESCRIPTION
## Summary of changes

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2912
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
