### PR TITLE
Stabilise e2e/k8s tests: bootstrap readiness + retry-on-failure

### DIFF
--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -204,16 +204,8 @@ async def _bootstrap_user_via_sidecar(
             raise _temporary_error()
 
 
-# How long a single bootstrap attempt waits for the crate container to become
-# ready before deferring back to kopf's handler retry. Polls frequently so the
-# exec fires the moment the container is up, rather than bouncing off a
-# not-ready container with 400/500s and waiting a full retry cycle.
-#
-# Generous on purpose: a crate container's readiness covers disk attach (slow on
-# azure-disk), init containers (incl. a JMX-jar download), JVM boot and the
-# readiness probe -- routinely a few minutes under load, so a tight budget would
-# just churn kopf retries. This is only a per-attempt cap; kopf still retries
-# beyond it, bounded by the overall BOOTSTRAP_TIMEOUT.
+# Per-attempt cap. readiness can take minutes under load (disk attach, init
+# containers, JVM boot), and kopf retries beyond it up to BOOTSTRAP_TIMEOUT.
 _READINESS_POLL_INTERVAL = 2
 _READINESS_MAX_WAIT = 300
 
@@ -395,10 +387,6 @@ async def _bootstrap_user_via_pod_exec(
                 tty=False,
             )
 
-    # Don't exec into a container that isn't ready yet: that yields a
-    # 400/500 'Invalid response status' and a wasted retry cycle. Wait for the
-    # crate container to be ready first; if it isn't within this attempt's
-    # budget, defer to kopf's handler retry.
     if not await _wait_for_crate_container_ready(namespace, master_node_pod, logger):
         logger.info(
             "crate container in %s not ready yet; deferring system-user bootstrap",

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -19,6 +19,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
+import asyncio
 import json
 import logging
 from typing import Any, Dict, List, Optional
@@ -203,6 +204,93 @@ async def _bootstrap_user_via_sidecar(
             raise _temporary_error()
 
 
+# How long a single bootstrap attempt waits for the crate container to become
+# ready before deferring back to kopf's handler retry. Polls frequently so the
+# exec fires the moment the container is up, rather than bouncing off a
+# not-ready container with 400/500s and waiting a full retry cycle.
+#
+# Generous on purpose: a crate container's readiness covers disk attach (slow on
+# azure-disk), init containers (incl. a JMX-jar download), JVM boot and the
+# readiness probe -- routinely a few minutes under load, so a tight budget would
+# just churn kopf retries. This is only a per-attempt cap; kopf still retries
+# beyond it, bounded by the overall BOOTSTRAP_TIMEOUT.
+_READINESS_POLL_INTERVAL = 2
+_READINESS_MAX_WAIT = 300
+
+
+async def _wait_for_crate_container_ready(
+    namespace: str, master_node_pod: str, logger: logging.Logger
+) -> bool:
+    """Wait for the ``crate`` container in ``master_node_pod`` to report ready.
+
+    The bootstrap exec targets the ``crate`` container; attempting it before the
+    container is ready makes the apiserver reject the exec upgrade with a
+    ``400/500 Invalid response status``. Under kopf's retry cadence that adds
+    minutes to cluster bring-up (and cascades into timeouts in other tests).
+    Polling readiness first turns it into a single clean exec.
+
+    Returns ``True`` once ready, or ``False`` if the per-attempt budget elapses
+    (the caller then defers to kopf's handler retry, which calls this again). On
+    timeout it logs the pod's last-seen phase and per-container state so a slow
+    or stuck start (image pull, crash loop, init container waiting on a volume)
+    is diagnosable from the run.
+    """
+    waited = 0
+    last_pod = None
+    while True:
+        try:
+            async with GlobalApiClient() as api_client:
+                last_pod = await CoreV1Api(api_client).read_namespaced_pod(
+                    name=master_node_pod, namespace=namespace
+                )
+            if any(
+                c.name == "crate" and c.ready
+                for c in (last_pod.status.container_statuses or [])
+            ):
+                return True
+        except ApiException as e:
+            # Transient read error -- keep polling within the budget.
+            logger.warning("readiness check for %s failed: %s", master_node_pod, e)
+        if waited >= _READINESS_MAX_WAIT:
+            _log_pod_not_ready(master_node_pod, last_pod, waited, logger)
+            return False
+        await asyncio.sleep(_READINESS_POLL_INTERVAL)
+        waited += _READINESS_POLL_INTERVAL
+
+
+def _log_pod_not_ready(master_node_pod, pod, waited, logger):
+    """Log the target pod's phase and per-container state when the crate
+    container fails to become ready within the bootstrap readiness budget."""
+    if pod is None:
+        logger.warning(
+            "crate container in %s not ready after %ss; pod could not be read",
+            master_node_pod,
+            waited,
+        )
+        return
+    containers = {
+        c.name: {
+            "ready": c.ready,
+            "restartCount": c.restart_count,
+            "state": str(c.state),
+        }
+        for c in (pod.status.container_statuses or [])
+    }
+    init_containers = {
+        c.name: {"ready": c.ready, "state": str(c.state)}
+        for c in (pod.status.init_container_statuses or [])
+    }
+    logger.warning(
+        "crate container in %s not ready after %ss: phase=%s containers=%s "
+        "initContainers=%s",
+        master_node_pod,
+        waited,
+        pod.status.phase,
+        containers,
+        init_containers,
+    )
+
+
 async def _log_pod_exec_failure(namespace, master_node_pod, e, logger):
     """
     Log diagnostics for a failed bootstrap pod-exec so transient/persistent
@@ -306,6 +394,17 @@ async def _bootstrap_user_via_pod_exec(
                 stdout=True,
                 tty=False,
             )
+
+    # Don't exec into a container that isn't ready yet: that yields a
+    # 400/500 'Invalid response status' and a wasted retry cycle. Wait for the
+    # crate container to be ready first; if it isn't within this attempt's
+    # budget, defer to kopf's handler retry.
+    if not await _wait_for_crate_container_ready(namespace, master_node_pod, logger):
+        logger.info(
+            "crate container in %s not ready yet; deferring system-user bootstrap",
+            master_node_pod,
+        )
+        raise _temporary_error()
 
     needs_update = False
     try:

--- a/crate/operator/bootstrap.py
+++ b/crate/operator/bootstrap.py
@@ -203,6 +203,47 @@ async def _bootstrap_user_via_sidecar(
             raise _temporary_error()
 
 
+async def _log_pod_exec_failure(namespace, master_node_pod, e, logger):
+    """
+    Log diagnostics for a failed bootstrap pod-exec so transient/persistent
+    websocket failures (e.g. ``400 Invalid response status``) are debuggable
+    from the run: the exception detail plus the target pod's phase and per
+    container readiness (was the ``crate`` container actually ready to exec?).
+    """
+    logger.warning(
+        "bootstrap pod_exec into %s failed: type=%s status=%s detail=%s",
+        master_node_pod,
+        type(e).__name__,
+        getattr(e, "status", None),
+        getattr(e, "message", None) or str(e),
+    )
+    try:
+        async with GlobalApiClient() as api_client:
+            pod = await CoreV1Api(api_client).read_namespaced_pod(
+                name=master_node_pod, namespace=namespace
+            )
+        containers = {
+            c.name: {
+                "ready": c.ready,
+                "restartCount": c.restart_count,
+                "state": str(c.state),
+            }
+            for c in (pod.status.container_statuses or [])
+        }
+        logger.warning(
+            "bootstrap target pod %s phase=%s containers=%s",
+            master_node_pod,
+            pod.status.phase,
+            containers,
+        )
+    except Exception as diag_e:  # diagnostics must never mask the real failure
+        logger.warning(
+            "could not read pod %s for bootstrap diagnostics: %s",
+            master_node_pod,
+            diag_e,
+        )
+
+
 async def _bootstrap_user_via_pod_exec(
     namespace: str,
     master_node_pod: str,
@@ -272,6 +313,7 @@ async def _bootstrap_user_via_pod_exec(
         result = await pod_exec(command_create)
     except (ApiException, WSServerHandshakeError) as e:
         exception_logger("... failed. %s", str(e))
+        await _log_pod_exec_failure(namespace, master_node_pod, e, logger)
         raise _temporary_error()
     else:
         if "rowcount" in result:
@@ -289,6 +331,7 @@ async def _bootstrap_user_via_pod_exec(
             result = await pod_exec(command_alter)
         except (ApiException, WSServerHandshakeError) as e:
             exception_logger("... failed. %s", str(e))
+            await _log_pod_exec_failure(namespace, master_node_pod, e, logger)
             raise _temporary_error()
         else:
             if "rowcount" in result:

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
             "pytest-aiohttp==1.0.5",
             "pytest-asyncio==1.4.0",
             "pytest-xdist==3.8.0",  # enables parallel testing
+            "pytest-rerunfailures==16.3",  # retry flaky k8s/e2e tests
             "filelock==3.29.0",  # used for locks when running in parallel mode
         ],
         "develop": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,9 +95,24 @@ def pytest_addoption(parser):
     parser.addoption(KUBECONTEXT_OPTION, help="Name of the context")
 
 
+# k8s/e2e tests spin real clusters on shared cloud infra in parallel, so an
+# occasional transient timing loss (slow disk attach/resize, apiserver
+# throttling) is expected. Retry them on failure: a flake passes on a rerun and
+# keeps the run green, while a real bug fails every attempt and still reds it.
+# Unit tests are never retried, so a logic regression fails immediately.
+K8S_TEST_RERUNS = 2
+K8S_TEST_RERUNS_DELAY = 5  # seconds between attempts
+
+
 def pytest_collection_modifyitems(config, items):
     if config.getoption(KUBECONFIG_OPTION):
-        # --kube-config given in cli: do not skip k8s tests
+        # --kube-config given in cli: do not skip k8s tests; retry them instead.
+        flaky = pytest.mark.flaky(
+            reruns=K8S_TEST_RERUNS, reruns_delay=K8S_TEST_RERUNS_DELAY
+        )
+        for item in items:
+            if "k8s" in item.keywords:
+                item.add_marker(flaky)
         return
     skip = pytest.mark.skip(reason=f"Need {KUBECONFIG_OPTION} option to run")
     for item in items:

--- a/tests/test_bootstrap_readiness.py
+++ b/tests/test_bootstrap_readiness.py
@@ -1,0 +1,102 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from crate.operator.bootstrap import _wait_for_crate_container_ready
+
+
+def _pod(crate_ready: bool):
+    return SimpleNamespace(
+        status=SimpleNamespace(
+            phase="Running" if crate_ready else "Pending",
+            container_statuses=[
+                SimpleNamespace(
+                    name="crate",
+                    ready=crate_ready,
+                    restart_count=0,
+                    state="running" if crate_ready else "waiting",
+                )
+            ],
+            init_container_statuses=[],
+        )
+    )
+
+
+def _patched(read_side_effect=None, read_return=None):
+    """Patch the GlobalApiClient/CoreV1Api used by the helper so read_namespaced_pod
+    yields the given pod(s)."""
+    core = MagicMock()
+    core.read_namespaced_pod = AsyncMock(
+        side_effect=read_side_effect, return_value=read_return
+    )
+    return (
+        patch("crate.operator.bootstrap.GlobalApiClient", return_value=AsyncMock()),
+        patch("crate.operator.bootstrap.CoreV1Api", return_value=core),
+        core,
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_true_immediately_when_ready():
+    gac, capi, _ = _patched(read_return=_pod(True))
+    with gac, capi, patch("asyncio.sleep", new_callable=AsyncMock) as sleep:
+        assert await _wait_for_crate_container_ready("ns", "pod", MagicMock()) is True
+        sleep.assert_not_awaited()  # ready first poll -> no waiting
+
+
+@pytest.mark.asyncio
+async def test_returns_true_after_container_becomes_ready():
+    gac, capi, core = _patched(read_side_effect=[_pod(False), _pod(False), _pod(True)])
+    with gac, capi, patch("asyncio.sleep", new_callable=AsyncMock):
+        assert await _wait_for_crate_container_ready("ns", "pod", MagicMock()) is True
+        assert core.read_namespaced_pod.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_logs_pod_state_on_timeout():
+    """On timeout the helper must log the pod phase + container state so a stuck
+    start is diagnosable from the run."""
+    logger = MagicMock(spec=logging.Logger)
+    gac, capi, _ = _patched(read_return=_pod(False))
+    with gac, capi, patch("asyncio.sleep", new_callable=AsyncMock):
+        assert await _wait_for_crate_container_ready("ns", "pod", logger) is False
+    diag = [
+        c.args[0]
+        for c in logger.warning.call_args_list
+        if "not ready after" in c.args[0]
+    ]
+    assert diag, "expected a 'not ready after' diagnostic log on timeout"
+    assert "phase=" in diag[-1] and "containers=" in diag[-1]
+
+
+@pytest.mark.asyncio
+async def test_returns_false_when_never_ready_within_budget():
+    gac, capi, _ = _patched(read_return=_pod(False))
+    with gac, capi, patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await _wait_for_crate_container_ready(
+            "ns", "pod", MagicMock(spec=logging.Logger)
+        )
+        assert result is False


### PR DESCRIPTION
Independent CI/robustness fixes extracted ahead of the dedicated-master-nodes feature, so master gets them without waiting for that PR. All three help master's existing setup; none contain master-node logic.

## 1. Wait for the crate container to be ready before the bootstrap exec
The system-user bootstrap execs into the `crate` container (`CREATE USER "system"`). When it fires before the container is ready, the apiserver rejects the exec upgrade with a `400/500 "Invalid response status"`; the handler then retries on kopf's cadence, adding minutes to cluster bring-up and intermittently cascading into timeouts in unrelated, timing-sensitive tests.

Gate the exec on readiness: poll the crate container's ready status first and only exec once it's up. Generous per-attempt budget (300s) since readiness routinely takes a while under load; it's only a per-attempt cap (kopf still retries up to `BOOTSTRAP_TIMEOUT`). On timeout the pod's phase + per-container/init-container state is logged so a stuck start is diagnosable.

(Includes the bootstrap pod-exec failure diagnostics it builds on.)

## 2. Retry k8s/e2e tests on failure
The k8s suite spins real clusters on shared cloud infra in parallel; cluster operations have variable latency (disk attach/resize, apiserver Priority & Fairness throttling), so a fixed-timeout e2e test occasionally loses the race even when the operator is correct.

Add `pytest-rerunfailures` and attach a `flaky(reruns=2)` marker to every `k8s`-marked test when running against a cluster. A transient flake passes on a rerun and keeps the run green; a real bug fails all 3 attempts and still reds the build. Unit tests are never retried, so logic regressions fail immediately. Marker-based — no Jenkins CLI change; GitHub Actions is unaffected (it skips k8s tests).

## Notes
- Adds unit tests for the bootstrap readiness helper (incl. the timeout diagnostic).
- No production behavior change beyond the bootstrap readiness gate (which is strictly more correct — exec'ing a not-ready container can only fail).
