### PR TITLE
First-class dedicated master node support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Unreleased
   on resume and stopped after them on suspend, and compute changes and volume
   expansion are applied to the master node group as well as the data nodes.
 
+* Excluded dedicated master nodes from the client-facing service. The load
+  balancer now only targets data nodes, so client traffic is never routed to a
+  ``node.data=false`` master. Master nodes remain in the headless discovery
+  service so the cluster still forms.
+
 * Webhook notifications now reflect dedicated master nodes: the scale webhook
   reports the effective master replica count (``0`` while suspended), the
   change-compute webhook includes master compute, and the storage-expansion

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,9 +11,6 @@ Unreleased
 * Made dedicated master nodes (``spec.nodes.master``) behave consistently
   across all cluster operations.
 
-* A compute change now performs a rolling restart of only the node groups whose
-  resources actually changed, instead of the whole cluster.
-
 2.61.0 (2026-06-02)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,25 +9,10 @@ Unreleased
   ``spec.cluster.exposure`` is set to ``traefik``.
 
 * Made dedicated master nodes (``spec.nodes.master``) behave consistently
-  across all cluster operations. Master nodes are now started before data nodes
-  on resume and stopped after them on suspend, and compute changes and volume
-  expansion are applied to the master node group as well as the data nodes.
-
-* Excluded dedicated master nodes from the client-facing service. The load
-  balancer now only targets data nodes, so client traffic is never routed to a
-  ``node.data=false`` master. Master nodes remain in the headless discovery
-  service so the cluster still forms.
-
-* Webhook notifications now reflect dedicated master nodes: the scale webhook
-  reports the effective master replica count (``0`` while suspended), the
-  change-compute webhook includes master compute, and the storage-expansion
-  feedback reports the new disk size per node group.
+  across all cluster operations.
 
 * A compute change now performs a rolling restart of only the node groups whose
-  resources actually changed, instead of the whole cluster. Changing just the
-  master group no longer restarts the data nodes; when several groups change at
-  once they are restarted one node at a time, masters first. Upgrades continue
-  to restart every node.
+  resources actually changed, instead of the whole cluster.
 
 2.61.0 (2026-06-02)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,16 @@ Unreleased
 * Replaced grand-central Ingress with HTTPRoute and Traefik Middlewares when
   ``spec.cluster.exposure`` is set to ``traefik``.
 
+* Made dedicated master nodes (``spec.nodes.master``) behave consistently
+  across all cluster operations. Master nodes are now started before data nodes
+  on resume and stopped after them on suspend, and compute changes and volume
+  expansion are applied to the master node group as well as the data nodes.
+
+* Webhook notifications now reflect dedicated master nodes: the scale webhook
+  reports the effective master replica count (``0`` while suspended), the
+  change-compute webhook includes master compute, and the storage-expansion
+  feedback reports the new disk size per node group.
+
 2.61.0 (2026-06-02)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ Unreleased
   change-compute webhook includes master compute, and the storage-expansion
   feedback reports the new disk size per node group.
 
+* A compute change now performs a rolling restart of only the node groups whose
+  resources actually changed, instead of the whole cluster. Changing just the
+  master group no longer restarts the data nodes; when several groups change at
+  once they are restarted one node at a time, masters first. Upgrades continue
+  to restart every node.
+
 2.61.0 (2026-06-02)
 -------------------
 

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -38,6 +38,7 @@ from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import get_cratedb_resource
 from crate.operator.webhooks import (
+    WebhookChangeComputeMasterFields,
     WebhookChangeComputePayload,
     WebhookEvent,
     WebhookStatus,
@@ -117,28 +118,28 @@ def compute_payload_for_specs(old_spec, new_spec) -> WebhookChangeComputePayload
     )
 
 
-def _master_compute_fields(old_master, new_master) -> dict:
+def _master_compute_fields(old_master, new_master) -> WebhookChangeComputeMasterFields:
     """
     The dedicated-master compute fields for the CHANGE_COMPUTE webhook, keyed
     with the ``*_master_*`` names. Empty for clusters without dedicated masters.
     """
     if old_master is None or new_master is None:
-        return {}
+        return WebhookChangeComputeMasterFields()
     p = compute_payload_for_specs(old_master, new_master)
-    return {
-        "old_master_cpu_limit": p["old_cpu_limit"],
-        "old_master_memory_limit": p["old_memory_limit"],
-        "old_master_cpu_request": p["old_cpu_request"],
-        "old_master_memory_request": p["old_memory_request"],
-        "old_master_heap_ratio": p["old_heap_ratio"],
-        "old_master_nodepool": p["old_nodepool"],
-        "new_master_cpu_limit": p["new_cpu_limit"],
-        "new_master_memory_limit": p["new_memory_limit"],
-        "new_master_cpu_request": p["new_cpu_request"],
-        "new_master_memory_request": p["new_memory_request"],
-        "new_master_heap_ratio": p["new_heap_ratio"],
-        "new_master_nodepool": p["new_nodepool"],
-    }
+    return WebhookChangeComputeMasterFields(
+        old_master_cpu_limit=p["old_cpu_limit"],
+        old_master_memory_limit=p["old_memory_limit"],
+        old_master_cpu_request=p["old_cpu_request"],
+        old_master_memory_request=p["old_memory_request"],
+        old_master_heap_ratio=p["old_heap_ratio"],
+        old_master_nodepool=p["old_nodepool"],
+        new_master_cpu_limit=p["new_cpu_limit"],
+        new_master_memory_limit=p["new_memory_limit"],
+        new_master_cpu_request=p["new_cpu_request"],
+        new_master_memory_request=p["new_memory_request"],
+        new_master_heap_ratio=p["new_heap_ratio"],
+        new_master_nodepool=p["new_nodepool"],
+    )
 
 
 def generate_change_compute_payload(old, body):
@@ -160,7 +161,7 @@ async def update_cprocessor_crate_settings(
     apps: AppsV1Api,
     namespace: str,
     sts_name: str,
-    processors: int,
+    processors: float,
 ) -> List[str]:
     """
     Call the Kubernetes API, update the -Cprocessors value in the crate
@@ -169,7 +170,8 @@ async def update_cprocessor_crate_settings(
     :param apps: An instance of the Kubernetes Apps V1 API.
     :param namespace: The Kubernetes namespace for the CrateDB cluster.
     :param sts_name: The name of the Kubernetes StatefulSet to update.
-    :param processors: The new number of processors.
+    :param processors: The new number of processors; fractional values are
+        rounded up (``ceil``) to match how create bakes ``-Cprocessors``.
     :return: The updated command list.
     """
     stateful_set = await apps.read_namespaced_stateful_set(

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -182,8 +182,6 @@ async def update_cprocessor_crate_settings(
             updated_command = []
             for cmd in container.command:
                 if cmd.startswith("-Cprocessors=") and processors is not None:
-                    # Round up to match create.py, which bakes -Cprocessors as
-                    # the rounded-up CPU limit.
                     updated_command.append(
                         f"-Cprocessors={math.ceil(float(processors))}"
                     )

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -31,9 +31,8 @@ from crate.operator.create import (
     get_statefulset_env_crate_heap,
     get_tolerations,
 )
-from crate.operator.operations import iter_node_groups
+from crate.operator.operations import iter_changed_compute_groups
 from crate.operator.utils import crate
-from crate.operator.utils.crd import has_compute_changed
 from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import get_cratedb_resource
@@ -209,13 +208,7 @@ async def change_cluster_compute(
     dedicated masters and/or any data group -- each with its own resources.
     Pods pick up the new cpu/memory on the subsequent restart.
     """
-    old_groups = {g.name: g for g in iter_node_groups(old["spec"]["nodes"])}
-
-    for group in iter_node_groups(body["spec"]["nodes"]):
-        old_group = old_groups.get(group.name)
-        if old_group is None or not has_compute_changed(old_group.spec, group.spec):
-            continue
-
+    for old_group, group in iter_changed_compute_groups(old, body):
         sts_name = group.statefulset_name(name)
         compute_change_data = compute_payload_for_specs(old_group.spec, group.spec)
         patch = await generate_body_patch(

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -117,12 +117,43 @@ def compute_payload_for_specs(old_spec, new_spec) -> WebhookChangeComputePayload
     )
 
 
+def _master_compute_fields(old_master, new_master) -> dict:
+    """
+    The dedicated-master compute fields for the CHANGE_COMPUTE webhook, keyed
+    with the ``*_master_*`` names. Empty for clusters without dedicated masters.
+    """
+    if old_master is None or new_master is None:
+        return {}
+    p = compute_payload_for_specs(old_master, new_master)
+    return {
+        "old_master_cpu_limit": p["old_cpu_limit"],
+        "old_master_memory_limit": p["old_memory_limit"],
+        "old_master_cpu_request": p["old_cpu_request"],
+        "old_master_memory_request": p["old_memory_request"],
+        "old_master_heap_ratio": p["old_heap_ratio"],
+        "old_master_nodepool": p["old_nodepool"],
+        "new_master_cpu_limit": p["new_cpu_limit"],
+        "new_master_memory_limit": p["new_memory_limit"],
+        "new_master_cpu_request": p["new_cpu_request"],
+        "new_master_memory_request": p["new_memory_request"],
+        "new_master_heap_ratio": p["new_heap_ratio"],
+        "new_master_nodepool": p["new_nodepool"],
+    }
+
+
 def generate_change_compute_payload(old, body):
-    # The webhook payload still reports the first data group's compute; emitting
-    # master compute is a separate (billing) concern, handled in TB/B2.
-    return compute_payload_for_specs(
+    # Reports the first data group's compute plus, additively, the dedicated
+    # masters' compute (so billing sees master compute changes too).
+    payload = compute_payload_for_specs(
         old["spec"]["nodes"]["data"][0], body["spec"]["nodes"]["data"][0]
     )
+    payload.update(
+        _master_compute_fields(
+            old["spec"]["nodes"].get("master"),
+            body["spec"]["nodes"].get("master"),
+        )
+    )
+    return payload
 
 
 async def update_cprocessor_crate_settings(

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -19,7 +19,8 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 import logging
-from typing import Any, List
+import math
+from typing import Any, List, Optional
 
 import kopf
 from kubernetes_asyncio.client import AppsV1Api
@@ -30,7 +31,9 @@ from crate.operator.create import (
     get_statefulset_env_crate_heap,
     get_tolerations,
 )
+from crate.operator.operations import iter_node_groups
 from crate.operator.utils import crate
+from crate.operator.utils.crd import has_compute_changed
 from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler
 from crate.operator.utils.kubeapi import get_cratedb_resource
@@ -56,7 +59,7 @@ class ChangeComputeSubHandler(StateBasedSubHandler):
         webhook_payload = generate_change_compute_payload(old, body)
         async with GlobalApiClient() as api_client:
             apps = AppsV1Api(api_client)
-            await change_cluster_compute(apps, namespace, name, webhook_payload, logger)
+            await change_cluster_compute(apps, namespace, name, old, body, logger)
 
         await self.send_notification_now(
             logger,
@@ -89,24 +92,36 @@ class AfterChangeComputeSubHandler(StateBasedSubHandler):
         )
 
 
-def generate_change_compute_payload(old, body):
-    old_data = old["spec"]["nodes"]["data"][0]
-    new_data = body["spec"]["nodes"]["data"][0]
-    old_resources = old_data.get("resources", {})
-    new_resources = new_data.get("resources", {})
+def compute_payload_for_specs(old_spec, new_spec) -> WebhookChangeComputePayload:
+    """
+    Build a compute-change payload from a single node group's old/new specs.
+    The same StatefulSet patch is derived from this payload for masters and
+    data groups alike (resources are read per group, since master CPU/mem may
+    differ from data).
+    """
+    old_resources = old_spec.get("resources", {})
+    new_resources = new_spec.get("resources", {})
     return WebhookChangeComputePayload(
         old_cpu_limit=old_resources.get("limits", {}).get("cpu"),
         old_memory_limit=old_resources.get("limits", {}).get("memory"),
         old_cpu_request=old_resources.get("requests", {}).get("cpu"),
         old_memory_request=old_resources.get("requests", {}).get("memory"),
         old_heap_ratio=old_resources.get("heapRatio"),
-        old_nodepool=old_data.get("nodepool"),
+        old_nodepool=old_spec.get("nodepool"),
         new_cpu_limit=new_resources.get("limits", {}).get("cpu"),
         new_memory_limit=new_resources.get("limits", {}).get("memory"),
         new_cpu_request=new_resources.get("requests", {}).get("cpu"),
         new_memory_request=new_resources.get("requests", {}).get("memory"),
         new_heap_ratio=new_resources.get("heapRatio"),
-        new_nodepool=new_data.get("nodepool"),
+        new_nodepool=new_spec.get("nodepool"),
+    )
+
+
+def generate_change_compute_payload(old, body):
+    # The webhook payload still reports the first data group's compute; emitting
+    # master compute is a separate (billing) concern, handled in TB/B2.
+    return compute_payload_for_specs(
+        old["spec"]["nodes"]["data"][0], body["spec"]["nodes"]["data"][0]
     )
 
 
@@ -135,7 +150,11 @@ async def update_cprocessor_crate_settings(
             updated_command = []
             for cmd in container.command:
                 if cmd.startswith("-Cprocessors=") and processors is not None:
-                    updated_command.append(f"-Cprocessors={processors}")
+                    # Round up to match create.py, which bakes -Cprocessors as
+                    # the rounded-up CPU limit.
+                    updated_command.append(
+                        f"-Cprocessors={math.ceil(float(processors))}"
+                    )
                 else:
                     updated_command.append(cmd)
             container.command = updated_command
@@ -148,23 +167,32 @@ async def change_cluster_compute(
     apps: AppsV1Api,
     namespace: str,
     name: str,
-    compute_change_data: WebhookChangeComputePayload,
+    old: kopf.Body,
+    body: kopf.Body,
     logger: logging.Logger,
 ):
     """
-    Patches the statefulset with the new cpu and memory requests and limits.
+    Patch the StatefulSet of every node group whose compute changed -- the
+    dedicated masters and/or any data group -- each with its own resources.
+    Pods pick up the new cpu/memory on the subsequent restart.
     """
-    body = await generate_body_patch(apps, name, namespace, compute_change_data, logger)
+    old_groups = {g.name: g for g in iter_node_groups(old["spec"]["nodes"])}
 
-    # Note only the stateful set is updated. Pods will become updated on restart
-    sts_name = f"crate-data-hot-{name}"
-    await apps.patch_namespaced_stateful_set(
-        namespace=namespace,
-        name=sts_name,
-        body=body,
-    )
-    logger.info("updated the statefulset with name %s with body: %s", sts_name, body)
-    pass
+    for group in iter_node_groups(body["spec"]["nodes"]):
+        old_group = old_groups.get(group.name)
+        if old_group is None or not has_compute_changed(old_group.spec, group.spec):
+            continue
+
+        sts_name = group.statefulset_name(name)
+        compute_change_data = compute_payload_for_specs(old_group.spec, group.spec)
+        patch = await generate_body_patch(
+            apps, name, namespace, compute_change_data, logger, sts_name=sts_name
+        )
+        # Note only the stateful set is updated. Pods are updated on restart.
+        await apps.patch_namespaced_stateful_set(
+            namespace=namespace, name=sts_name, body=patch
+        )
+        logger.info("updated the statefulset %s with body: %s", sts_name, patch)
 
 
 async def generate_body_patch(
@@ -173,24 +201,28 @@ async def generate_body_patch(
     namespace: str,
     compute_change_data: WebhookChangeComputePayload,
     logger: logging.Logger,
+    sts_name: Optional[str] = None,
 ) -> dict:
     """
     Generates a dict representing the patch that will be applied to the statefulset.
     That patch modifies cpu/memory requests/limits based on compute_change_data.
     It also patches affinity as needed based on the existence or not of requests data.
+
+    :param sts_name: The StatefulSet to patch. Defaults to the first data
+        group's StatefulSet when omitted (callers patching the master or a
+        specific data group pass it explicitly).
     """
 
-    crd = await get_cratedb_resource(namespace, name)
-    if crd is None:
-        raise ValueError(f"CRD {name} not found in namespace {namespace}")
+    if sts_name is None:
+        crd = await get_cratedb_resource(namespace, name)
+        if crd is None:
+            raise ValueError(f"CRD {name} not found in namespace {namespace}")
 
-    try:
-        sts_name = f"crate-data-{crd['spec']['nodes']['data'][0]['name']}-{name}"
-    except (KeyError, IndexError) as e:
-        logger.error(f"Failed to construct sts_name: {e}")
-        raise ValueError(f"Failed to construct sts_name: {e}")
-
-    # sts_name = sts_name + f"-{name}"
+        try:
+            sts_name = f"crate-data-{crd['spec']['nodes']['data'][0]['name']}-{name}"
+        except (KeyError, IndexError) as e:
+            logger.error(f"Failed to construct sts_name: {e}")
+            raise ValueError(f"Failed to construct sts_name: {e}")
 
     updated_command = await update_cprocessor_crate_settings(
         apps=apps,

--- a/crate/operator/change_compute.py
+++ b/crate/operator/change_compute.py
@@ -228,7 +228,6 @@ async def generate_body_patch(
         apps=apps,
         namespace=namespace,
         sts_name=sts_name,
-        # sts_name=f"crate-data-hot-{name}",
         processors=compute_change_data["new_cpu_limit"],
     )
 

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -30,6 +30,10 @@ LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
 LABEL_NAME = "app.kubernetes.io/name"
 LABEL_PART_OF = "app.kubernetes.io/part-of"
 LABEL_NODE_NAME = f"{API_GROUP}/node-name"
+# Whether a node serves data (and thus client traffic). "false" on dedicated
+# master nodes; the client-facing service selects on "true" to keep masters
+# out of the load-balancer pool.
+LABEL_NODE_DATA = f"{API_GROUP}/node-data"
 LABEL_USER_PASSWORD = f"operator.{API_GROUP}/user-password"
 
 SYSTEM_USERNAME = "system"

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -102,6 +102,7 @@ from crate.operator.constants import (
     LABEL_COMPONENT,
     LABEL_MANAGED_BY,
     LABEL_NAME,
+    LABEL_NODE_DATA,
     LABEL_NODE_NAME,
     LABEL_PART_OF,
     SHARED_NODE_SELECTOR_KEY,
@@ -877,6 +878,9 @@ def get_statefulset(
     node_labels.update(node_spec.get("labels", {}))
     # This is to identify pods of the same cluster but with a different node type
     node_labels[LABEL_NODE_NAME] = node_name
+    # Mark whether this node serves data; the client-facing service selects on
+    # this so dedicated master nodes (data=false) stay out of the LB pool.
+    node_labels[LABEL_NODE_DATA] = "true" if treat_as_data else "false"
     full_pod_name_prefix = f"crate-{node_name_prefix}{name}"
     image_registry, version = crate_image.rsplit(":", 1)
 
@@ -1275,6 +1279,7 @@ def get_data_service(
     source_ranges: Optional[List[str]] = None,
     additional_annotations: Optional[Dict] = None,
     use_traefik: bool = False,
+    has_dedicated_masters: bool = False,
 ) -> V1Service:
     res_annotations = {}
 
@@ -1286,6 +1291,14 @@ def get_data_service(
 
     service_type = "ClusterIP" if use_traefik else "LoadBalancer"
 
+    selector = {LABEL_COMPONENT: "cratedb", LABEL_NAME: name}
+    if has_dedicated_masters:
+        # Only data nodes serve client traffic, so keep dedicated master nodes
+        # (node-data=false) out of the LB pool. Scoped to clusters that actually
+        # have masters: data-only clusters keep the plain selector, so their
+        # (possibly unlabelled, pre-existing) pods still match on resume.
+        selector[LABEL_NODE_DATA] = "true"
+
     spec_kwargs = dict(
         ports=[
             V1ServicePort(name="http", port=http_port, target_port=Port.HTTP.value),
@@ -1293,7 +1306,7 @@ def get_data_service(
                 name="psql", port=postgres_port, target_port=Port.POSTGRES.value
             ),
         ],
-        selector={LABEL_COMPONENT: "cratedb", LABEL_NAME: name},
+        selector=selector,
         type=service_type,
     )
 
@@ -1393,6 +1406,7 @@ async def create_services(
     source_ranges: Optional[List[str]] = None,
     additional_annotations: Optional[Dict] = None,
     use_traefik: bool = False,
+    has_dedicated_masters: bool = False,
 ) -> None:
     async with GlobalApiClient() as api_client:
         core = CoreV1Api(api_client)
@@ -1408,6 +1422,7 @@ async def create_services(
             source_ranges,
             additional_annotations=additional_annotations,
             use_traefik=use_traefik,
+            has_dedicated_masters=has_dedicated_masters,
         )
         await call_kubeapi(
             core.create_namespaced_service,
@@ -1476,6 +1491,7 @@ async def recreate_services(
         source_ranges,
         additional_annotations,
         use_traefik=use_traefik,
+        has_dedicated_masters="master" in spec["nodes"],
     )
 
 
@@ -1707,6 +1723,7 @@ class CreateServicesSubHandler(StateBasedSubHandler):
         source_ranges: Optional[List[str]] = None,
         additional_annotations: Optional[Dict] = None,
         exposure: str = "loadbalancer",
+        has_dedicated_masters: bool = False,
         **kwargs: Any,
     ):
         use_traefik = exposure == "traefik"
@@ -1723,6 +1740,7 @@ class CreateServicesSubHandler(StateBasedSubHandler):
             source_ranges,
             additional_annotations,
             use_traefik=use_traefik,
+            has_dedicated_masters=has_dedicated_masters,
         )
 
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -878,8 +878,6 @@ def get_statefulset(
     node_labels.update(node_spec.get("labels", {}))
     # This is to identify pods of the same cluster but with a different node type
     node_labels[LABEL_NODE_NAME] = node_name
-    # Mark whether this node serves data; the client-facing service selects on
-    # this so dedicated master nodes (data=false) stay out of the LB pool.
     node_labels[LABEL_NODE_DATA] = "true" if treat_as_data else "false"
     full_pod_name_prefix = f"crate-{node_name_prefix}{name}"
     image_registry, version = crate_image.rsplit(":", 1)

--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -128,15 +128,24 @@ async def expand_volume(
                 f"{int(storage_status)}/{int(new_storage)}"
             )
             conditions = current_pvc.status.conditions or []
+            # We only need the control plane to *accept* the expansion, not to
+            # finish the physical resize. Once the external-resizer reports the
+            # PVC ``Resizing`` (or the later ``FileSystemResizePending``), or the
+            # capacity already reflects the new size, we are done -- the online
+            # resize completes on its own and can take a while on some backends
+            # (e.g. azure-disk). Waiting for ``status.capacity`` to actually grow
+            # would block the handler for the full physical resize and times out
+            # on slow backends, even though nothing more is required of us.
+            accepted = {"Resizing", "FileSystemResizePending"}
             if int(storage_status) == int(new_storage) or any(
-                cond.type == "FileSystemResizePending" for cond in conditions
+                cond.type in accepted for cond in conditions
             ):
                 pvc_storage[pvc["name"]] = {"in_progress": False}
             else:
                 pvc_storage[pvc["name"]] = {"in_progress": True}
-    # If resizing for at least one of the PVCs is not finished, we try again.
-    # Or assume that the StorageClass does not support expansion and fail
-    # after the timeout is reached.
+    # If the expansion has not been accepted for at least one PVC yet, retry.
+    # A StorageClass that does not support expansion never produces a resize
+    # condition, so this still fails after the timeout is reached.
     if pending_pvc := next(
         (
             name

--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -39,7 +39,33 @@ from crate.operator.webhooks import (
     WebhookFeedbackPayload,
     WebhookOperation,
     WebhookStatus,
+    WebhookStorageGroupPayload,
 )
+
+
+def collect_disk_expansions(
+    diff: kopf.Diff, logger: logging.Logger
+) -> List[Tuple[str, Any]]:
+    """
+    Build one ``(node_label, new_size)`` pair per node group whose disk size
+    changed. Data groups are a list (diffed as a whole); the dedicated masters
+    are a single dict, so kopf reports their disk size at the leaf.
+
+    :param diff: The kopf diff for the update.
+    """
+    expansions: List[Tuple[str, Any]] = []
+    for operation, field_path, old_value, new_value in diff:
+        if field_path == ("spec", "nodes", "data"):
+            for old_spec, new_spec in zip(old_value, new_value):
+                old_size = old_spec["resources"]["disk"]["size"]
+                new_size = new_spec["resources"]["disk"]["size"]
+                if old_size != new_size:
+                    expansions.append((new_spec["name"], new_size))
+        elif field_path == ("spec", "nodes", "master", "resources", "disk", "size"):
+            expansions.append(("master", new_value))
+        else:
+            logger.info("Ignoring operation %s on field %s", operation, field_path)
+    return expansions
 
 
 async def expand_volume(
@@ -139,22 +165,7 @@ class ExpandVolumeSubHandler(StateBasedSubHandler):
         logger: logging.Logger,
         **kwargs: Any,
     ):
-        # Collect one (node_label, new_size) per node group whose disk size
-        # changed. Data groups are a list (diffed as a whole); the dedicated
-        # masters are a single dict, so kopf reports their disk size at the leaf.
-        expansions: List[Tuple[str, Any]] = []
-
-        for operation, field_path, old_value, new_value in diff:
-            if field_path == ("spec", "nodes", "data"):
-                for old_spec, new_spec in zip(old_value, new_value):
-                    old_size = old_spec["resources"]["disk"]["size"]
-                    new_size = new_spec["resources"]["disk"]["size"]
-                    if old_size != new_size:
-                        expansions.append((new_spec["name"], new_size))
-            elif field_path == ("spec", "nodes", "master", "resources", "disk", "size"):
-                expansions.append(("master", new_value))
-            else:
-                logger.info("Ignoring operation %s on field %s", operation, field_path)
+        expansions = collect_disk_expansions(diff, logger)
 
         if expansions:
             async with GlobalApiClient() as api_client:
@@ -163,13 +174,20 @@ class ExpandVolumeSubHandler(StateBasedSubHandler):
                 await expand_volume(core, namespace, name, expansions, logger)
 
         # schedule success notification and send it after the cluster
-        # has been restarted successfully.
+        # has been restarted successfully. The per-group new sizes let billing
+        # attribute storage per node group (master, hot, ...).
         self.schedule_notification(
             WebhookEvent.FEEDBACK,
             WebhookFeedbackPayload(
                 message="The cluster storage has been resized successfully.",
                 operation=WebhookOperation.UPDATE,
                 action=WebhookAction.EXPAND_STORAGE,
+                disk_sizes=[
+                    WebhookStorageGroupPayload(
+                        name=node_label, new_disk_size=str(new_size)
+                    )
+                    for node_label, new_size in expansions
+                ],
             ),
             WebhookStatus.SUCCESS,
         )

--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -128,14 +128,10 @@ async def expand_volume(
                 f"{int(storage_status)}/{int(new_storage)}"
             )
             conditions = current_pvc.status.conditions or []
-            # We only need the control plane to *accept* the expansion, not to
-            # finish the physical resize. Once the external-resizer reports the
-            # PVC ``Resizing`` (or the later ``FileSystemResizePending``), or the
-            # capacity already reflects the new size, we are done -- the online
-            # resize completes on its own and can take a while on some backends
-            # (e.g. azure-disk). Waiting for ``status.capacity`` to actually grow
-            # would block the handler for the full physical resize and times out
-            # on slow backends, even though nothing more is required of us.
+            # We only need the resize accepted, not physically complete -
+            # ``Resizing/FileSystemResizePending`` (or capacity already grown)
+            # is enough. The online resize finishes on its own, waiting would
+            # time out on slow backends.
             accepted = {"Resizing", "FileSystemResizePending"}
             if int(storage_status) == int(new_storage) or any(
                 cond.type in accepted for cond in conditions

--- a/crate/operator/expand_volume.py
+++ b/crate/operator/expand_volume.py
@@ -20,13 +20,13 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Tuple
 
 import kopf
 from kubernetes_asyncio.client import CoreV1Api
 
 from crate.operator.config import config
-from crate.operator.constants import DATA_NODE_NAME, DATA_PVC_NAME_PREFIX
+from crate.operator.constants import DATA_PVC_NAME_PREFIX
 from crate.operator.operations import get_pvcs_in_namespace
 from crate.operator.utils import crate
 from crate.operator.utils.formatting import convert_to_bytes
@@ -46,22 +46,20 @@ async def expand_volume(
     core: CoreV1Api,
     namespace: str,
     name: str,
-    data_diff_items: kopf.Diff,
+    expansions: List[Tuple[str, Any]],
     logger: logging.Logger,
 ):
     """
-    Expand a cluster's disk size according to the given ``data_diff_items``.
+    Expand the disk volumes of one or more node groups.
 
     :param core: An instance of the Kubernetes Core V1 API.
     :param namespace: The Kubernetes namespace for the CrateDB cluster.
     :param name: The CrateDB custom resource name defining the CrateDB cluster.
-    :param old: The old resource body.
-    :param data_diff_items: A list of changes made to the individual
-        data node specifications.
+    :param expansions: One ``(node_label, new_size)`` pair per node group whose
+        disk size changed. ``node_label`` is the group's node-name label
+        (``"master"`` for the dedicated masters, or a data group's name);
+        ``new_size`` is the target disk size (a size string or byte count).
     """
-    all_pvcs = await get_pvcs_in_namespace(core, namespace, name, DATA_NODE_NAME)
-    pvc_storage = {}
-
     await send_operation_progress_notification(
         namespace=namespace,
         name=name,
@@ -72,51 +70,44 @@ async def expand_volume(
         action=WebhookAction.EXPAND_STORAGE,
     )
 
-    for pvc in all_pvcs:
-        if not pvc["name"].startswith(DATA_PVC_NAME_PREFIX):
-            continue
-        current_pvc = await core.read_namespaced_persistent_volume_claim(
-            name=pvc["name"],
-            namespace=namespace,
-        )
-        if data_diff_items:
-            for _, field_path, old_storage, new_storage in data_diff_items:
-                current_storage = convert_to_bytes(
-                    current_pvc.spec.resources.requests["storage"]
-                )
-                new_storage = convert_to_bytes(new_storage)
-                if current_storage != new_storage:
-                    body: Dict[str, Any] = {
-                        "spec": {
-                            "resources": {
-                                "requests": {"storage": str(int(new_storage))}
-                            },
-                        }
+    pvc_storage = {}
+    for node_label, new_size in expansions:
+        new_storage = convert_to_bytes(new_size)
+        all_pvcs = await get_pvcs_in_namespace(core, namespace, name, node_label)
+        for pvc in all_pvcs:
+            if not pvc["name"].startswith(DATA_PVC_NAME_PREFIX):
+                continue
+            current_pvc = await core.read_namespaced_persistent_volume_claim(
+                name=pvc["name"],
+                namespace=namespace,
+            )
+            current_storage = convert_to_bytes(
+                current_pvc.spec.resources.requests["storage"]
+            )
+            if current_storage != new_storage:
+                body: Dict[str, Any] = {
+                    "spec": {
+                        "resources": {"requests": {"storage": str(int(new_storage))}},
                     }
-                    logger.info(f"Patch PVC {pvc['name']} with body {body}")
-                    await core.patch_namespaced_persistent_volume_claim(
-                        name=pvc["name"],
-                        namespace=namespace,
-                        body=body,
-                    )
-                storage_status = convert_to_bytes(
-                    current_pvc.status.capacity["storage"]
+                }
+                logger.info(f"Patch PVC {pvc['name']} with body {body}")
+                await core.patch_namespaced_persistent_volume_claim(
+                    name=pvc["name"],
+                    namespace=namespace,
+                    body=body,
                 )
-                logger.info(
-                    f"PVC {pvc['name']} storage current/new "
-                    f"{int(storage_status)}/{int(new_storage)}"
-                )
-                conditions = current_pvc.status.conditions or []
-                if int(storage_status) == int(new_storage) or any(
-                    cond.type == "FileSystemResizePending" for cond in conditions
-                ):
-                    pvc_storage[pvc["name"]] = {
-                        "in_progress": False,
-                    }
-                else:
-                    pvc_storage[pvc["name"]] = {
-                        "in_progress": True,
-                    }
+            storage_status = convert_to_bytes(current_pvc.status.capacity["storage"])
+            logger.info(
+                f"PVC {pvc['name']} storage current/new "
+                f"{int(storage_status)}/{int(new_storage)}"
+            )
+            conditions = current_pvc.status.conditions or []
+            if int(storage_status) == int(new_storage) or any(
+                cond.type == "FileSystemResizePending" for cond in conditions
+            ):
+                pvc_storage[pvc["name"]] = {"in_progress": False}
+            else:
+                pvc_storage[pvc["name"]] = {"in_progress": True}
     # If resizing for at least one of the PVCs is not finished, we try again.
     # Or assume that the StorageClass does not support expansion and fail
     # after the timeout is reached.
@@ -148,37 +139,28 @@ class ExpandVolumeSubHandler(StateBasedSubHandler):
         logger: logging.Logger,
         **kwargs: Any,
     ):
-        expand_data_diff_items: Optional[List[kopf.DiffItem]] = None
+        # Collect one (node_label, new_size) per node group whose disk size
+        # changed. Data groups are a list (diffed as a whole); the dedicated
+        # masters are a single dict, so kopf reports their disk size at the leaf.
+        expansions: List[Tuple[str, Any]] = []
 
         for operation, field_path, old_value, new_value in diff:
             if field_path == ("spec", "nodes", "data"):
-                expand_data_diff_items = []
-                for node_spec_idx in range(len(old_value)):
-                    old_spec = old_value[node_spec_idx]
-                    new_spec = new_value[node_spec_idx]
-
-                    expand_data_diff_items.append(
-                        kopf.DiffItem(
-                            kopf.DiffOperation.CHANGE,
-                            (str(node_spec_idx), "resources", "disk", "size"),
-                            old_spec["resources"]["disk"]["size"],
-                            new_spec["resources"]["disk"]["size"],
-                        )
-                    )
+                for old_spec, new_spec in zip(old_value, new_value):
+                    old_size = old_spec["resources"]["disk"]["size"]
+                    new_size = new_spec["resources"]["disk"]["size"]
+                    if old_size != new_size:
+                        expansions.append((new_spec["name"], new_size))
+            elif field_path == ("spec", "nodes", "master", "resources", "disk", "size"):
+                expansions.append(("master", new_value))
             else:
                 logger.info("Ignoring operation %s on field %s", operation, field_path)
 
-        if expand_data_diff_items:
+        if expansions:
             async with GlobalApiClient() as api_client:
                 core = CoreV1Api(api_client)
 
-                await expand_volume(
-                    core,
-                    namespace,
-                    name,
-                    kopf.Diff(expand_data_diff_items),
-                    logger,
-                )
+                await expand_volume(core, namespace, name, expansions, logger)
 
         # schedule success notification and send it after the cluster
         # has been restarted successfully.

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -40,7 +40,11 @@ from crate.operator.create import (
     get_owner_references,
 )
 from crate.operator.exposure import CreateTraefikResourcesSubHandler
-from crate.operator.operations import get_master_nodes_names, get_total_nodes_count
+from crate.operator.operations import (
+    get_master_nodes_names,
+    get_total_nodes_count,
+    validate_node_spec,
+)
 from crate.operator.utils.secrets import get_image_pull_secrets
 
 
@@ -68,6 +72,7 @@ async def create_cratedb(
     prometheus_port = ports_spec.get("prometheus", Port.PROMETHEUS.value)
     transport_port = ports_spec.get("transport", Port.TRANSPORT.value)
 
+    validate_node_spec(spec["nodes"], logger)
     master_nodes = get_master_nodes_names(spec["nodes"])
     total_nodes_count = get_total_nodes_count(spec["nodes"], "all")
     data_nodes_count = get_total_nodes_count(spec["nodes"], "data")

--- a/crate/operator/handlers/handle_create_cratedb.py
+++ b/crate/operator/handlers/handle_create_cratedb.py
@@ -138,6 +138,7 @@ async def create_cratedb(
             .get("service", {})
             .get("annotations", {}),
             exposure=exposure,
+            has_dedicated_masters=has_master_nodes,
         ),
         id="services",
     )

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -157,28 +157,45 @@ async def update_cratedb(
             do_upgrade = True
             do_restart = True
             operation = OperationType.UPGRADE
-        elif field_path == ("spec", "nodes", "master", "replicas"):
-            old_master = old_spec or 0
-            new_master = new_spec or 0
-            if old_master == 0 or new_master == 0:
-                # Scaling masters across zero is only safe as part of a full
-                # cluster suspend/resume, where the operator scales the masters
-                # itself (after data on suspend, before data on resume; see
-                # suspend_or_start_cluster). When the data nodes are crossing
-                # zero too we let that data-driven path handle it and do not
-                # register a separate master scale. Otherwise shutting masters
-                # down while data nodes stay up would break cluster formation,
-                # so we reject it outright.
-                if not data_nodes_cross_zero:
-                    raise kopf.PermanentError(
-                        "Scaling master nodes to or from zero is only "
-                        "supported as part of a full cluster suspend/resume "
-                        "(driven by the data nodes), not as a standalone "
-                        "master.replicas change."
-                    )
-            else:
-                do_scale = True
-                operation = OperationType.SCALE
+        elif field_path[:3] == ("spec", "nodes", "master"):
+            # Dedicated masters are a single dict in the CRD, so kopf reports
+            # their changes at leaf level (unlike the data list). Classify the
+            # leaf to route it to the right operation.
+            master_subpath = field_path[3:]
+            if master_subpath == ("replicas",):
+                old_master = old_spec or 0
+                new_master = new_spec or 0
+                if old_master == 0 or new_master == 0:
+                    # Scaling masters across zero is only safe as part of a
+                    # full cluster suspend/resume, where the operator scales
+                    # the masters itself (after data on suspend, before data on
+                    # resume; see suspend_or_start_cluster). When the data nodes
+                    # are crossing zero too we let that data-driven path handle
+                    # it and do not register a separate master scale. Otherwise
+                    # shutting masters down while data nodes stay up would break
+                    # cluster formation, so we reject it outright.
+                    if not data_nodes_cross_zero:
+                        raise kopf.PermanentError(
+                            "Scaling master nodes to or from zero is only "
+                            "supported as part of a full cluster "
+                            "suspend/resume (driven by the data nodes), not as "
+                            "a standalone master.replicas change."
+                        )
+                else:
+                    do_scale = True
+                    operation = OperationType.SCALE
+            elif master_subpath[:2] == ("resources", "disk"):
+                # Master disk changes are storage expansion, handled in T3.
+                pass
+            elif master_subpath[:1] == ("resources",) or master_subpath == (
+                "nodepool",
+            ):
+                # A master cpu/memory/heapRatio/nodepool change is a compute
+                # change. restart already covers the master StatefulSet, so the
+                # patched resources take effect.
+                do_change_compute = True
+                operation = OperationType.CHANGE_COMPUTE
+                do_restart = True
         elif field_path == ("spec", "cluster", "exposure"):
             old_val = old_spec if old_spec is not None else "loadbalancer"
             new_val = new_spec if new_spec is not None else "loadbalancer"

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -143,10 +143,6 @@ async def update_cratedb(
 
     operation = OperationType.UNKNOWN
 
-    # A master replica change that crosses zero (0<->N) is only valid as part of
-    # a whole-cluster suspend/resume, which is driven by the data nodes. We
-    # precompute that here so the master branch below can tell a legitimate
-    # suspend/resume apart from an unsafe standalone master scale.
     data_nodes_cross_zero = _data_nodes_cross_zero(diff)
 
     for _, field_path, old_spec, new_spec in diff:
@@ -166,14 +162,9 @@ async def update_cratedb(
                 old_master = old_spec or 0
                 new_master = new_spec or 0
                 if old_master == 0 or new_master == 0:
-                    # Scaling masters across zero is only safe as part of a
-                    # full cluster suspend/resume, where the operator scales
-                    # the masters itself (after data on suspend, before data on
-                    # resume; see suspend_or_start_cluster). When the data nodes
-                    # are crossing zero too we let that data-driven path handle
-                    # it and do not register a separate master scale. Otherwise
-                    # shutting masters down while data nodes stay up would break
-                    # cluster formation, so we reject it outright.
+                    # When data is also crossing zero, suspend_or_start_cluster
+                    # scales the masters itself - reject only a standalone
+                    # across-zero change.
                     if not data_nodes_cross_zero:
                         raise kopf.PermanentError(
                             "Scaling master nodes to or from zero is only "

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -56,6 +56,21 @@ from crate.operator.utils.notifications import FlushNotificationsSubHandler
 from crate.operator.webhooks import WebhookAction
 
 
+def _data_nodes_cross_zero(diff: kopf.Diff) -> bool:
+    """
+    Return whether any data node group is scaling to or from zero replicas in
+    this diff, i.e. whether the cluster is being suspended or resumed. Used to
+    distinguish a legitimate (data-driven) suspend/resume from an unsafe
+    standalone master scale.
+    """
+    for _, field_path, old_value, new_value in diff:
+        if field_path == ("spec", "nodes", "data"):
+            for old_spec, new_spec in zip(old_value, new_value):
+                if old_spec.get("replicas") == 0 or new_spec.get("replicas") == 0:
+                    return True
+    return False
+
+
 async def update_cratedb(
     namespace: str,
     name: str,
@@ -128,6 +143,12 @@ async def update_cratedb(
 
     operation = OperationType.UNKNOWN
 
+    # A master replica change that crosses zero (0<->N) is only valid as part of
+    # a whole-cluster suspend/resume, which is driven by the data nodes. We
+    # precompute that here so the master branch below can tell a legitimate
+    # suspend/resume apart from an unsafe standalone master scale.
+    data_nodes_cross_zero = _data_nodes_cross_zero(diff)
+
     for _, field_path, old_spec, new_spec in diff:
         if field_path in {
             ("spec", "cluster", "imageRegistry"),
@@ -137,8 +158,27 @@ async def update_cratedb(
             do_restart = True
             operation = OperationType.UPGRADE
         elif field_path == ("spec", "nodes", "master", "replicas"):
-            do_scale = True
-            operation = OperationType.SCALE
+            old_master = old_spec or 0
+            new_master = new_spec or 0
+            if old_master == 0 or new_master == 0:
+                # Scaling masters across zero is only safe as part of a full
+                # cluster suspend/resume, where the operator scales the masters
+                # itself (after data on suspend, before data on resume; see
+                # suspend_or_start_cluster). When the data nodes are crossing
+                # zero too we let that data-driven path handle it and do not
+                # register a separate master scale. Otherwise shutting masters
+                # down while data nodes stay up would break cluster formation,
+                # so we reject it outright.
+                if not data_nodes_cross_zero:
+                    raise kopf.PermanentError(
+                        "Scaling master nodes to or from zero is only "
+                        "supported as part of a full cluster suspend/resume "
+                        "(driven by the data nodes), not as a standalone "
+                        "master.replicas change."
+                    )
+            else:
+                do_scale = True
+                operation = OperationType.SCALE
         elif field_path == ("spec", "cluster", "exposure"):
             old_val = old_spec if old_spec is not None else "loadbalancer"
             new_val = new_spec if new_spec is not None else "loadbalancer"

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -184,8 +184,16 @@ async def update_cratedb(
                 else:
                     do_scale = True
                     operation = OperationType.SCALE
+            elif master_subpath == ("resources", "disk", "size"):
+                # A master disk-size increase is a storage expansion, the same
+                # as for data groups.
+                do_expand_volume = True
+                if config.NO_DOWNTIME_STORAGE_EXPANSION:
+                    do_before_update = False
+                    do_after_update = False
             elif master_subpath[:2] == ("resources", "disk"):
-                # Master disk changes are storage expansion, handled in T3.
+                # Other disk fields (count/storageClass) are not actioned,
+                # mirroring the data groups.
                 pass
             elif master_subpath[:1] == ("resources",) or master_subpath == (
                 "nodepool",

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -181,6 +181,13 @@ async def update_cratedb(
                             "suspend/resume (driven by the data nodes), not as "
                             "a standalone master.replicas change."
                         )
+                elif new_master < 3 or new_master % 2 == 0:
+                    # Masters must stay an odd quorum of at least three.
+                    raise kopf.PermanentError(
+                        "Dedicated master nodes (spec.nodes.master.replicas) "
+                        "must be an odd number >= 3 to form a quorum, got "
+                        f"{new_master}."
+                    )
                 else:
                     do_scale = True
                     operation = OperationType.SCALE

--- a/crate/operator/main.py
+++ b/crate/operator/main.py
@@ -58,6 +58,7 @@ from crate.operator.operations import (
     DELAY_CRONJOB,
     DELAY_CRONJOB_START,
     ensure_cronjob_reenabled,
+    get_total_nodes_count,
     is_namespace_terminating,
 )
 from crate.operator.restore_backup import is_valid_snapshot
@@ -367,11 +368,13 @@ async def ping_cratedb(
     logger: logging.Logger,
     **_kwargs,
 ):
-    hot_node: dict = next(
-        filter(lambda node: node["name"] == "hot", spec["nodes"]["data"])
-    )
+    # The health check is gated on the total number of *data* nodes: the
+    # cluster is treated as suspended (and the ping skipped) only when all data
+    # nodes are at 0. Summing across data groups avoids assuming a group named
+    # "hot" and works regardless of dedicated masters.
+    desired_instances = get_total_nodes_count(spec["nodes"], "data")
     await ping_cratedb_status(
-        namespace, name, spec["cluster"]["name"], hot_node["replicas"], patch, logger
+        namespace, name, spec["cluster"]["name"], desired_instances, patch, logger
     )
 
 

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -151,6 +151,42 @@ def get_master_nodes_names(nodes: Dict[str, Any]) -> List[str]:
         return [f"data-{node_name}-{i}" for i in range(node["replicas"])]
 
 
+def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
+    """
+    Validate the ``spec.nodes`` of a CrateDB resource, raising a
+    :class:`kopf.PermanentError` (which stops the operator from retrying) for
+    structurally invalid configurations.
+
+    A cluster must define at least one data node group -- the data nodes hold
+    the tables, and several code paths (bootstrap, compute changes, the webhook
+    payloads) read ``nodes["data"][0]`` directly. When dedicated master nodes
+    are configured their replica count must be odd and at least three, so the
+    masters can always form a quorum.
+
+    :param nodes: The ``spec.nodes`` from a CrateDB custom resource.
+    :param logger: Logger used to record why the spec was rejected.
+    """
+    if not nodes.get("data"):
+        logger.error("CrateDB spec rejected: no data node group defined.")
+        raise kopf.PermanentError(
+            "A CrateDB cluster must define at least one data node group "
+            "(spec.nodes.data)."
+        )
+
+    if "master" in nodes:
+        replicas = nodes["master"]["replicas"]
+        if replicas < 3 or replicas % 2 == 0:
+            logger.error(
+                "CrateDB spec rejected: dedicated master replicas=%s "
+                "(must be odd and >= 3).",
+                replicas,
+            )
+            raise kopf.PermanentError(
+                "Dedicated master nodes (spec.nodes.master.replicas) must be an "
+                f"odd number >= 3 to form a quorum, got {replicas}."
+            )
+
+
 @dataclass(frozen=True)
 class NodeGroup:
     """

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -710,9 +710,6 @@ async def restart_cluster(
     """
     pending_pods: List[Dict[str, str]] = status.get("pendingPods") or []
     if not pending_pods:
-        # Restart only the node groups that need it (masters first); a compute
-        # change to one group must not roll the others, while an upgrade rolls
-        # all. The one-at-a-time loop below serialises whatever is collected.
         for group in _node_groups_to_restart(old, body, action):
             pending_pods.extend(
                 await get_pods_in_statefulset(core, namespace, name, group.name)
@@ -1055,12 +1052,9 @@ async def suspend_or_start_cluster(
                 )
                 current_replicas = statefulset.spec.replicas
                 if current_replicas != new_replicas:
-                    # Check the cluster is healthy before removing a data node,
-                    # but only while data nodes still need scaling down. Once the
-                    # data nodes are gone, a dedicated-master remainder reports
-                    # unhealthy (tables have no data nodes to live on), and
-                    # gating on that here would deadlock the rest of the suspend
-                    # (scaling the masters down).
+                    # Only gate on health while data nodes remain - a
+                    # masters-only remainder always reports unhealthy and would
+                    # deadlock the suspend.
                     conn_factory = await _get_connection_factory(core, namespace, name)
                     await check_cluster_healthy(
                         name, namespace, apps, conn_factory, logger
@@ -1111,8 +1105,6 @@ async def suspend_or_start_cluster(
                     # Delete the LoadBalancer service
                     await delete_lb_service(core, namespace, name)
 
-    # On suspend, scale the masters to 0 only after every data node is gone, so
-    # we never remove the masters out from under running data nodes.
     if has_dedicated_masters and is_suspend:
         await scale_master_statefulset(apps, namespace, name, 0, logger)
         await check_all_master_nodes_gone(core, namespace, name)

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -204,6 +204,26 @@ def iter_node_groups(nodes: Dict[str, Any]) -> List[NodeGroup]:
     return groups
 
 
+def iter_changed_compute_groups(
+    old: kopf.Body, body: kopf.Body
+) -> List[Tuple[NodeGroup, NodeGroup]]:
+    """
+    The ``(old, new)`` node-group pairs whose compute (cpu/memory/nodepool)
+    changed between ``old`` and ``body``, masters first.
+
+    The single source of truth for "which groups changed compute", shared by
+    the change-compute patching (which needs both specs to build the payload)
+    and the restart scoping (which restarts exactly those groups).
+    """
+    old_groups = {g.name: g for g in iter_node_groups(old["spec"]["nodes"])}
+    return [
+        (old_group, group)
+        for group in iter_node_groups(body["spec"]["nodes"])
+        if (old_group := old_groups.get(group.name)) is not None
+        and has_compute_changed(old_group.spec, group.spec)
+    ]
+
+
 async def get_pods_in_cluster(
     core: CoreV1Api, namespace: str, name: str
 ) -> Tuple[Tuple[str], Tuple[str]]:
@@ -609,24 +629,17 @@ def _node_groups_to_restart(
     """
     The node groups whose pods must be restarted for ``action``, masters first.
 
-    An upgrade restarts every node (they all get the new image). A compute
-    change restarts *only* the groups whose resources actually changed, so e.g.
-    a master-only CPU/memory change does not roll the data nodes. When several
-    groups change at once (e.g. ``master`` + ``data-hot`` + ``data-cold``) all
-    of them are returned -- masters first, since ``iter_node_groups`` yields the
-    masters before the data groups -- and the caller restarts them one node at a
-    time, serialised across groups.
+    An upgrade changes the cluster-wide version, so every node is restarted. A
+    compute change touches only per-group resources, so only the groups whose
+    compute actually changed are restarted -- e.g. a master-only CPU/memory
+    change does not roll the data nodes. ``iter_node_groups`` yields masters
+    first and the caller restarts one node at a time, so a multi-group change
+    (e.g. ``master`` + ``data-hot`` + ``data-cold``) is serialised
+    masters-before-data.
     """
-    groups = iter_node_groups(body["spec"]["nodes"])
     if action != WebhookAction.CHANGE_COMPUTE:
-        return groups
-    old_groups = {g.name: g for g in iter_node_groups(old["spec"]["nodes"])}
-    changed: List[NodeGroup] = []
-    for group in groups:
-        old_group = old_groups.get(group.name)
-        if old_group is not None and has_compute_changed(old_group.spec, group.spec):
-            changed.append(group)
-    return changed
+        return iter_node_groups(body["spec"]["nodes"])
+    return [new for _old, new in iter_changed_compute_groups(old, body)]
 
 
 async def restart_cluster(

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -980,9 +980,7 @@ async def suspend_or_start_cluster(
                     # unhealthy (tables have no data nodes to live on), and
                     # gating on that here would deadlock the rest of the suspend
                     # (scaling the masters down).
-                    conn_factory = await _get_connection_factory(
-                        core, namespace, name
-                    )
+                    conn_factory = await _get_connection_factory(core, namespace, name)
                     await check_cluster_healthy(
                         name, namespace, apps, conn_factory, logger
                     )

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -23,6 +23,7 @@ import asyncio
 import datetime
 import logging
 import pkgutil
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 import kopf
@@ -147,6 +148,59 @@ def get_master_nodes_names(nodes: Dict[str, Any]) -> List[str]:
         node = nodes["data"][0]
         node_name = node["name"]
         return [f"data-{node_name}-{i}" for i in range(node["replicas"])]
+
+
+@dataclass(frozen=True)
+class NodeGroup:
+    """
+    A single CrateDB node group: the dedicated masters, or one data group.
+
+    Lets callers treat masters and data groups uniformly while keeping the CRD
+    asymmetry explicit: ``spec.nodes.master`` is a single object *without* a
+    ``name``, whereas ``spec.nodes.data`` is a list of named groups.
+    """
+
+    #: Logical group name -- ``"master"`` for the dedicated masters, otherwise
+    #: the data group's own name (e.g. ``"hot"``).
+    name: str
+    #: The node group's spec dict (``replicas``, ``resources``, ...).
+    spec: Dict[str, Any]
+    #: Whether this is the dedicated master group.
+    is_master: bool
+
+    @property
+    def node_name_prefix(self) -> str:
+        """
+        Prefix of the node names CrateDB reports in ``sys.nodes`` (and the
+        infix of the StatefulSet name): ``"master"`` (``master-0``, ...) or
+        ``"data-<group>"`` (``data-hot-0``, ...).
+        """
+        return "master" if self.is_master else f"data-{self.name}"
+
+    def statefulset_name(self, cluster_name: str) -> str:
+        """
+        The StatefulSet name for this group: ``crate-master-<cluster_name>``
+        or ``crate-data-<group>-<cluster_name>``.
+        """
+        return f"crate-{self.node_name_prefix}-{cluster_name}"
+
+
+def iter_node_groups(nodes: Dict[str, Any]) -> List[NodeGroup]:
+    """
+    Enumerate a cluster's node groups, dedicated masters **first**.
+
+    Masters are yielded first so callers that must order operations
+    master-before-data (cluster formation, resume) can just iterate. Legacy
+    clusters without ``spec.nodes.master`` yield only their data groups.
+
+    :param nodes: The ``spec.nodes`` from a CrateDB custom resource.
+    """
+    groups: List[NodeGroup] = []
+    if "master" in nodes:
+        groups.append(NodeGroup(name="master", spec=nodes["master"], is_master=True))
+    for node in nodes["data"]:
+        groups.append(NodeGroup(name=node["name"], spec=node, is_master=False))
+    return groups
 
 
 async def get_pods_in_cluster(

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -407,6 +407,84 @@ async def check_all_data_nodes_present(
         raise kopf.TemporaryError("Waiting for database connection.", delay=15)
 
 
+async def scale_master_statefulset(
+    apps: AppsV1Api,
+    namespace: str,
+    name: str,
+    target_replicas: int,
+    logger: logging.Logger,
+):
+    """
+    Scale the dedicated master StatefulSet to ``target_replicas`` (no-op if it
+    is already there). Used by suspend/resume to bring masters down/up.
+
+    :param apps: An instance of the Kubernetes Apps V1 API.
+    :param namespace: The Kubernetes namespace for the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param target_replicas: The desired number of master replicas.
+    """
+    sts_name = f"crate-master-{name}"
+    statefulset = await apps.read_namespaced_stateful_set(
+        namespace=namespace, name=sts_name
+    )
+    if statefulset.spec.replicas != target_replicas:
+        logger.info("Scaling master nodes to %s replicas", target_replicas)
+        await update_statefulset_replicas(
+            apps, namespace, sts_name, statefulset, target_replicas
+        )
+
+
+async def check_all_master_nodes_present(
+    apps: AppsV1Api,
+    namespace: str,
+    name: str,
+    expected_replicas: int,
+    logger: logging.Logger,
+):
+    """
+    Wait until all dedicated master pods report ready via their Kubernetes
+    readiness probe. This enforces the masters-before-data ordering on resume:
+    a master must be available before data nodes start, or cluster
+    formation/discovery fails.
+
+    :param apps: An instance of the Kubernetes Apps V1 API.
+    :param namespace: The Kubernetes namespace for the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param expected_replicas: The number of master pods expected to be ready.
+    :raises: A :class:`kopf.TemporaryError` while masters are not yet ready.
+    """
+    sts_name = f"crate-master-{name}"
+    statefulset = await apps.read_namespaced_stateful_set(
+        namespace=namespace, name=sts_name
+    )
+    ready_replicas = statefulset.status.ready_replicas or 0
+    if ready_replicas < expected_replicas:
+        raise kopf.TemporaryError(
+            f"Waiting for {expected_replicas} master node(s) to be ready "
+            f"(currently {ready_replicas}).",
+            delay=15,
+        )
+    logger.info("All %s master node(s) are ready.", expected_replicas)
+
+
+async def check_all_master_nodes_gone(
+    core: CoreV1Api,
+    namespace: str,
+    name: str,
+):
+    """
+    :param core: An instance of the Kubernetes Core V1 API.
+    :param namespace: The Kubernetes namespace for the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :raises: A :class:`kopf.TemporaryError` when master pods are still present.
+    """
+    pending_pods = await get_pods_in_statefulset(core, namespace, name, "master")
+    if pending_pods:
+        raise kopf.TemporaryError(
+            f"Waiting for master pods to be gone {pending_pods}", delay=5
+        )
+
+
 async def check_backup_metrics_pod_gone(
     core: CoreV1Api,
     namespace: str,
@@ -793,6 +871,23 @@ async def suspend_or_start_cluster(
     )
     use_traefik = exposure == "traefik"
 
+    # Dedicated master nodes are suspended/resumed in lockstep with the data
+    # nodes, but with strict ordering: on resume the masters must come up
+    # *before* the data nodes (so the cluster can form), and on suspend they go
+    # down *after* the data nodes. The CRD's master replica count is the resume
+    # target; suspend always scales masters to 0. Legacy clusters without
+    # dedicated masters are unaffected.
+    has_dedicated_masters = "master" in cratedb["spec"]["nodes"]
+    is_resume = any(old < new for _, _, old, new in (data_diff_items or []))
+    is_suspend = any(old > new for _, _, old, new in (data_diff_items or []))
+
+    if has_dedicated_masters and is_resume:
+        master_replicas = cratedb["spec"]["nodes"]["master"]["replicas"]
+        await scale_master_statefulset(apps, namespace, name, master_replicas, logger)
+        await check_all_master_nodes_present(
+            apps, namespace, name, master_replicas, logger
+        )
+
     if data_diff_items:
         for _, field_path, old_replicas, new_replicas in data_diff_items:
             if old_replicas < new_replicas:
@@ -869,10 +964,6 @@ async def suspend_or_start_cluster(
                 )
             elif old_replicas > new_replicas:
                 # suspend the cluster -> scale down to 0 replicas
-                # First check if the cluster is healthy at all,
-                # and prevent scaling down if not.
-                conn_factory = await _get_connection_factory(core, namespace, name)
-                await check_cluster_healthy(name, namespace, apps, conn_factory, logger)
                 index_path, *_ = field_path
                 index = int(index_path)
                 node_spec = old["spec"]["nodes"]["data"][index]
@@ -883,6 +974,18 @@ async def suspend_or_start_cluster(
                 )
                 current_replicas = statefulset.spec.replicas
                 if current_replicas != new_replicas:
+                    # Check the cluster is healthy before removing a data node,
+                    # but only while data nodes still need scaling down. Once the
+                    # data nodes are gone, a dedicated-master remainder reports
+                    # unhealthy (tables have no data nodes to live on), and
+                    # gating on that here would deadlock the rest of the suspend
+                    # (scaling the masters down).
+                    conn_factory = await _get_connection_factory(
+                        core, namespace, name
+                    )
+                    await check_cluster_healthy(
+                        name, namespace, apps, conn_factory, logger
+                    )
                     await update_statefulset_replicas(
                         apps, namespace, sts_name, statefulset, new_replicas
                     )
@@ -928,6 +1031,12 @@ async def suspend_or_start_cluster(
                 else:
                     # Delete the LoadBalancer service
                     await delete_lb_service(core, namespace, name)
+
+    # On suspend, scale the masters to 0 only after every data node is gone, so
+    # we never remove the masters out from under running data nodes.
+    if has_dedicated_masters and is_suspend:
+        await scale_master_statefulset(apps, namespace, name, 0, logger)
+        await check_all_master_nodes_gone(core, namespace, name)
 
 
 async def suspend_or_start_grand_central(

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -88,6 +88,7 @@ from crate.operator.grand_central import (
 )
 from crate.operator.sql import execute_sql
 from crate.operator.utils import crate
+from crate.operator.utils.crd import has_compute_changed
 from crate.operator.utils.jwt import crate_version_supports_jwt
 from crate.operator.utils.k8s_api_client import GlobalApiClient
 from crate.operator.utils.kopf import StateBasedSubHandler, subhandler_partial
@@ -602,11 +603,38 @@ async def scale_backup_metrics_deployment(
         await update_deployment_replicas(apps, namespace, backup_metrics_name, replicas)
 
 
+def _node_groups_to_restart(
+    old: kopf.Body, body: kopf.Body, action: WebhookAction
+) -> List[NodeGroup]:
+    """
+    The node groups whose pods must be restarted for ``action``, masters first.
+
+    An upgrade restarts every node (they all get the new image). A compute
+    change restarts *only* the groups whose resources actually changed, so e.g.
+    a master-only CPU/memory change does not roll the data nodes. When several
+    groups change at once (e.g. ``master`` + ``data-hot`` + ``data-cold``) all
+    of them are returned -- masters first, since ``iter_node_groups`` yields the
+    masters before the data groups -- and the caller restarts them one node at a
+    time, serialised across groups.
+    """
+    groups = iter_node_groups(body["spec"]["nodes"])
+    if action != WebhookAction.CHANGE_COMPUTE:
+        return groups
+    old_groups = {g.name: g for g in iter_node_groups(old["spec"]["nodes"])}
+    changed: List[NodeGroup] = []
+    for group in groups:
+        old_group = old_groups.get(group.name)
+        if old_group is not None and has_compute_changed(old_group.spec, group.spec):
+            changed.append(group)
+    return changed
+
+
 async def restart_cluster(
     core: CoreV1Api,
     namespace: str,
     name: str,
     old: kopf.Body,
+    body: kopf.Body,
     logger: logging.Logger,
     patch: kopf.Patch,
     status: kopf.Status,
@@ -621,20 +649,24 @@ async def restart_cluster(
     wait for the cluster to have the desired number of nodes again and for the
     cluster to be in a ``GREEN`` state, before terminating the next pod.
 
+    For a compute change only the node groups whose resources changed are
+    restarted (see ``_node_groups_to_restart``); an upgrade restarts all.
+
     :param core: An instance of the Kubernetes Core V1 API.
     :param namespace: The Kubernetes namespace where to look up CrateDB cluster.
     :param name: The CrateDB custom resource name defining the CrateDB cluster.
     :param old: The old resource body.
+    :param body: The new resource body, used to determine which node groups
+        changed (and therefore need restarting) for a compute change.
     """
     pending_pods: List[Dict[str, str]] = status.get("pendingPods") or []
     if not pending_pods:
-        if "master" in old["spec"]["nodes"]:
+        # Restart only the node groups that need it (masters first); a compute
+        # change to one group must not roll the others, while an upgrade rolls
+        # all. The one-at-a-time loop below serialises whatever is collected.
+        for group in _node_groups_to_restart(old, body, action):
             pending_pods.extend(
-                await get_pods_in_statefulset(core, namespace, name, "master")
-            )
-        for node_spec in old["spec"]["nodes"]["data"]:
-            pending_pods.extend(
-                await get_pods_in_statefulset(core, namespace, name, node_spec["name"])
+                await get_pods_in_statefulset(core, namespace, name, group.name)
             )
         patch.status["pendingPods"] = pending_pods
 
@@ -1233,6 +1265,7 @@ class RestartSubHandler(StateBasedSubHandler):
         self,
         namespace: str,
         name: str,
+        body: kopf.Body,
         old: kopf.Body,
         logger: logging.Logger,
         patch: kopf.Patch,
@@ -1243,7 +1276,7 @@ class RestartSubHandler(StateBasedSubHandler):
         async with GlobalApiClient() as api_client:
             core = CoreV1Api(api_client)
             await restart_cluster(
-                core, namespace, name, old, logger, patch, status, action
+                core, namespace, name, old, body, logger, patch, status, action
             )
 
 

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -23,7 +23,7 @@ import asyncio
 import logging
 import re
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import kopf
 from aiopg import Cursor
@@ -674,6 +674,36 @@ def effective_master_replicas(
     return old_master, new_master
 
 
+def classify_data_scaling(
+    scale_data_diff_items: Optional[List[kopf.DiffItem]],
+    old_data: List[Dict[str, Any]],
+    new_data: List[Dict[str, Any]],
+) -> Tuple[bool, bool]:
+    """
+    Decide whether a data-replica change is a cluster suspend/resume or an
+    ordinary scale, returning ``(data_resuming, data_suspending)``.
+
+    Suspend and resume are *cluster-wide*: a suspend takes **all** data node
+    groups to zero, and a resume brings them all back up from zero. Scaling a
+    single group to zero while other groups keep running is an ordinary scale,
+    not a suspend -- so the decision looks at every group's target/source
+    replica count, not just the first one that changed (which, for a
+    multi-group cluster, could misclassify a partial scale-down as a suspend).
+
+    :param scale_data_diff_items: The data groups whose replicas changed; empty
+        or ``None`` means no data scaling happened.
+    :param old_data: ``old["spec"]["nodes"]["data"]`` -- every data group's
+        previous spec.
+    :param new_data: ``spec["nodes"]["data"]`` -- every data group's new spec.
+    """
+    if not scale_data_diff_items:
+        return False, False
+
+    data_resuming = all(group.get("replicas", 0) == 0 for group in old_data)
+    data_suspending = all(group.get("replicas", 0) == 0 for group in new_data)
+    return data_resuming, data_suspending
+
+
 class ScaleSubHandler(StateBasedSubHandler):
     @crate.on.error(error_handler=crate.send_update_failed_notification)
     @crate.timeout(timeout=float(config.SCALING_TIMEOUT))
@@ -718,14 +748,11 @@ class ScaleSubHandler(StateBasedSubHandler):
             else:
                 logger.info("Ignoring operation %s on field %s", operation, field_path)
 
-        # If a data group's old value is zero we are resuming the cluster (it
-        # was suspended); if the new value is zero we are suspending it.
-        data_resuming = False
-        data_suspending = False
-        if scale_data_diff_items and len(scale_data_diff_items[0]) >= 4:
-            first = scale_data_diff_items[0]
-            data_resuming = first[2] == 0
-            data_suspending = first[3] == 0
+        data_resuming, data_suspending = classify_data_scaling(
+            scale_data_diff_items,
+            old["spec"]["nodes"]["data"],
+            spec["nodes"]["data"],
+        )
 
         async with GlobalApiClient() as api_client:
             apps = AppsV1Api(api_client)

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -720,11 +720,12 @@ class ScaleSubHandler(StateBasedSubHandler):
 
         # If a data group's old value is zero we are resuming the cluster (it
         # was suspended); if the new value is zero we are suspending it.
-        have_data_diff = bool(scale_data_diff_items) and (
-            len(scale_data_diff_items[0]) >= 4
-        )
-        data_resuming = have_data_diff and scale_data_diff_items[0][2] == 0
-        data_suspending = have_data_diff and scale_data_diff_items[0][3] == 0
+        data_resuming = False
+        data_suspending = False
+        if scale_data_diff_items and len(scale_data_diff_items[0]) >= 4:
+            first = scale_data_diff_items[0]
+            data_resuming = first[2] == 0
+            data_suspending = first[3] == 0
 
         async with GlobalApiClient() as api_client:
             apps = AppsV1Api(api_client)

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -644,6 +644,36 @@ async def scale_cluster(
             )
 
 
+def effective_master_replicas(
+    old_nodes: dict,
+    new_nodes: dict,
+    *,
+    data_suspending: bool,
+    data_resuming: bool,
+):
+    """
+    Return the ``(old, new)`` *effective* master replica counts for the SCALE
+    webhook -- what the operator actually runs, not the CRD spec value.
+
+    Under operator-inferred suspend/resume the CRD master count is left
+    unchanged, but the operator scales masters to 0 on suspend and back on
+    resume. Billing must see 0 while suspended, else it keeps charging for
+    masters that aren't running. Legacy clusters (no ``master``) yield
+    ``(None, None)``.
+
+    :param old_nodes: ``old.spec.nodes``.
+    :param new_nodes: ``spec.nodes`` (the new/current spec).
+    """
+    old_master = old_nodes.get("master", {}).get("replicas")
+    new_master = new_nodes.get("master", {}).get("replicas")
+    if "master" in new_nodes:
+        if data_suspending:
+            new_master = 0
+        elif data_resuming:
+            old_master = 0
+    return old_master, new_master
+
+
 class ScaleSubHandler(StateBasedSubHandler):
     @crate.on.error(error_handler=crate.send_update_failed_notification)
     @crate.timeout(timeout=float(config.SCALING_TIMEOUT))
@@ -688,21 +718,19 @@ class ScaleSubHandler(StateBasedSubHandler):
             else:
                 logger.info("Ignoring operation %s on field %s", operation, field_path)
 
+        # If a data group's old value is zero we are resuming the cluster (it
+        # was suspended); if the new value is zero we are suspending it.
+        have_data_diff = bool(scale_data_diff_items) and (
+            len(scale_data_diff_items[0]) >= 4
+        )
+        data_resuming = have_data_diff and scale_data_diff_items[0][2] == 0
+        data_suspending = have_data_diff and scale_data_diff_items[0][3] == 0
+
         async with GlobalApiClient() as api_client:
             apps = AppsV1Api(api_client)
             core = CoreV1Api(api_client)
 
-            # If old value is zero, resume the cluster (it was suspended)
-            # If new value is zero, suspend the cluster
-            if (
-                # Ensure the diff data exists to keep mypy happy
-                scale_data_diff_items
-                and len(scale_data_diff_items[0]) >= 4
-                # Check for suspend or resume
-                and (
-                    scale_data_diff_items[0][2] == 0 or scale_data_diff_items[0][3] == 0
-                )
-            ):
+            if data_resuming or data_suspending:
                 await suspend_or_start_cluster(
                     apps,
                     core,
@@ -730,6 +758,13 @@ class ScaleSubHandler(StateBasedSubHandler):
                     logger,
                 )
 
+        old_master_replicas, new_master_replicas = effective_master_replicas(
+            old["spec"]["nodes"],
+            spec["nodes"],
+            data_suspending=data_suspending,
+            data_resuming=data_resuming,
+        )
+
         self.schedule_notification(
             WebhookEvent.SCALE,
             WebhookScalePayload(
@@ -745,10 +780,8 @@ class ScaleSubHandler(StateBasedSubHandler):
                     )
                     for item in spec["nodes"]["data"]
                 ],
-                old_master_replicas=old["spec"]["nodes"]
-                .get("master", {})
-                .get("replicas"),
-                new_master_replicas=spec["nodes"].get("master", {}).get("replicas"),
+                old_master_replicas=old_master_replicas,
+                new_master_replicas=new_master_replicas,
             ),
             WebhookStatus.SUCCESS,
         )

--- a/crate/operator/webhooks.py
+++ b/crate/operator/webhooks.py
@@ -23,7 +23,7 @@ import asyncio
 import enum
 import logging
 import random
-from typing import List, Optional, TypedDict
+from typing import List, NotRequired, Optional, TypedDict
 
 import aiohttp
 import kopf
@@ -168,6 +168,24 @@ class WebhookChangeComputePayload(WebhookSubPayload):
 
     old_nodepool: str
     new_nodepool: str
+
+    # Dedicated-master compute. Additive and optional (absent for clusters
+    # without dedicated masters) so the payload stays backward-compatible.
+    old_master_cpu_limit: NotRequired[Optional[int]]
+    old_master_memory_limit: NotRequired[Optional[str]]
+    old_master_cpu_request: NotRequired[Optional[int]]
+    old_master_memory_request: NotRequired[Optional[str]]
+
+    new_master_cpu_limit: NotRequired[Optional[int]]
+    new_master_memory_limit: NotRequired[Optional[str]]
+    new_master_cpu_request: NotRequired[Optional[int]]
+    new_master_memory_request: NotRequired[Optional[str]]
+
+    old_master_heap_ratio: NotRequired[Optional[float]]
+    new_master_heap_ratio: NotRequired[Optional[float]]
+
+    old_master_nodepool: NotRequired[Optional[str]]
+    new_master_nodepool: NotRequired[Optional[str]]
 
 
 class WebhookInfoChangedPayload(WebhookSubPayload):

--- a/crate/operator/webhooks.py
+++ b/crate/operator/webhooks.py
@@ -23,7 +23,7 @@ import asyncio
 import enum
 import logging
 import random
-from typing import List, NotRequired, Optional, TypedDict
+from typing import List, Optional, TypedDict
 
 import aiohttp
 import kopf
@@ -152,7 +152,28 @@ class WebhookUpgradePayload(WebhookSubPayload):
     new_version: str
 
 
-class WebhookChangeComputePayload(WebhookSubPayload):
+class WebhookChangeComputeMasterFields(TypedDict, total=False):
+    # Dedicated-master compute. Optional (absent for clusters without dedicated
+    # masters) so the payload stays backward-compatible. Kept in a total=False
+    # base instead of typing.NotRequired for Python 3.10 compatibility.
+    old_master_cpu_limit: Optional[int]
+    old_master_memory_limit: Optional[str]
+    old_master_cpu_request: Optional[int]
+    old_master_memory_request: Optional[str]
+
+    new_master_cpu_limit: Optional[int]
+    new_master_memory_limit: Optional[str]
+    new_master_cpu_request: Optional[int]
+    new_master_memory_request: Optional[str]
+
+    old_master_heap_ratio: Optional[float]
+    new_master_heap_ratio: Optional[float]
+
+    old_master_nodepool: Optional[str]
+    new_master_nodepool: Optional[str]
+
+
+class WebhookChangeComputePayload(WebhookSubPayload, WebhookChangeComputeMasterFields):
     old_cpu_limit: int
     old_memory_limit: str
     old_cpu_request: int
@@ -169,24 +190,6 @@ class WebhookChangeComputePayload(WebhookSubPayload):
     old_nodepool: str
     new_nodepool: str
 
-    # Dedicated-master compute. Additive and optional (absent for clusters
-    # without dedicated masters) so the payload stays backward-compatible.
-    old_master_cpu_limit: NotRequired[Optional[int]]
-    old_master_memory_limit: NotRequired[Optional[str]]
-    old_master_cpu_request: NotRequired[Optional[int]]
-    old_master_memory_request: NotRequired[Optional[str]]
-
-    new_master_cpu_limit: NotRequired[Optional[int]]
-    new_master_memory_limit: NotRequired[Optional[str]]
-    new_master_cpu_request: NotRequired[Optional[int]]
-    new_master_memory_request: NotRequired[Optional[str]]
-
-    old_master_heap_ratio: NotRequired[Optional[float]]
-    new_master_heap_ratio: NotRequired[Optional[float]]
-
-    old_master_nodepool: NotRequired[Optional[str]]
-    new_master_nodepool: NotRequired[Optional[str]]
-
 
 class WebhookInfoChangedPayload(WebhookSubPayload):
     external_ip: str
@@ -196,7 +199,19 @@ class WebhookClusterHealthPayload(WebhookSubPayload):
     status: str
 
 
-class WebhookFeedbackPayload(WebhookSubPayload):
+class WebhookStorageGroupPayload(TypedDict):
+    name: str
+    new_disk_size: str
+
+
+class WebhookFeedbackOptionalFields(TypedDict, total=False):
+    # Per-node-group disk sizes for EXPAND_STORAGE feedback (additive/optional,
+    # so billing can attribute storage per group: master, hot, warm, ...).
+    # total=False (not typing.NotRequired) for Python 3.10 compatibility.
+    disk_sizes: Optional[List[WebhookStorageGroupPayload]]
+
+
+class WebhookFeedbackPayload(WebhookSubPayload, WebhookFeedbackOptionalFields):
     message: str
     operation: WebhookOperation
     action: WebhookAction

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,4 @@ asyncio_mode = auto
 addopts = --strict-markers
 markers =
   k8s: marks test as integration test that requires Kubernetes setup
+  master: dedicated-master-node e2e tests; run by default, select only these with -m master

--- a/tests/test_change_compute.py
+++ b/tests/test_change_compute.py
@@ -543,9 +543,9 @@ class TestUpdateCprocessorCrateSettings:
         assert "-Cprocessors=8" in updated
         assert "-Cprocessors=16" not in updated
         assert "-Cnode.master=true" in updated
-        assert apps.read_namespaced_stateful_set.await_args.kwargs["name"] == (
-            "crate-master-c"
-        )
+        call = apps.read_namespaced_stateful_set.await_args
+        assert call is not None
+        assert call.kwargs["name"] == "crate-master-c"
 
     @pytest.mark.asyncio
     async def test_rounds_cpu_up_to_match_create(self):
@@ -572,10 +572,14 @@ class TestGenerateChangeComputePayloadMaster:
     def test_includes_master_compute_when_masters_present(self):
         from crate.operator.change_compute import generate_change_compute_payload
 
-        old = {"spec": {"nodes": {
-            "master": _group_spec(16, "60000000000"),
-            "data": [{"name": "hot", **_group_spec(32, "30000000000")}],
-        }}}
+        old = {
+            "spec": {
+                "nodes": {
+                    "master": _group_spec(16, "60000000000"),
+                    "data": [{"name": "hot", **_group_spec(32, "30000000000")}],
+                }
+            }
+        }
         new = copy.deepcopy(old)
         new["spec"]["nodes"]["master"]["resources"]["limits"]["cpu"] = 8
 
@@ -590,9 +594,13 @@ class TestGenerateChangeComputePayloadMaster:
     def test_omits_master_fields_for_legacy_cluster(self):
         from crate.operator.change_compute import generate_change_compute_payload
 
-        old = {"spec": {"nodes": {
-            "data": [{"name": "hot", **_group_spec(32, "30000000000")}],
-        }}}
+        old = {
+            "spec": {
+                "nodes": {
+                    "data": [{"name": "hot", **_group_spec(32, "30000000000")}],
+                }
+            }
+        }
         new = copy.deepcopy(old)
         new["spec"]["nodes"]["data"][0]["resources"]["limits"]["cpu"] = 30
 

--- a/tests/test_change_compute.py
+++ b/tests/test_change_compute.py
@@ -19,6 +19,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import copy
 import logging
 from unittest import mock
 
@@ -31,7 +32,11 @@ from kubernetes_asyncio.client import (
     V1PodAntiAffinity,
 )
 
-from crate.operator.change_compute import generate_body_patch
+from crate.operator.change_compute import (
+    change_cluster_compute,
+    compute_payload_for_specs,
+    generate_body_patch,
+)
 from crate.operator.constants import API_GROUP, RESOURCE_CRATEDB
 from crate.operator.cratedb import connection_factory
 from crate.operator.webhooks import (
@@ -385,3 +390,179 @@ async def test_generate_body_patch(
             "toleration_seconds": None,
             "value": "any",
         }
+
+
+def _group_spec(cpu, memory, *, replicas=3, nodepool="dedicated", heap_ratio=0.25):
+    return {
+        "replicas": replicas,
+        "nodepool": nodepool,
+        "resources": {
+            "limits": {"cpu": cpu, "memory": memory},
+            "requests": {"cpu": cpu, "memory": memory},
+            "heapRatio": heap_ratio,
+        },
+    }
+
+
+class TestComputePayloadForSpecs:
+    def test_reads_resources_from_the_given_spec(self):
+        # Master resources are read independently from the master spec, so a
+        # master payload reflects the master's (possibly smaller) compute.
+        old_spec = _group_spec(16, "60000000000")
+        new_spec = _group_spec(8, "30000000000")
+
+        payload = compute_payload_for_specs(old_spec, new_spec)
+
+        assert payload["old_cpu_limit"] == 16
+        assert payload["new_cpu_limit"] == 8
+        assert payload["new_memory_limit"] == "30000000000"
+        assert payload["new_heap_ratio"] == 0.25
+        assert payload["new_nodepool"] == "dedicated"
+
+
+def _cluster_body(master_cpu, hot_cpu):
+    return {
+        "spec": {
+            "nodes": {
+                "master": _group_spec(master_cpu, "60000000000"),
+                "data": [{"name": "hot", **_group_spec(hot_cpu, "30000000000")}],
+            }
+        }
+    }
+
+
+class TestChangeClusterCompute:
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.change_compute.generate_body_patch",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_patches_only_the_master_when_only_master_changed(self, mock_patch):
+        mock_patch.return_value = {"spec": {}}
+        apps = mock.Mock()
+        apps.patch_namespaced_stateful_set = mock.AsyncMock()
+        old = _cluster_body(master_cpu=16, hot_cpu=32)
+        new = copy.deepcopy(old)
+        new["spec"]["nodes"]["master"]["resources"]["limits"]["cpu"] = 8
+
+        await change_cluster_compute(apps, "ns", "c", old, new, mock.Mock())
+
+        patched = [
+            call.kwargs["name"]
+            for call in apps.patch_namespaced_stateful_set.await_args_list
+        ]
+        assert patched == ["crate-master-c"]
+        # The master StatefulSet name is passed through explicitly.
+        assert mock_patch.await_args.kwargs["sts_name"] == "crate-master-c"
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.change_compute.generate_body_patch",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_patches_only_the_data_group_when_only_data_changed(self, mock_patch):
+        mock_patch.return_value = {"spec": {}}
+        apps = mock.Mock()
+        apps.patch_namespaced_stateful_set = mock.AsyncMock()
+        old = _cluster_body(master_cpu=16, hot_cpu=32)
+        new = copy.deepcopy(old)
+        new["spec"]["nodes"]["data"][0]["resources"]["limits"]["cpu"] = 30
+
+        await change_cluster_compute(apps, "ns", "c", old, new, mock.Mock())
+
+        patched = [
+            call.kwargs["name"]
+            for call in apps.patch_namespaced_stateful_set.await_args_list
+        ]
+        assert patched == ["crate-data-hot-c"]
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.change_compute.generate_body_patch",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_no_patch_when_nothing_changed(self, mock_patch):
+        apps = mock.Mock()
+        apps.patch_namespaced_stateful_set = mock.AsyncMock()
+        body = _cluster_body(master_cpu=16, hot_cpu=32)
+
+        await change_cluster_compute(apps, "ns", "c", body, body, mock.Mock())
+
+        apps.patch_namespaced_stateful_set.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.change_compute.generate_body_patch",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_legacy_cluster_without_masters(self, mock_patch):
+        mock_patch.return_value = {"spec": {}}
+        apps = mock.Mock()
+        apps.patch_namespaced_stateful_set = mock.AsyncMock()
+        old = {"spec": {"nodes": {"data": [{"name": "hot", **_group_spec(32, "30")}]}}}
+        new = copy.deepcopy(old)
+        new["spec"]["nodes"]["data"][0]["resources"]["limits"]["cpu"] = 30
+
+        await change_cluster_compute(apps, "ns", "c", old, new, mock.Mock())
+
+        patched = [
+            call.kwargs["name"]
+            for call in apps.patch_namespaced_stateful_set.await_args_list
+        ]
+        assert patched == ["crate-data-hot-c"]
+
+
+class TestUpdateCprocessorCrateSettings:
+    @pytest.mark.asyncio
+    async def test_updates_cprocessors_for_the_given_statefulset(self):
+        # A cpu change must rewrite -Cprocessors in the crate container command
+        # of whichever StatefulSet is passed (here the master STS), leaving the
+        # rest of the command untouched.
+        from crate.operator.change_compute import update_cprocessor_crate_settings
+
+        container = mock.Mock()
+        container.name = "crate"
+        container.command = [
+            "/docker-entrypoint.sh",
+            "crate",
+            "-Cprocessors=16",
+            "-Cnode.master=true",
+        ]
+        other = mock.Mock()
+        other.name = "sql-exporter"
+        other.command = ["-Cprocessors=999"]  # must not be touched
+        sts = mock.Mock()
+        sts.spec.template.spec.containers = [container, other]
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(return_value=sts)
+
+        updated = await update_cprocessor_crate_settings(
+            apps=apps, namespace="ns", sts_name="crate-master-c", processors=8
+        )
+
+        assert "-Cprocessors=8" in updated
+        assert "-Cprocessors=16" not in updated
+        assert "-Cnode.master=true" in updated
+        assert apps.read_namespaced_stateful_set.await_args.kwargs["name"] == (
+            "crate-master-c"
+        )
+
+    @pytest.mark.asyncio
+    async def test_rounds_cpu_up_to_match_create(self):
+        # A fractional CPU limit must be rounded up, the same way create.py
+        # bakes -Cprocessors, so the running and configured values agree.
+        from crate.operator.change_compute import update_cprocessor_crate_settings
+
+        container = mock.Mock()
+        container.name = "crate"
+        container.command = ["crate", "-Cprocessors=4"]
+        sts = mock.Mock()
+        sts.spec.template.spec.containers = [container]
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(return_value=sts)
+
+        updated = await update_cprocessor_crate_settings(
+            apps=apps, namespace="ns", sts_name="crate-master-c", processors=1.5
+        )
+
+        assert "-Cprocessors=2" in updated

--- a/tests/test_change_compute.py
+++ b/tests/test_change_compute.py
@@ -566,3 +566,38 @@ class TestUpdateCprocessorCrateSettings:
         )
 
         assert "-Cprocessors=2" in updated
+
+
+class TestGenerateChangeComputePayloadMaster:
+    def test_includes_master_compute_when_masters_present(self):
+        from crate.operator.change_compute import generate_change_compute_payload
+
+        old = {"spec": {"nodes": {
+            "master": _group_spec(16, "60000000000"),
+            "data": [{"name": "hot", **_group_spec(32, "30000000000")}],
+        }}}
+        new = copy.deepcopy(old)
+        new["spec"]["nodes"]["master"]["resources"]["limits"]["cpu"] = 8
+
+        payload = generate_change_compute_payload(old, new)
+
+        # Data fields stay as before; master compute is added additively.
+        assert payload["new_cpu_limit"] == 32
+        assert payload["old_master_cpu_limit"] == 16
+        assert payload["new_master_cpu_limit"] == 8
+        assert payload["new_master_memory_limit"] == "60000000000"
+
+    def test_omits_master_fields_for_legacy_cluster(self):
+        from crate.operator.change_compute import generate_change_compute_payload
+
+        old = {"spec": {"nodes": {
+            "data": [{"name": "hot", **_group_spec(32, "30000000000")}],
+        }}}
+        new = copy.deepcopy(old)
+        new["spec"]["nodes"]["data"][0]["resources"]["limits"]["cpu"] = 30
+
+        payload = generate_change_compute_payload(old, new)
+
+        assert payload["new_cpu_limit"] == 30
+        assert "old_master_cpu_limit" not in payload
+        assert "new_master_cpu_limit" not in payload

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -44,6 +44,8 @@ from crate.operator.constants import (
     LABEL_COMPONENT,
     LABEL_MANAGED_BY,
     LABEL_NAME,
+    LABEL_NODE_DATA,
+    LABEL_NODE_NAME,
     LABEL_PART_OF,
     RESOURCE_CRATEDB,
     TERMINATION_GRACE_PERIOD_SECONDS,
@@ -58,7 +60,9 @@ from crate.operator.create import (
     get_cluster_resource_limits,
     get_cluster_resource_requests,
     get_data_service,
+    get_discovery_service,
     get_sql_exporter_config,
+    get_statefulset,
     get_statefulset_affinity,
     get_statefulset_containers,
     get_statefulset_crate_command,
@@ -1188,6 +1192,109 @@ class TestServiceModels:
                 ]
                 == dns
             )
+
+    def test_data_service_selector_excludes_masters_with_dedicated_masters(self, faker):
+        name = faker.domain_word()
+        service = get_data_service(
+            None,
+            name,
+            {},
+            faker.port_number(),
+            faker.port_number(),
+            None,
+            has_dedicated_masters=True,
+        )
+        # With dedicated masters the client-facing service must only target data
+        # nodes, so masters (node-data=false) stay out of the load-balancer pool.
+        assert service.spec.selector == {
+            LABEL_COMPONENT: "cratedb",
+            LABEL_NAME: name,
+            LABEL_NODE_DATA: "true",
+        }
+
+    def test_data_service_selector_unchanged_without_masters(self, faker):
+        name = faker.domain_word()
+        service = get_data_service(
+            None, name, {}, faker.port_number(), faker.port_number(), None
+        )
+        # Data-only clusters keep the plain selector (no node-data), so the
+        # service still matches pre-existing, unlabelled pods on resume.
+        assert service.spec.selector == {
+            LABEL_COMPONENT: "cratedb",
+            LABEL_NAME: name,
+        }
+        assert LABEL_NODE_DATA not in service.spec.selector
+
+    def test_discovery_service_selects_all_nodes(self, faker):
+        name = faker.domain_word()
+        service = get_discovery_service(
+            None,
+            name,
+            {},
+            faker.port_number(),
+            faker.port_number(),
+            faker.port_number(),
+        )
+        # Discovery must reach every node (masters included) for the cluster to
+        # form, so it must not filter on node-data.
+        assert LABEL_NODE_DATA not in service.spec.selector
+        assert service.spec.selector == {
+            LABEL_COMPONENT: "cratedb",
+            LABEL_NAME: name,
+        }
+
+    @pytest.mark.parametrize(
+        "treat_as_data, node_name, expected_node_data",
+        [(True, "hot", "true"), (False, "master", "false")],
+    )
+    def test_statefulset_stamps_node_data_label(
+        self, faker, treat_as_data, node_name, expected_node_data
+    ):
+        name = faker.domain_word()
+        sts = get_statefulset(
+            None,
+            "some-namespace",
+            name,
+            {
+                LABEL_MANAGED_BY: "crate-operator",
+                LABEL_NAME: name,
+                LABEL_PART_OF: "cratedb",
+                LABEL_COMPONENT: "cratedb",
+            },
+            True,  # treat_as_master
+            treat_as_data,
+            name,  # cluster_name
+            node_name,
+            f"{node_name}-",
+            {
+                "replicas": 3,
+                "resources": {
+                    "requests": {"cpu": 0.5, "memory": "1Gi"},
+                    "limits": {"cpu": 0.5, "memory": "1Gi"},
+                    "heapRatio": 0.4,
+                    "disk": {"count": 1, "size": "16Gi", "storageClass": "default"},
+                },
+            },
+            ["master-1", "master-2", "master-3"],
+            3,
+            3,
+            10000,
+            20000,
+            30000,
+            40000,
+            50000,
+            f"crate:{CRATE_VERSION}",
+            None,
+            {},
+            [],
+            {},
+            logging.getLogger(__name__),
+        )
+        # The pod template carries node-data so the data service can select on
+        # it; data nodes are "true", dedicated masters are "false".
+        pod_labels = sts.spec.template.metadata.labels
+        assert pod_labels[LABEL_NODE_NAME] == node_name
+        assert pod_labels[LABEL_NODE_DATA] == expected_node_data
 
 
 @pytest.mark.k8s

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -18,6 +18,7 @@
 # However, if you have executed another commercial license agreement
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
+import logging
 from unittest import mock
 
 import bitmath
@@ -292,3 +293,51 @@ class TestExpandVolumePerGroup:
         )
 
         core.patch_namespaced_persistent_volume_claim.assert_not_awaited()
+
+
+def _disk_diff_data(old_size, new_size):
+    return kopf.DiffItem(
+        kopf.DiffOperation.CHANGE,
+        ("spec", "nodes", "data"),
+        [{"name": "hot", "resources": {"disk": {"size": old_size}}}],
+        [{"name": "hot", "resources": {"disk": {"size": new_size}}}],
+    )
+
+
+def _disk_diff_master(old_size, new_size):
+    return kopf.DiffItem(
+        kopf.DiffOperation.CHANGE,
+        ("spec", "nodes", "master", "resources", "disk", "size"),
+        old_size,
+        new_size,
+    )
+
+
+class TestCollectDiskExpansions:
+    def test_collects_master_and_data_groups(self):
+        from crate.operator.expand_volume import collect_disk_expansions
+
+        diff = kopf.Diff(
+            [_disk_diff_data("100", "200"), _disk_diff_master("50", "120")]
+        )
+
+        expansions = collect_disk_expansions(diff, logging.getLogger(__name__))
+
+        assert ("hot", "200") in expansions
+        assert ("master", "120") in expansions
+
+    def test_skips_data_groups_with_unchanged_size(self):
+        from crate.operator.expand_volume import collect_disk_expansions
+
+        diff = kopf.Diff([_disk_diff_data("200", "200")])
+
+        assert collect_disk_expansions(diff, logging.getLogger(__name__)) == []
+
+    def test_master_only_disk_change(self):
+        from crate.operator.expand_volume import collect_disk_expansions
+
+        diff = kopf.Diff([_disk_diff_master("50", "120")])
+
+        assert collect_disk_expansions(diff, logging.getLogger(__name__)) == [
+            ("master", "120")
+        ]

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -21,6 +21,7 @@
 from unittest import mock
 
 import bitmath
+import kopf
 import pytest
 from kubernetes_asyncio.client import (
     CoreV1Api,
@@ -199,3 +200,95 @@ async def _expand_volume(
         name=name,
         body=patch_body,
     )
+
+
+def _fake_pvc(*, requests_storage, capacity_storage, resize_pending=False):
+    pvc = mock.Mock()
+    pvc.spec.resources.requests = {"storage": requests_storage}
+    pvc.status.capacity = {"storage": capacity_storage}
+    condition = mock.Mock()
+    condition.type = "FileSystemResizePending"
+    pvc.status.conditions = [condition] if resize_pending else []
+    return pvc
+
+
+class TestExpandVolumePerGroup:
+    @pytest.mark.asyncio
+    @mock.patch("crate.operator.expand_volume.send_operation_progress_notification")
+    @mock.patch(
+        "crate.operator.expand_volume.get_pvcs_in_namespace",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_expands_master_pvcs_by_label(self, mock_get_pvcs, _mock_notify):
+        from crate.operator.expand_volume import expand_volume
+
+        mock_get_pvcs.return_value = [{"uid": "u", "name": "data0-crate-master-c-0"}]
+        core = mock.Mock()
+        # Already physically resized, so no retry is raised.
+        core.read_namespaced_persistent_volume_claim = mock.AsyncMock(
+            return_value=_fake_pvc(
+                requests_storage="137438953472", capacity_storage="274877906944"
+            )
+        )
+        core.patch_namespaced_persistent_volume_claim = mock.AsyncMock()
+
+        await expand_volume(
+            core, "ns", "c", [("master", "274877906944")], mock.Mock()
+        )
+
+        # PVCs were looked up by the master node label.
+        assert mock_get_pvcs.await_args.args[3] == "master"
+        # The PVC was patched to the new size.
+        patch_body = core.patch_namespaced_persistent_volume_claim.await_args.kwargs[
+            "body"
+        ]
+        assert (
+            patch_body["spec"]["resources"]["requests"]["storage"] == "274877906944"
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("crate.operator.expand_volume.send_operation_progress_notification")
+    @mock.patch(
+        "crate.operator.expand_volume.get_pvcs_in_namespace",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_retries_while_resize_in_progress(self, mock_get_pvcs, _mock_notify):
+        from crate.operator.expand_volume import expand_volume
+
+        mock_get_pvcs.return_value = [{"uid": "u", "name": "data0-crate-master-c-0"}]
+        core = mock.Mock()
+        core.read_namespaced_persistent_volume_claim = mock.AsyncMock(
+            return_value=_fake_pvc(
+                requests_storage="137438953472", capacity_storage="137438953472"
+            )
+        )
+        core.patch_namespaced_persistent_volume_claim = mock.AsyncMock()
+
+        with pytest.raises(kopf.TemporaryError):
+            await expand_volume(
+                core, "ns", "c", [("master", "274877906944")], mock.Mock()
+            )
+
+    @pytest.mark.asyncio
+    @mock.patch("crate.operator.expand_volume.send_operation_progress_notification")
+    @mock.patch(
+        "crate.operator.expand_volume.get_pvcs_in_namespace",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_noop_when_already_at_target_size(self, mock_get_pvcs, _mock_notify):
+        from crate.operator.expand_volume import expand_volume
+
+        mock_get_pvcs.return_value = [{"uid": "u", "name": "data0-crate-master-c-0"}]
+        core = mock.Mock()
+        core.read_namespaced_persistent_volume_claim = mock.AsyncMock(
+            return_value=_fake_pvc(
+                requests_storage="274877906944", capacity_storage="274877906944"
+            )
+        )
+        core.patch_namespaced_persistent_volume_claim = mock.AsyncMock()
+
+        await expand_volume(
+            core, "ns", "c", [("master", "274877906944")], mock.Mock()
+        )
+
+        core.patch_namespaced_persistent_volume_claim.assert_not_awaited()

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -203,13 +203,19 @@ async def _expand_volume(
     )
 
 
-def _fake_pvc(*, requests_storage, capacity_storage, resize_pending=False):
+def _fake_pvc(
+    *, requests_storage, capacity_storage, resize_pending=False, condition_type=None
+):
     pvc = mock.Mock()
     pvc.spec.resources.requests = {"storage": requests_storage}
     pvc.status.capacity = {"storage": capacity_storage}
-    condition = mock.Mock()
-    condition.type = "FileSystemResizePending"
-    pvc.status.conditions = [condition] if resize_pending else []
+    ctype = condition_type or ("FileSystemResizePending" if resize_pending else None)
+    if ctype:
+        condition = mock.Mock()
+        condition.type = ctype
+        pvc.status.conditions = [condition]
+    else:
+        pvc.status.conditions = []
     return pvc
 
 
@@ -267,6 +273,34 @@ class TestExpandVolumePerGroup:
             await expand_volume(
                 core, "ns", "c", [("master", "274877906944")], mock.Mock()
             )
+
+    @pytest.mark.asyncio
+    @mock.patch("crate.operator.expand_volume.send_operation_progress_notification")
+    @mock.patch(
+        "crate.operator.expand_volume.get_pvcs_in_namespace",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_accepts_resizing_condition_without_waiting(
+        self, mock_get_pvcs, _mock_notify
+    ):
+        """Once the control plane has accepted the expansion (PVC ``Resizing``),
+        the handler must not block waiting for the physical resize to finish --
+        on slow backends (e.g. azure-disk) that would time out unnecessarily."""
+        from crate.operator.expand_volume import expand_volume
+
+        mock_get_pvcs.return_value = [{"uid": "u", "name": "data0-crate-master-c-0"}]
+        core = mock.Mock()
+        # Accepted (Resizing) but capacity not yet grown -> must NOT raise.
+        core.read_namespaced_persistent_volume_claim = mock.AsyncMock(
+            return_value=_fake_pvc(
+                requests_storage="137438953472",
+                capacity_storage="137438953472",
+                condition_type="Resizing",
+            )
+        )
+        core.patch_namespaced_persistent_volume_claim = mock.AsyncMock()
+
+        await expand_volume(core, "ns", "c", [("master", "274877906944")], mock.Mock())
 
     @pytest.mark.asyncio
     @mock.patch("crate.operator.expand_volume.send_operation_progress_notification")

--- a/tests/test_expand_volume.py
+++ b/tests/test_expand_volume.py
@@ -233,19 +233,17 @@ class TestExpandVolumePerGroup:
         )
         core.patch_namespaced_persistent_volume_claim = mock.AsyncMock()
 
-        await expand_volume(
-            core, "ns", "c", [("master", "274877906944")], mock.Mock()
-        )
+        await expand_volume(core, "ns", "c", [("master", "274877906944")], mock.Mock())
 
         # PVCs were looked up by the master node label.
-        assert mock_get_pvcs.await_args.args[3] == "master"
+        get_pvcs_call = mock_get_pvcs.await_args
+        assert get_pvcs_call is not None
+        assert get_pvcs_call.args[3] == "master"
         # The PVC was patched to the new size.
-        patch_body = core.patch_namespaced_persistent_volume_claim.await_args.kwargs[
-            "body"
-        ]
-        assert (
-            patch_body["spec"]["resources"]["requests"]["storage"] == "274877906944"
-        )
+        patch_call = core.patch_namespaced_persistent_volume_claim.await_args
+        assert patch_call is not None
+        patch_body = patch_call.kwargs["body"]
+        assert patch_body["spec"]["resources"]["requests"]["storage"] == "274877906944"
 
     @pytest.mark.asyncio
     @mock.patch("crate.operator.expand_volume.send_operation_progress_notification")
@@ -288,9 +286,7 @@ class TestExpandVolumePerGroup:
         )
         core.patch_namespaced_persistent_volume_claim = mock.AsyncMock()
 
-        await expand_volume(
-            core, "ns", "c", [("master", "274877906944")], mock.Mock()
-        )
+        await expand_volume(core, "ns", "c", [("master", "274877906944")], mock.Mock())
 
         core.patch_namespaced_persistent_volume_claim.assert_not_awaited()
 

--- a/tests/test_master_nodes.py
+++ b/tests/test_master_nodes.py
@@ -1,0 +1,468 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+"""
+End-to-end tests for dedicated master nodes.
+
+These tests create, suspend, expand and delete *real* CrateDB clusters. Like
+all ``k8s`` tests they only run against the contexts allowed by ``conftest``
+(a ``crate-*`` context, e.g. CI's disposable cluster, or ``minikube``), and are
+skipped entirely unless ``--kube-config`` is given.
+
+Locally, run them against a kubeconfig that contains only minikube, e.g.::
+
+    export KUBECONFIG=/tmp/minikube-only.kubeconfig
+    minikube start --cpus 6 --memory 12288
+    python -m pytest tests/test_master_nodes.py -m k8s -vvv \\
+        --kube-config "$KUBECONFIG" --kube-context minikube
+"""
+
+import asyncio
+import logging
+from unittest import mock
+
+import pytest
+from kubernetes_asyncio.client import (
+    AppsV1Api,
+    CoreV1Api,
+    CustomObjectsApi,
+    StorageV1Api,
+    V1Namespace,
+)
+
+from crate.operator.config import config
+from crate.operator.constants import (
+    API_GROUP,
+    DATA_PVC_NAME_PREFIX,
+    KOPF_STATE_STORE_PREFIX,
+    RESOURCE_CRATEDB,
+)
+from crate.operator.cratedb import connection_factory
+from crate.operator.operations import get_pods_in_statefulset
+from crate.operator.utils.formatting import convert_to_bytes
+from crate.operator.utils.kubeapi import get_host
+from crate.operator.webhooks import WebhookEvent
+from tests.utils import (
+    DEFAULT_TIMEOUT,
+    assert_wait_for,
+    create_test_sys_jobs_table,
+    is_cluster_healthy,
+    is_kopf_handler_finished,
+    require_connection,
+    start_cluster,
+)
+
+# Dedicated-master e2e. These run as part of the normal suite; mark them so the
+# whole module can be selected on its own with ``pytest -m master`` (and
+# excluded with ``-m "not master"`` if ever needed).
+pytestmark = pytest.mark.master
+
+
+# The CRD enforces an odd master count >= 3. Three small masters + one data
+# node keeps a master cluster within a local minikube's resources while still
+# exercising the masters-first ordering. cpu must be a number (not "500m").
+MASTER_REPLICAS = 3
+HOT_REPLICAS = 1
+SMALL_RESOURCES = {
+    "limits": {"cpu": 1, "memory": "2Gi"},
+    "requests": {"cpu": 0.5, "memory": "1Gi"},
+}
+
+
+async def _master_sts(apps: AppsV1Api, namespace: str, name: str):
+    return await apps.read_namespaced_stateful_set(
+        namespace=namespace, name=f"crate-master-{name}"
+    )
+
+
+async def _master_sts_replicas(apps: AppsV1Api, namespace: str, name: str) -> int:
+    return (await _master_sts(apps, namespace, name)).spec.replicas
+
+
+async def _master_pods_gone(core: CoreV1Api, namespace: str, name: str) -> bool:
+    return len(await get_pods_in_statefulset(core, namespace, name, "master")) == 0
+
+
+async def _master_pods_present(core: CoreV1Api, namespace: str, name: str) -> bool:
+    return len(await get_pods_in_statefulset(core, namespace, name, "master")) > 0
+
+
+def _scale_data(coapi, name, namespace, replicas):
+    return coapi.patch_namespaced_custom_object(
+        group=API_GROUP,
+        version="v1",
+        plural=RESOURCE_CRATEDB,
+        namespace=namespace.metadata.name,
+        name=name,
+        body=[
+            {"op": "replace", "path": "/spec/nodes/data/0/replicas", "value": replicas}
+        ],
+    )
+
+
+def _patch(coapi, name, namespace, path, value):
+    return coapi.patch_namespaced_custom_object(
+        group=API_GROUP,
+        version="v1",
+        plural=RESOURCE_CRATEDB,
+        namespace=namespace.metadata.name,
+        name=name,
+        body=[{"op": "replace", "path": path, "value": value}],
+    )
+
+
+def _scale_webhook_reported_master(mock_send, *, new_master_replicas) -> bool:
+    for call in mock_send.await_args_list:
+        if (
+            call.args[2] == WebhookEvent.SCALE
+            and call.args[3].get("new_master_replicas") == new_master_replicas
+        ):
+            return True
+    return False
+
+
+def _compute_webhook_reported_master(mock_send) -> bool:
+    for call in mock_send.await_args_list:
+        if (
+            call.args[2] == WebhookEvent.COMPUTE_CHANGED
+            and call.args[3].get("new_master_cpu_limit") is not None
+        ):
+            return True
+    return False
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+async def test_create_cluster_with_dedicated_masters(
+    faker, namespace, kopf_runner, api_client
+):
+    """A cluster with dedicated masters forms successfully: the master STS is
+    created and ready, and the cluster reports masters + data nodes healthy
+    (which only happens if masters come up before data)."""
+    apps = AppsV1Api(api_client)
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+
+    host, password = await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        hot_nodes=HOT_REPLICAS,
+        master_nodes=MASTER_REPLICAS,
+        resource_requests=SMALL_RESOURCES,
+    )
+
+    assert await _master_sts_replicas(apps, namespace.metadata.name, name) == (
+        MASTER_REPLICAS
+    )
+    assert await _master_pods_present(core, namespace.metadata.name, name)
+
+    # Healthy with the *combined* node count -> masters joined the cluster.
+    await assert_wait_for(
+        True,
+        is_cluster_healthy,
+        connection_factory(*require_connection(host, password)),
+        MASTER_REPLICAS + HOT_REPLICAS,
+        err_msg="Master cluster wasn't healthy.",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+@mock.patch("crate.operator.webhooks.webhook_client.send_notification")
+async def test_suspend_resume_cluster_with_masters(
+    mock_send, faker, namespace, kopf_runner, api_client
+):
+    """Suspend scales masters to 0 (after data); resume brings them back (before
+    data). The SCALE webhook reports the effective master count: 0 on suspend,
+    restored on resume (B1)."""
+    apps = AppsV1Api(api_client)
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+
+    host, password = await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        hot_nodes=HOT_REPLICAS,
+        master_nodes=MASTER_REPLICAS,
+        resource_requests=SMALL_RESOURCES,
+    )
+    # before_cluster_update checks for running snapshots via the configured
+    # JOBS_TABLE, so it must exist or every update operation stalls.
+    await create_test_sys_jobs_table(
+        connection_factory(*require_connection(host, password))
+    )
+
+    # --- Suspend ---
+    await _scale_data(coapi, name, namespace, 0)
+    await asyncio.sleep(1.0)
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Suspend has not finished",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+    # Masters scaled to 0 and their pods are gone.
+    assert await _master_sts_replicas(apps, namespace.metadata.name, name) == 0
+    await assert_wait_for(
+        True,
+        _master_pods_gone,
+        core,
+        namespace.metadata.name,
+        name,
+        err_msg="Master pods still present after suspend.",
+        timeout=DEFAULT_TIMEOUT,
+    )
+    # B1: billing sees the masters as effectively 0 while suspended.
+    assert _scale_webhook_reported_master(mock_send, new_master_replicas=0)
+
+    # --- Resume ---
+    await _scale_data(coapi, name, namespace, HOT_REPLICAS)
+    await asyncio.sleep(1.0)
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Resume has not finished",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+    assert await _master_sts_replicas(apps, namespace.metadata.name, name) == (
+        MASTER_REPLICAS
+    )
+    host = await get_host(core, namespace.metadata.name, name)
+    await assert_wait_for(
+        True,
+        is_cluster_healthy,
+        connection_factory(*require_connection(host, password)),
+        MASTER_REPLICAS + HOT_REPLICAS,
+        err_msg="Cluster wasn't healthy after resume.",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+    # B1: masters restored on resume.
+    assert _scale_webhook_reported_master(
+        mock_send, new_master_replicas=MASTER_REPLICAS
+    )
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+@mock.patch("crate.operator.webhooks.webhook_client.send_notification")
+async def test_change_compute_on_master(
+    mock_send, faker, namespace, kopf_runner, api_client
+):
+    """Changing a master's CPU patches the master StatefulSet (and -Cprocessors)
+    and emits master compute in the CHANGE_COMPUTE webhook (B2)."""
+    apps = AppsV1Api(api_client)
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+
+    host, password = await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        hot_nodes=HOT_REPLICAS,
+        master_nodes=MASTER_REPLICAS,
+        resource_requests=SMALL_RESOURCES,
+    )
+    # before_cluster_update checks for running snapshots via the configured
+    # JOBS_TABLE, so it must exist or the compute change stalls.
+    await create_test_sys_jobs_table(
+        connection_factory(*require_connection(host, password))
+    )
+
+    await _patch(coapi, name, namespace, "/spec/nodes/master/resources/limits/cpu", 2)
+    await asyncio.sleep(1.0)
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Master compute change has not finished",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+    sts = await _master_sts(apps, namespace.metadata.name, name)
+    crate_container = next(
+        c for c in sts.spec.template.spec.containers if c.name == "crate"
+    )
+    assert crate_container.resources.limits["cpu"] == str(2)
+    assert "-Cprocessors=2" in crate_container.command
+
+    # B2: master compute is present in the CHANGE_COMPUTE webhook.
+    assert _compute_webhook_reported_master(mock_send)
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+async def test_expand_master_volume(faker, namespace, kopf_runner, api_client):
+    """Increasing the master disk size resizes the master PVCs."""
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+
+    await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        hot_nodes=HOT_REPLICAS,
+        master_nodes=MASTER_REPLICAS,
+        resource_requests=SMALL_RESOURCES,
+    )
+
+    # Volume expansion only works if the StorageClass allows it (e.g. some
+    # StorageClasses don't); skip rather than fail when it doesn't.
+    storage = StorageV1Api(api_client)
+    sc = await storage.read_storage_class(name=config.DEBUG_VOLUME_STORAGE_CLASS)
+    if sc.allow_volume_expansion is not True:
+        pytest.skip(
+            f"StorageClass {config.DEBUG_VOLUME_STORAGE_CLASS} does not allow "
+            "volume expansion."
+        )
+
+    new_size = "32GiB"
+    await _patch(
+        coapi, name, namespace, "/spec/nodes/master/resources/disk/size", new_size
+    )
+    await asyncio.sleep(1.0)
+
+    # Wait for the operator to finish the expansion first (race-free), then
+    # inspect the master PVCs once.
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Master volume expansion has not finished",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+    pvcs = await core.list_namespaced_persistent_volume_claim(
+        namespace=namespace.metadata.name
+    )
+    # Filter master PVCs by name (a label selector with a slashed key behaved
+    # unreliably here). Log everything so a failure is diagnosable from the run.
+    all_names = [pvc.metadata.name for pvc in pvcs.items]
+    # Match only the master *data*-disk PVCs (data0-crate-master-...): each pod
+    # also has a separate "debug" volume (debug-crate-master-...) that is not
+    # expanded, so it must be excluded.
+    sizes = {
+        pvc.metadata.name: pvc.spec.resources.requests.get("storage")
+        for pvc in pvcs.items
+        if pvc.metadata.name.startswith(DATA_PVC_NAME_PREFIX)
+        and f"crate-master-{name}" in pvc.metadata.name
+    }
+    logging.getLogger(__name__).warning(
+        "expand check: cluster=%s target=%s all_pvcs=%s master_sizes=%s",
+        name,
+        new_size,
+        all_names,
+        sizes,
+    )
+    assert sizes, f"no master PVCs matched 'crate-master-{name}' in {all_names}"
+    target = convert_to_bytes(new_size)
+    not_resized = {
+        n: s for n, s in sizes.items() if s is None or convert_to_bytes(s) != target
+    }
+    assert not not_resized, f"master PVCs not resized to {new_size}: {not_resized}"
+
+
+@pytest.mark.k8s
+@pytest.mark.asyncio
+async def test_legacy_cluster_without_masters_regression(
+    faker, namespace, kopf_runner, api_client
+):
+    """Regression: a cluster without dedicated masters still creates, suspends
+    and resumes correctly (no master logic kicks in)."""
+    apps = AppsV1Api(api_client)
+    coapi = CustomObjectsApi(api_client)
+    core = CoreV1Api(api_client)
+    name = faker.domain_word()
+
+    host, password = await start_cluster(
+        name,
+        namespace,
+        core,
+        coapi,
+        hot_nodes=HOT_REPLICAS,
+        resource_requests=SMALL_RESOURCES,
+    )
+    await create_test_sys_jobs_table(
+        connection_factory(*require_connection(host, password))
+    )
+
+    # No master StatefulSet exists for a legacy cluster.
+    stss = await apps.list_namespaced_stateful_set(namespace=namespace.metadata.name)
+    assert f"crate-master-{name}" not in {s.metadata.name for s in stss.items}
+
+    # Suspend / resume round-trip still works.
+    await _scale_data(coapi, name, namespace, 0)
+    await asyncio.sleep(1.0)
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Suspend has not finished",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+    await _scale_data(coapi, name, namespace, HOT_REPLICAS)
+    await asyncio.sleep(1.0)
+    await assert_wait_for(
+        True,
+        is_kopf_handler_finished,
+        coapi,
+        name,
+        namespace.metadata.name,
+        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
+        err_msg="Resume has not finished",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )
+    host = await get_host(core, namespace.metadata.name, name)
+    await assert_wait_for(
+        True,
+        is_cluster_healthy,
+        connection_factory(*require_connection(host, password)),
+        HOT_REPLICAS,
+        err_msg="Legacy cluster wasn't healthy after resume.",
+        timeout=DEFAULT_TIMEOUT * 5,
+    )

--- a/tests/test_master_nodes.py
+++ b/tests/test_master_nodes.py
@@ -36,7 +36,6 @@ Locally, run them against a kubeconfig that contains only minikube, e.g.::
 """
 
 import asyncio
-import logging
 from unittest import mock
 
 import pytest
@@ -44,19 +43,15 @@ from kubernetes_asyncio.client import (
     AppsV1Api,
     CoreV1Api,
     CustomObjectsApi,
-    StorageV1Api,
 )
 
-from crate.operator.config import config
 from crate.operator.constants import (
     API_GROUP,
-    DATA_PVC_NAME_PREFIX,
     KOPF_STATE_STORE_PREFIX,
     RESOURCE_CRATEDB,
 )
 from crate.operator.cratedb import connection_factory
 from crate.operator.operations import get_pods_in_statefulset
-from crate.operator.utils.formatting import convert_to_bytes
 from crate.operator.utils.kubeapi import get_host
 from crate.operator.webhooks import WebhookEvent
 from tests.utils import (
@@ -324,83 +319,6 @@ async def test_change_compute_on_master(
 
     # B2: master compute is present in the CHANGE_COMPUTE webhook.
     assert _compute_webhook_reported_master(mock_send)
-
-
-@pytest.mark.k8s
-@pytest.mark.asyncio
-async def test_expand_master_volume(faker, namespace, kopf_runner, api_client):
-    """Increasing the master disk size resizes the master PVCs."""
-    coapi = CustomObjectsApi(api_client)
-    core = CoreV1Api(api_client)
-    name = faker.domain_word()
-
-    await start_cluster(
-        name,
-        namespace,
-        core,
-        coapi,
-        hot_nodes=HOT_REPLICAS,
-        master_nodes=MASTER_REPLICAS,
-        resource_requests=SMALL_RESOURCES,
-    )
-
-    # Volume expansion only works if the StorageClass allows it (e.g. some
-    # StorageClasses don't); skip rather than fail when it doesn't.
-    storage = StorageV1Api(api_client)
-    sc = await storage.read_storage_class(name=config.DEBUG_VOLUME_STORAGE_CLASS)
-    if sc.allow_volume_expansion is not True:
-        pytest.skip(
-            f"StorageClass {config.DEBUG_VOLUME_STORAGE_CLASS} does not allow "
-            "volume expansion."
-        )
-
-    new_size = "32GiB"
-    await _patch(
-        coapi, name, namespace, "/spec/nodes/master/resources/disk/size", new_size
-    )
-    await asyncio.sleep(1.0)
-
-    # Wait for the operator to finish the expansion first (race-free), then
-    # inspect the master PVCs once.
-    await assert_wait_for(
-        True,
-        is_kopf_handler_finished,
-        coapi,
-        name,
-        namespace.metadata.name,
-        f"{KOPF_STATE_STORE_PREFIX}/cluster_update",
-        err_msg="Master volume expansion has not finished",
-        timeout=DEFAULT_TIMEOUT * 5,
-    )
-
-    pvcs = await core.list_namespaced_persistent_volume_claim(
-        namespace=namespace.metadata.name
-    )
-    # Filter master PVCs by name (a label selector with a slashed key behaved
-    # unreliably here). Log everything so a failure is diagnosable from the run.
-    all_names = [pvc.metadata.name for pvc in pvcs.items]
-    # Match only the master *data*-disk PVCs (data0-crate-master-...): each pod
-    # also has a separate "debug" volume (debug-crate-master-...) that is not
-    # expanded, so it must be excluded.
-    sizes = {
-        pvc.metadata.name: pvc.spec.resources.requests.get("storage")
-        for pvc in pvcs.items
-        if pvc.metadata.name.startswith(DATA_PVC_NAME_PREFIX)
-        and f"crate-master-{name}" in pvc.metadata.name
-    }
-    logging.getLogger(__name__).warning(
-        "expand check: cluster=%s target=%s all_pvcs=%s master_sizes=%s",
-        name,
-        new_size,
-        all_names,
-        sizes,
-    )
-    assert sizes, f"no master PVCs matched 'crate-master-{name}' in {all_names}"
-    target = convert_to_bytes(new_size)
-    not_resized = {
-        n: s for n, s in sizes.items() if s is None or convert_to_bytes(s) != target
-    }
-    assert not not_resized, f"master PVCs not resized to {new_size}: {not_resized}"
 
 
 @pytest.mark.k8s

--- a/tests/test_master_nodes.py
+++ b/tests/test_master_nodes.py
@@ -39,11 +39,7 @@ import asyncio
 from unittest import mock
 
 import pytest
-from kubernetes_asyncio.client import (
-    AppsV1Api,
-    CoreV1Api,
-    CustomObjectsApi,
-)
+from kubernetes_asyncio.client import AppsV1Api, CoreV1Api, CustomObjectsApi
 
 from crate.operator.constants import (
     API_GROUP,

--- a/tests/test_master_nodes.py
+++ b/tests/test_master_nodes.py
@@ -99,6 +99,25 @@ async def _master_pods_present(core: CoreV1Api, namespace: str, name: str) -> bo
     return len(await get_pods_in_statefulset(core, namespace, name, "master")) > 0
 
 
+async def _data_service_target_pods(core: CoreV1Api, namespace: str, name: str):
+    """Pod names currently backing the client-facing ``crate-<name>`` service."""
+    ep = await core.read_namespaced_endpoints(f"crate-{name}", namespace)
+    return {
+        addr.target_ref.name
+        for subset in (ep.subsets or [])
+        for addr in (subset.addresses or [])
+        if addr.target_ref is not None
+    }
+
+
+async def _data_service_excludes_masters(
+    core: CoreV1Api, namespace: str, name: str
+) -> bool:
+    """True once the client service has endpoints, none of them master pods."""
+    pods = await _data_service_target_pods(core, namespace, name)
+    return bool(pods) and not any(p.startswith(f"crate-master-{name}-") for p in pods)
+
+
 def _scale_data(coapi, name, namespace, replicas):
     return coapi.patch_namespaced_custom_object(
         group=API_GROUP,
@@ -179,6 +198,18 @@ async def test_create_cluster_with_dedicated_masters(
         MASTER_REPLICAS + HOT_REPLICAS,
         err_msg="Master cluster wasn't healthy.",
         timeout=DEFAULT_TIMEOUT * 5,
+    )
+
+    # The client-facing service must route to data nodes only: dedicated
+    # masters are deliberately kept out of the load-balancer pool.
+    await assert_wait_for(
+        True,
+        _data_service_excludes_masters,
+        core,
+        namespace.metadata.name,
+        name,
+        err_msg="dedicated master pods must be excluded from the client service",
+        timeout=DEFAULT_TIMEOUT,
     )
 
 

--- a/tests/test_master_nodes.py
+++ b/tests/test_master_nodes.py
@@ -45,7 +45,6 @@ from kubernetes_asyncio.client import (
     CoreV1Api,
     CustomObjectsApi,
     StorageV1Api,
-    V1Namespace,
 )
 
 from crate.operator.config import config

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -19,6 +19,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import contextlib
 from unittest import mock
 
 import kopf
@@ -30,6 +31,8 @@ from crate.operator.operations import (
     check_all_master_nodes_present,
     iter_node_groups,
     scale_master_statefulset,
+    suspend_or_start_cluster,
+    validate_node_spec,
 )
 
 
@@ -212,3 +215,208 @@ class TestScaleMasterStatefulset:
         await scale_master_statefulset(apps, "ns", "c", 3, mock.Mock())
 
         mock_update.assert_not_awaited()
+
+
+class TestValidateNodeSpec:
+    def test_accepts_data_only_cluster(self):
+        validate_node_spec({"data": [{"name": "hot", "replicas": 3}]}, mock.Mock())
+
+    def test_accepts_dedicated_masters_odd_ge_three(self):
+        for replicas in (3, 5, 7):
+            validate_node_spec(
+                {
+                    "master": {"replicas": replicas},
+                    "data": [{"name": "hot", "replicas": 1}],
+                },
+                mock.Mock(),
+            )
+
+    def test_rejects_missing_data_group(self):
+        with pytest.raises(kopf.PermanentError, match="at least one data node group"):
+            validate_node_spec({"master": {"replicas": 3}}, mock.Mock())
+
+    def test_rejects_empty_data_group(self):
+        with pytest.raises(kopf.PermanentError, match="at least one data node group"):
+            validate_node_spec({"data": []}, mock.Mock())
+
+    def test_rejects_even_master_replicas(self):
+        with pytest.raises(kopf.PermanentError, match="odd number >= 3"):
+            validate_node_spec(
+                {
+                    "master": {"replicas": 4},
+                    "data": [{"name": "hot", "replicas": 1}],
+                },
+                mock.Mock(),
+            )
+
+    def test_rejects_fewer_than_three_masters(self):
+        with pytest.raises(kopf.PermanentError, match="odd number >= 3"):
+            validate_node_spec(
+                {
+                    "master": {"replicas": 1},
+                    "data": [{"name": "hot", "replicas": 1}],
+                },
+                mock.Mock(),
+            )
+
+
+def _suspend_resume_patches(order, master_replicas=3, data_groups=None):
+    """
+    Patch every collaborator ``suspend_or_start_cluster`` calls so the function
+    runs end to end against mocks, recording the ordering-relevant calls into
+    ``order``. Returns an ``ExitStack`` of the active patches.
+    """
+    if data_groups is None:
+        data_groups = [{"name": "hot", "replicas": 0}]
+    cratedb = {
+        "spec": {
+            "nodes": {"master": {"replicas": master_replicas}, "data": data_groups}
+        },
+        "metadata": {},
+    }
+
+    async def _record(label, *args, **kwargs):
+        order.append(label)
+
+    async def _scale_master(apps, namespace, name, target, logger):
+        order.append(f"master_scale:{target}")
+
+    async def _scale_data(apps, namespace, sts_name, sts, new_replicas):
+        order.append(f"data_scale:{new_replicas}")
+
+    p = mock.patch
+    M = "crate.operator.operations."
+    stack = contextlib.ExitStack()
+    stack.enter_context(
+        p(M + "get_cratedb_resource", new=mock.AsyncMock(return_value=cratedb))
+    )
+    stack.enter_context(
+        p(M + "scale_master_statefulset", new=mock.AsyncMock(side_effect=_scale_master))
+    )
+    stack.enter_context(
+        p(
+            M + "check_all_master_nodes_present",
+            new=mock.AsyncMock(
+                side_effect=lambda *a, **k: order.append("masters_present")
+            ),
+        )
+    )
+    stack.enter_context(
+        p(
+            M + "check_all_master_nodes_gone",
+            new=mock.AsyncMock(
+                side_effect=lambda *a, **k: order.append("masters_gone")
+            ),
+        )
+    )
+    stack.enter_context(
+        p(
+            M + "check_all_data_nodes_gone",
+            new=mock.AsyncMock(side_effect=lambda *a, **k: order.append("data_gone")),
+        )
+    )
+    stack.enter_context(
+        p(
+            M + "check_cluster_healthy",
+            new=mock.AsyncMock(
+                side_effect=lambda *a, **k: order.append("health_check")
+            ),
+        )
+    )
+    stack.enter_context(
+        p(
+            M + "update_statefulset_replicas",
+            new=mock.AsyncMock(side_effect=_scale_data),
+        )
+    )
+    stack.enter_context(
+        p(M + "is_service_present", new=mock.AsyncMock(return_value=True))
+    )
+    stack.enter_context(
+        p(M + "is_lb_service_ready", new=mock.AsyncMock(return_value=True))
+    )
+    for fn in (
+        "recreate_services",
+        "send_operation_progress_notification",
+        "suspend_or_start_grand_central",
+        "delete_lb_service",
+        "update_deployment_replicas",
+        "_get_connection_factory",
+        "check_all_data_nodes_present",
+    ):
+        stack.enter_context(p(M + fn, new=mock.AsyncMock()))
+    return stack
+
+
+def _data_scaling_diff(old_replicas, new_replicas):
+    return kopf.Diff(
+        [
+            kopf.DiffItem(
+                kopf.DiffOperation.CHANGE,
+                ("0", "replicas"),
+                old_replicas,
+                new_replicas,
+            )
+        ]
+    )
+
+
+class TestSuspendResumeOrdering:
+    @pytest.mark.asyncio
+    async def test_resume_brings_masters_up_before_data(self):
+        # On resume the masters must form a quorum *before* the data nodes are
+        # scaled back up, otherwise the cluster can't recover.
+        order: list = []
+        old = {"spec": {"nodes": {"data": [{"name": "hot", "replicas": 0}]}}}
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(spec_replicas=0)
+        )
+
+        with _suspend_resume_patches(order):
+            await suspend_or_start_cluster(
+                apps,
+                mock.Mock(),
+                "ns",
+                "c",
+                old,
+                _data_scaling_diff(0, 3),
+                False,
+                mock.Mock(),
+            )
+
+        assert "master_scale:3" in order
+        assert "data_scale:3" in order
+        assert order.index("master_scale:3") < order.index("data_scale:3")
+        assert order.index("masters_present") < order.index("data_scale:3")
+
+    @pytest.mark.asyncio
+    async def test_suspend_scales_masters_down_after_data_is_gone(self):
+        # On suspend the masters go to zero only *after* every data node is gone
+        # -- never out from under running data nodes (the deadlock-fix order).
+        order: list = []
+        old = {"spec": {"nodes": {"data": [{"name": "hot", "replicas": 3}]}}}
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(spec_replicas=3)
+        )
+
+        with _suspend_resume_patches(
+            order, data_groups=[{"name": "hot", "replicas": 0}]
+        ):
+            await suspend_or_start_cluster(
+                apps,
+                mock.Mock(),
+                "ns",
+                "c",
+                old,
+                _data_scaling_diff(3, 0),
+                False,
+                mock.Mock(),
+            )
+
+        assert "data_gone" in order
+        assert "master_scale:0" in order
+        assert order.index("data_scale:0") < order.index("master_scale:0")
+        assert order.index("data_gone") < order.index("master_scale:0")
+        assert order.index("master_scale:0") < order.index("masters_gone")

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -19,7 +19,32 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-from crate.operator.operations import iter_node_groups
+from unittest import mock
+
+import kopf
+import pytest
+
+from crate.operator.handlers.handle_update_cratedb import _data_nodes_cross_zero
+from crate.operator.operations import (
+    check_all_master_nodes_gone,
+    check_all_master_nodes_present,
+    iter_node_groups,
+    scale_master_statefulset,
+)
+
+
+def _data_diff(old_replicas, new_replicas):
+    """A ``spec.nodes.data`` diff for a single group changing replica count."""
+    return kopf.Diff(
+        [
+            kopf.DiffItem(
+                kopf.DiffOperation.CHANGE,
+                ("spec", "nodes", "data"),
+                [{"name": "hot", "replicas": old_replicas}],
+                [{"name": "hot", "replicas": new_replicas}],
+            )
+        ]
+    )
 
 
 class TestIterNodeGroups:
@@ -68,3 +93,122 @@ class TestIterNodeGroups:
 
         assert groups[0].spec is master_spec
         assert "name" not in groups[0].spec
+
+
+class TestDataNodesCrossZero:
+    def test_suspend_is_detected(self):
+        assert _data_nodes_cross_zero(_data_diff(3, 0)) is True
+
+    def test_resume_is_detected(self):
+        assert _data_nodes_cross_zero(_data_diff(0, 3)) is True
+
+    def test_plain_scale_is_not_suspend_or_resume(self):
+        assert _data_nodes_cross_zero(_data_diff(3, 2)) is False
+
+    def test_master_only_diff_is_not_detected(self):
+        # A standalone master.replicas change with no data transition: this is
+        # exactly the case the dispatch guardrail must reject.
+        diff = kopf.Diff(
+            [
+                kopf.DiffItem(
+                    kopf.DiffOperation.CHANGE,
+                    ("spec", "nodes", "master", "replicas"),
+                    3,
+                    0,
+                )
+            ]
+        )
+        assert _data_nodes_cross_zero(diff) is False
+
+
+def _statefulset(spec_replicas=None, ready_replicas=None):
+    sts = mock.Mock()
+    sts.spec.replicas = spec_replicas
+    sts.status.ready_replicas = ready_replicas
+    return sts
+
+
+class TestCheckAllMasterNodesPresent:
+    @pytest.mark.asyncio
+    async def test_waits_until_all_masters_ready(self):
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(ready_replicas=1)
+        )
+
+        with pytest.raises(kopf.TemporaryError):
+            await check_all_master_nodes_present(apps, "ns", "c", 3, mock.Mock())
+
+    @pytest.mark.asyncio
+    async def test_passes_when_all_masters_ready(self):
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(ready_replicas=3)
+        )
+
+        await check_all_master_nodes_present(apps, "ns", "c", 3, mock.Mock())
+
+    @pytest.mark.asyncio
+    async def test_treats_missing_ready_count_as_zero(self):
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(ready_replicas=None)
+        )
+
+        with pytest.raises(kopf.TemporaryError):
+            await check_all_master_nodes_present(apps, "ns", "c", 1, mock.Mock())
+
+
+class TestCheckAllMasterNodesGone:
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.operations.get_pods_in_statefulset",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_raises_while_master_pods_present(self, mock_get_pods):
+        mock_get_pods.return_value = [{"uid": "x", "name": "crate-master-c-0"}]
+
+        with pytest.raises(kopf.TemporaryError):
+            await check_all_master_nodes_gone(mock.Mock(), "ns", "c")
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.operations.get_pods_in_statefulset",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_passes_when_no_master_pods(self, mock_get_pods):
+        mock_get_pods.return_value = []
+
+        await check_all_master_nodes_gone(mock.Mock(), "ns", "c")
+
+
+class TestScaleMasterStatefulset:
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.operations.update_statefulset_replicas",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_scales_when_replica_count_differs(self, mock_update):
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(spec_replicas=0)
+        )
+
+        await scale_master_statefulset(apps, "ns", "c", 3, mock.Mock())
+
+        mock_update.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "crate.operator.operations.update_statefulset_replicas",
+        new_callable=mock.AsyncMock,
+    )
+    async def test_noop_when_already_at_target(self, mock_update):
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(spec_replicas=3)
+        )
+
+        await scale_master_statefulset(apps, "ns", "c", 3, mock.Mock())
+
+        mock_update.assert_not_awaited()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,0 +1,70 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from crate.operator.operations import iter_node_groups
+
+
+class TestIterNodeGroups:
+    def test_masters_yielded_first(self):
+        nodes = {
+            "master": {"replicas": 3},
+            "data": [{"name": "hot", "replicas": 7}],
+        }
+
+        groups = iter_node_groups(nodes)
+
+        assert [g.name for g in groups] == ["master", "hot"]
+        assert groups[0].is_master is True
+        assert groups[1].is_master is False
+
+    def test_legacy_cluster_without_masters(self):
+        # No ``master`` key: only the data groups are enumerated, and nothing
+        # is treated as a dedicated master.
+        nodes = {"data": [{"name": "hot", "replicas": 3}]}
+
+        groups = iter_node_groups(nodes)
+
+        assert [g.name for g in groups] == ["hot"]
+        assert all(g.is_master is False for g in groups)
+
+    def test_statefulset_names_and_node_prefixes(self):
+        nodes = {
+            "master": {"replicas": 3},
+            "data": [{"name": "hot", "replicas": 7}],
+        }
+
+        master, hot = iter_node_groups(nodes)
+
+        assert master.node_name_prefix == "master"
+        assert master.statefulset_name("my-cluster") == "crate-master-my-cluster"
+        assert hot.node_name_prefix == "data-hot"
+        assert hot.statefulset_name("my-cluster") == "crate-data-hot-my-cluster"
+
+    def test_spec_is_passed_through(self):
+        # The masters' spec is a single object (no ``name`` of its own); the
+        # group's logical name is synthesized, the spec passed through as-is.
+        master_spec = {"replicas": 3, "resources": {"limits": {"cpu": 16}}}
+        nodes = {"master": master_spec, "data": [{"name": "hot", "replicas": 7}]}
+
+        groups = iter_node_groups(nodes)
+
+        assert groups[0].spec is master_spec
+        assert "name" not in groups[0].spec

--- a/tests/test_ping_cratedb_status.py
+++ b/tests/test_ping_cratedb_status.py
@@ -237,3 +237,66 @@ async def test_ping_cratedb_status_exceptions(
         mock_report.assert_called_once_with(
             name, cluster_name, namespace, PrometheusClusterStatus.UNREACHABLE
         )
+
+
+class TestPingCratedbNodeLookup:
+    """The ping timer must derive its desired-instance count from the data node
+    topology without assuming a data group named "hot"."""
+
+    @pytest.mark.asyncio
+    @patch("crate.operator.main.ping_cratedb_status", new_callable=AsyncMock)
+    async def test_uses_total_data_count_for_non_hot_group(self, mock_ping):
+        import crate.operator.main as main
+
+        spec = {
+            "cluster": {"name": "n"},
+            "nodes": {
+                "master": {"replicas": 3},
+                "data": [{"name": "warm", "replicas": 5}],
+            },
+        }
+
+        await main.ping_cratedb(
+            namespace="ns", name="c", spec=spec, patch=MagicMock(), logger=MagicMock()
+        )
+
+        # desired_instances (4th positional arg) is the data node count, and no
+        # StopIteration is raised for the missing "hot" group.
+        assert mock_ping.await_args.args[3] == 5
+
+    @pytest.mark.asyncio
+    @patch("crate.operator.main.ping_cratedb_status", new_callable=AsyncMock)
+    async def test_reports_zero_when_data_suspended(self, mock_ping):
+        import crate.operator.main as main
+
+        spec = {
+            "cluster": {"name": "n"},
+            "nodes": {
+                "master": {"replicas": 3},
+                "data": [{"name": "hot", "replicas": 0}],
+            },
+        }
+
+        await main.ping_cratedb(
+            namespace="ns", name="c", spec=spec, patch=MagicMock(), logger=MagicMock()
+        )
+
+        # Data at 0 -> 0 desired instances, which ping_cratedb_status treats as
+        # SUSPENDED (masters do not affect the gate).
+        assert mock_ping.await_args.args[3] == 0
+
+    @pytest.mark.asyncio
+    @patch("crate.operator.main.ping_cratedb_status", new_callable=AsyncMock)
+    async def test_legacy_cluster_without_masters(self, mock_ping):
+        import crate.operator.main as main
+
+        spec = {
+            "cluster": {"name": "n"},
+            "nodes": {"data": [{"name": "hot", "replicas": 2}]},
+        }
+
+        await main.ping_cratedb(
+            namespace="ns", name="c", spec=spec, patch=MagicMock(), logger=MagicMock()
+        )
+
+        assert mock_ping.await_args.args[3] == 2

--- a/tests/test_restart_cluster.py
+++ b/tests/test_restart_cluster.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import kopf
 import pytest
 
-from crate.operator.operations import restart_cluster
+from crate.operator.operations import _node_groups_to_restart, restart_cluster
 from crate.operator.webhooks import WebhookAction
 
 
@@ -86,6 +86,7 @@ async def test_restart_cluster_calls_set_cluster_setting(
             namespace="abc",
             name="test-cluster",
             old=old,
+            body=old,
             logger=logger,
             patch=patch_obj,
             status=status,
@@ -100,6 +101,7 @@ async def test_restart_cluster_calls_set_cluster_setting(
             namespace="abc",
             name="test-cluster",
             old=old,
+            body=old,
             logger=logger,
             patch=patch_obj,
             status=status,
@@ -119,3 +121,62 @@ async def test_restart_cluster_calls_set_cluster_setting(
         logger,
         setting="cluster.routing.allocation.enable",
     )
+
+
+def _res(cpu):
+    return {
+        "resources": {
+            "limits": {"cpu": cpu, "memory": "1Gi"},
+            "requests": {"cpu": cpu, "memory": "1Gi"},
+        }
+    }
+
+
+def _spec(master_cpu=2, hot_cpu=2, cold_cpu=None):
+    data = [{"name": "hot", "replicas": 1, **_res(hot_cpu)}]
+    if cold_cpu is not None:
+        data.append({"name": "cold", "replicas": 1, **_res(cold_cpu)})
+    nodes = {"master": {"replicas": 3, **_res(master_cpu)}, "data": data}
+    return {"spec": {"nodes": nodes}}
+
+
+def test_change_compute_restarts_only_the_changed_master_group():
+    # Only the master CPU changed -> only the master group restarts (the data
+    # node must not be rolled).
+    groups = _node_groups_to_restart(
+        _spec(master_cpu=2, hot_cpu=2),
+        _spec(master_cpu=3, hot_cpu=2),
+        WebhookAction.CHANGE_COMPUTE,
+    )
+    assert [g.name for g in groups] == ["master"]
+
+
+def test_change_compute_restarts_only_the_changed_data_group():
+    groups = _node_groups_to_restart(
+        _spec(master_cpu=2, hot_cpu=2),
+        _spec(master_cpu=2, hot_cpu=3),
+        WebhookAction.CHANGE_COMPUTE,
+    )
+    assert [g.name for g in groups] == ["hot"]
+
+
+def test_change_compute_restarts_all_changed_groups_masters_first():
+    # master + hot + cold all change at once -> all restart, masters first,
+    # serialised by the caller's one-at-a-time loop.
+    groups = _node_groups_to_restart(
+        _spec(master_cpu=2, hot_cpu=2, cold_cpu=2),
+        _spec(master_cpu=3, hot_cpu=3, cold_cpu=3),
+        WebhookAction.CHANGE_COMPUTE,
+    )
+    assert [g.name for g in groups] == ["master", "hot", "cold"]
+
+
+def test_change_compute_with_no_compute_change_restarts_nothing():
+    groups = _node_groups_to_restart(_spec(), _spec(), WebhookAction.CHANGE_COMPUTE)
+    assert groups == []
+
+
+def test_upgrade_restarts_all_groups_regardless_of_change():
+    # An upgrade must roll every node (new image), even with no resource change.
+    groups = _node_groups_to_restart(_spec(), _spec(), WebhookAction.UPGRADE)
+    assert [g.name for g in groups] == ["master", "hot"]

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -650,3 +650,58 @@ async def do_crate_pods_exist(
 ) -> bool:
     crate_pods = await get_pods_in_statefulset(core, namespace, name, node_name)
     return len(crate_pods) > 0
+
+
+class TestEffectiveMasterReplicas:
+    """The SCALE webhook must report the master count the operator actually
+    runs, so suspend bills as zero masters."""
+
+    def test_suspend_reports_new_masters_as_zero(self):
+        from crate.operator.scale import effective_master_replicas
+
+        old, new = effective_master_replicas(
+            {"master": {"replicas": 3}, "data": [{"name": "hot", "replicas": 3}]},
+            {"master": {"replicas": 3}, "data": [{"name": "hot", "replicas": 0}]},
+            data_suspending=True,
+            data_resuming=False,
+        )
+
+        # Masters were running (3) and are now effectively scaled to 0.
+        assert (old, new) == (3, 0)
+
+    def test_resume_reports_old_masters_as_zero(self):
+        from crate.operator.scale import effective_master_replicas
+
+        old, new = effective_master_replicas(
+            {"master": {"replicas": 3}, "data": [{"name": "hot", "replicas": 0}]},
+            {"master": {"replicas": 3}, "data": [{"name": "hot", "replicas": 3}]},
+            data_suspending=False,
+            data_resuming=True,
+        )
+
+        # Masters were suspended (0) and are restored to 3.
+        assert (old, new) == (0, 3)
+
+    def test_ordinary_scale_uses_spec_values(self):
+        from crate.operator.scale import effective_master_replicas
+
+        old, new = effective_master_replicas(
+            {"master": {"replicas": 3}, "data": [{"name": "hot", "replicas": 3}]},
+            {"master": {"replicas": 5}, "data": [{"name": "hot", "replicas": 3}]},
+            data_suspending=False,
+            data_resuming=False,
+        )
+
+        assert (old, new) == (3, 5)
+
+    def test_legacy_cluster_without_masters(self):
+        from crate.operator.scale import effective_master_replicas
+
+        old, new = effective_master_replicas(
+            {"data": [{"name": "hot", "replicas": 3}]},
+            {"data": [{"name": "hot", "replicas": 0}]},
+            data_suspending=True,
+            data_resuming=False,
+        )
+
+        assert (old, new) == (None, None)

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -43,7 +43,12 @@ from crate.operator.constants import (
 from crate.operator.cratedb import connection_factory
 from crate.operator.create import get_statefulset_crate_command
 from crate.operator.operations import get_pods_in_statefulset, is_lb_service_present
-from crate.operator.scale import parse_replicas, patch_command, reset_allocation
+from crate.operator.scale import (
+    classify_data_scaling,
+    parse_replicas,
+    patch_command,
+    reset_allocation,
+)
 from crate.operator.utils.kubeapi import get_host
 from crate.operator.webhooks import WebhookEvent, WebhookStatus
 from tests.utils import (
@@ -705,3 +710,74 @@ class TestEffectiveMasterReplicas:
         )
 
         assert (old, new) == (None, None)
+
+
+class TestClassifyDataScaling:
+    # ``classify_data_scaling`` only inspects the diff list for emptiness; the
+    # suspend/resume decision is driven by the full old/new data specs, so a
+    # single placeholder item is enough to mark "something changed".
+    CHANGED = [object()]
+
+    def test_no_data_change_is_neither(self):
+        assert classify_data_scaling(
+            None,
+            [{"name": "hot", "replicas": 3}],
+            [{"name": "hot", "replicas": 3}],
+        ) == (False, False)
+        assert classify_data_scaling(
+            [],
+            [{"name": "hot", "replicas": 3}],
+            [{"name": "hot", "replicas": 3}],
+        ) == (False, False)
+
+    def test_single_group_suspend(self):
+        resuming, suspending = classify_data_scaling(
+            self.CHANGED,
+            [{"name": "hot", "replicas": 3}],
+            [{"name": "hot", "replicas": 0}],
+        )
+        assert (resuming, suspending) == (False, True)
+
+    def test_single_group_resume(self):
+        resuming, suspending = classify_data_scaling(
+            self.CHANGED,
+            [{"name": "hot", "replicas": 0}],
+            [{"name": "hot", "replicas": 3}],
+        )
+        assert (resuming, suspending) == (True, False)
+
+    def test_single_group_plain_scale(self):
+        resuming, suspending = classify_data_scaling(
+            self.CHANGED,
+            [{"name": "hot", "replicas": 3}],
+            [{"name": "hot", "replicas": 5}],
+        )
+        assert (resuming, suspending) == (False, False)
+
+    def test_multi_group_full_suspend(self):
+        # All groups go to zero -> cluster-wide suspend.
+        resuming, suspending = classify_data_scaling(
+            self.CHANGED,
+            [{"name": "hot", "replicas": 3}, {"name": "cold", "replicas": 2}],
+            [{"name": "hot", "replicas": 0}, {"name": "cold", "replicas": 0}],
+        )
+        assert (resuming, suspending) == (False, True)
+
+    def test_multi_group_full_resume(self):
+        resuming, suspending = classify_data_scaling(
+            self.CHANGED,
+            [{"name": "hot", "replicas": 0}, {"name": "cold", "replicas": 0}],
+            [{"name": "hot", "replicas": 3}, {"name": "cold", "replicas": 2}],
+        )
+        assert (resuming, suspending) == (True, False)
+
+    def test_multi_group_partial_scaledown_is_not_suspend(self):
+        # Only the cold group goes to zero while hot keeps running: this is an
+        # ordinary scale, NOT a suspend. (The bug in the old first-item-only
+        # detection misclassified this as a full suspend.)
+        resuming, suspending = classify_data_scaling(
+            self.CHANGED,
+            [{"name": "hot", "replicas": 3}, {"name": "cold", "replicas": 2}],
+            [{"name": "hot", "replicas": 3}, {"name": "cold", "replicas": 0}],
+        )
+        assert (resuming, suspending) == (False, False)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -307,6 +307,8 @@ async def start_cluster(
     resource_requests: Optional[Mapping[str, Any]] = None,
     backups_spec: Optional[Mapping[str, Any]] = None,
     grand_central_spec: Optional[Mapping[str, Any]] = None,
+    master_nodes: int = 0,
+    master_resources: Optional[Mapping[str, Any]] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
     additional_cluster_spec = additional_cluster_spec or {}
     body: dict = {
@@ -376,6 +378,26 @@ async def start_cluster(
     if grand_central_spec:
         body["spec"]["grandCentral"] = grand_central_spec
 
+    if master_nodes:
+        # Dedicated master nodes are a single object (no ``name``), unlike the
+        # data list. Defaults are deliberately small so a master cluster fits a
+        # local minikube; callers may override via ``master_resources``.
+        body["spec"]["nodes"]["master"] = master_resources or {
+            "replicas": master_nodes,
+            "resources": {
+                # cpu must be a number; small requests so several masters fit a
+                # local minikube while limits allow a usable heap.
+                "limits": {"cpu": 1, "memory": "2Gi"},
+                "requests": {"cpu": 0.5, "memory": "512Mi"},
+                "heapRatio": 0.25,
+                "disk": {
+                    "storageClass": config.DEBUG_VOLUME_STORAGE_CLASS,
+                    "size": "16GiB",
+                    "count": 1,
+                },
+            },
+        }
+
     await coapi.create_namespaced_custom_object(
         group=API_GROUP,
         version="v1",
@@ -425,7 +447,9 @@ async def start_cluster(
             True,
             is_cluster_healthy,
             connection_factory(host, password),
-            hot_nodes,
+            # Dedicated masters are full cluster members, so they count towards
+            # the expected node total alongside the data nodes.
+            hot_nodes + master_nodes,
             err_msg="Cluster wasn't healthy after 10 minutes.",
             timeout=CLUSTER_CREATE_TIMEOUT,
         )


### PR DESCRIPTION
ref:  https://github.com/crate/cloud/issues/2744

Makes dedicated master nodes (`spec.nodes.master`) behave consistently across all
cluster operations, with the invariant that master nodes are available before data
nodes (cluster formation/discovery depends on it).

## Changes
- **Node-group enumerator** (`iter_node_groups`) — single source of truth for
  iterating master + data groups, masters first.
- **Suspend / resume** — masters start before data on resume and stop after data on
  suspend; a standalone `master.replicas -> 0` while data is up is rejected.
- **Change-compute** — applied per node group (incl. master), with master resources
  read independently; `-Cprocessors` updated on the master StatefulSet.
- **Expand-volume** — master disk expansion handled alongside data groups.
- **Health ping** — robust node lookup (no longer assumes a `hot` data group).
- **Webhooks** — scale reports effective master replicas (`0` while suspended),
  change-compute includes master compute, expand-storage reports per-group disk size
  (all additive / backward-compatible).

## Tests
- Unit tests across the above (passing).
- e2e suite (`tests/test_master_nodes.py`, minikube-only, skipped without
  `--kube-config`): cluster creation with dedicated masters validated end-to-end on
  minikube; the full suspend/resume/compute/expand suite is intended to run on a
  cluster with more headroom (CI / dev).

## Follow-ups (out of scope here)
- cloud-api companion PR to consume the new webhook fields and define master-node
  products.
- Adding masters to an existing master-less cluster is **not** supported (requires a
  full restart).