### PR TITLE
Stabilise e2e exposure tests: widen waits + timeout diagnostics

### DIFF
--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -162,10 +162,11 @@ async def test_create_traefik_with_cidrs(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Bootstrap execs into the pod over a websocket that can transiently
-        # 400 until the container is ready; the operator retries, so allow
-        # enough time to absorb those retries (matches start_cluster's *5).
-        timeout=DEFAULT_TIMEOUT * 5,
+        # Provisioning and bootstrapping a cluster on a busy parallel CI
+        # cluster can take several minutes (image pulls, JVM start, node
+        # contention), so give the wait generous headroom -- the operator
+        # already retries the bootstrap exec every few seconds in testing.
+        timeout=DEFAULT_TIMEOUT * 10,
     )
 
     # Service should be ClusterIP
@@ -251,10 +252,11 @@ async def test_create_traefik_without_cidrs(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Bootstrap execs into the pod over a websocket that can transiently
-        # 400 until the container is ready; the operator retries, so allow
-        # enough time to absorb those retries (matches start_cluster's *5).
-        timeout=DEFAULT_TIMEOUT * 5,
+        # Provisioning and bootstrapping a cluster on a busy parallel CI
+        # cluster can take several minutes (image pulls, JVM start, node
+        # contention), so give the wait generous headroom -- the operator
+        # already retries the bootstrap exec every few seconds in testing.
+        timeout=DEFAULT_TIMEOUT * 10,
     )
 
     # Service ClusterIP
@@ -342,10 +344,11 @@ async def test_update_cidrs_traefik_empty_to_nonempty(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Bootstrap execs into the pod over a websocket that can transiently
-        # 400 until the container is ready; the operator retries, so allow
-        # enough time to absorb those retries (matches start_cluster's *5).
-        timeout=DEFAULT_TIMEOUT * 5,
+        # Provisioning and bootstrapping a cluster on a busy parallel CI
+        # cluster can take several minutes (image pulls, JVM start, node
+        # contention), so give the wait generous headroom -- the operator
+        # already retries the bootstrap exec every few seconds in testing.
+        timeout=DEFAULT_TIMEOUT * 10,
     )
 
     # Service should be ClusterIP
@@ -470,10 +473,11 @@ async def test_update_cidrs_traefik_nonempty_to_empty(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Bootstrap execs into the pod over a websocket that can transiently
-        # 400 until the container is ready; the operator retries, so allow
-        # enough time to absorb those retries (matches start_cluster's *5).
-        timeout=DEFAULT_TIMEOUT * 5,
+        # Provisioning and bootstrapping a cluster on a busy parallel CI
+        # cluster can take several minutes (image pulls, JVM start, node
+        # contention), so give the wait generous headroom -- the operator
+        # already retries the bootstrap exec every few seconds in testing.
+        timeout=DEFAULT_TIMEOUT * 10,
     )
 
     # Initially middleware exists
@@ -574,10 +578,11 @@ async def test_change_exposure_loadbalancer_to_traefik(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create.bootstrap",
-        # Bootstrap execs into the pod over a websocket that can transiently
-        # 400 until the container is ready; the operator retries, so allow
-        # enough time to absorb those retries (matches start_cluster's *5).
-        timeout=DEFAULT_TIMEOUT * 5,
+        # Provisioning and bootstrapping a cluster on a busy parallel CI
+        # cluster can take several minutes (image pulls, JVM start, node
+        # contention), so give the wait generous headroom -- the operator
+        # already retries the bootstrap exec every few seconds in testing.
+        timeout=DEFAULT_TIMEOUT * 10,
     )
 
     # Initially service is LoadBalancer, no Traefik resources
@@ -693,10 +698,11 @@ async def test_change_exposure_traefik_to_loadbalancer(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Bootstrap execs into the pod over a websocket that can transiently
-        # 400 until the container is ready; the operator retries, so allow
-        # enough time to absorb those retries (matches start_cluster's *5).
-        timeout=DEFAULT_TIMEOUT * 5,
+        # Provisioning and bootstrapping a cluster on a busy parallel CI
+        # cluster can take several minutes (image pulls, JVM start, node
+        # contention), so give the wait generous headroom -- the operator
+        # already retries the bootstrap exec every few seconds in testing.
+        timeout=DEFAULT_TIMEOUT * 10,
     )
 
     # Initially Traefik resources exist

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -32,6 +32,7 @@ from crate.operator.constants import (
 )
 
 from .utils import (
+    CLUSTER_CREATE_TIMEOUT,
     DEFAULT_TIMEOUT,
     assert_wait_for,
     is_kopf_handler_finished,
@@ -162,11 +163,7 @@ async def test_create_traefik_with_cidrs(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Provisioning and bootstrapping a cluster on a busy parallel CI
-        # cluster can take several minutes (image pulls, JVM start, node
-        # contention), so give the wait generous headroom -- the operator
-        # already retries the bootstrap exec every few seconds in testing.
-        timeout=DEFAULT_TIMEOUT * 10,
+        timeout=CLUSTER_CREATE_TIMEOUT,
     )
 
     # Service should be ClusterIP
@@ -252,11 +249,7 @@ async def test_create_traefik_without_cidrs(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Provisioning and bootstrapping a cluster on a busy parallel CI
-        # cluster can take several minutes (image pulls, JVM start, node
-        # contention), so give the wait generous headroom -- the operator
-        # already retries the bootstrap exec every few seconds in testing.
-        timeout=DEFAULT_TIMEOUT * 10,
+        timeout=CLUSTER_CREATE_TIMEOUT,
     )
 
     # Service ClusterIP
@@ -344,11 +337,7 @@ async def test_update_cidrs_traefik_empty_to_nonempty(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Provisioning and bootstrapping a cluster on a busy parallel CI
-        # cluster can take several minutes (image pulls, JVM start, node
-        # contention), so give the wait generous headroom -- the operator
-        # already retries the bootstrap exec every few seconds in testing.
-        timeout=DEFAULT_TIMEOUT * 10,
+        timeout=CLUSTER_CREATE_TIMEOUT,
     )
 
     # Service should be ClusterIP
@@ -473,11 +462,7 @@ async def test_update_cidrs_traefik_nonempty_to_empty(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Provisioning and bootstrapping a cluster on a busy parallel CI
-        # cluster can take several minutes (image pulls, JVM start, node
-        # contention), so give the wait generous headroom -- the operator
-        # already retries the bootstrap exec every few seconds in testing.
-        timeout=DEFAULT_TIMEOUT * 10,
+        timeout=CLUSTER_CREATE_TIMEOUT,
     )
 
     # Initially middleware exists
@@ -578,11 +563,7 @@ async def test_change_exposure_loadbalancer_to_traefik(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create.bootstrap",
-        # Provisioning and bootstrapping a cluster on a busy parallel CI
-        # cluster can take several minutes (image pulls, JVM start, node
-        # contention), so give the wait generous headroom -- the operator
-        # already retries the bootstrap exec every few seconds in testing.
-        timeout=DEFAULT_TIMEOUT * 10,
+        timeout=CLUSTER_CREATE_TIMEOUT,
     )
 
     # Initially service is LoadBalancer, no Traefik resources
@@ -698,11 +679,7 @@ async def test_change_exposure_traefik_to_loadbalancer(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        # Provisioning and bootstrapping a cluster on a busy parallel CI
-        # cluster can take several minutes (image pulls, JVM start, node
-        # contention), so give the wait generous headroom -- the operator
-        # already retries the bootstrap exec every few seconds in testing.
-        timeout=DEFAULT_TIMEOUT * 10,
+        timeout=CLUSTER_CREATE_TIMEOUT,
     )
 
     # Initially Traefik resources exist

--- a/tests/test_exposure.py
+++ b/tests/test_exposure.py
@@ -162,6 +162,10 @@ async def test_create_traefik_with_cidrs(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
+        # Bootstrap execs into the pod over a websocket that can transiently
+        # 400 until the container is ready; the operator retries, so allow
+        # enough time to absorb those retries (matches start_cluster's *5).
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     # Service should be ClusterIP
@@ -247,6 +251,10 @@ async def test_create_traefik_without_cidrs(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
+        # Bootstrap execs into the pod over a websocket that can transiently
+        # 400 until the container is ready; the operator retries, so allow
+        # enough time to absorb those retries (matches start_cluster's *5).
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     # Service ClusterIP
@@ -334,6 +342,10 @@ async def test_update_cidrs_traefik_empty_to_nonempty(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
+        # Bootstrap execs into the pod over a websocket that can transiently
+        # 400 until the container is ready; the operator retries, so allow
+        # enough time to absorb those retries (matches start_cluster's *5).
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     # Service should be ClusterIP
@@ -458,6 +470,10 @@ async def test_update_cidrs_traefik_nonempty_to_empty(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
+        # Bootstrap execs into the pod over a websocket that can transiently
+        # 400 until the container is ready; the operator retries, so allow
+        # enough time to absorb those retries (matches start_cluster's *5).
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     # Initially middleware exists
@@ -558,7 +574,10 @@ async def test_change_exposure_loadbalancer_to_traefik(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create.bootstrap",
-        timeout=DEFAULT_TIMEOUT * 3,
+        # Bootstrap execs into the pod over a websocket that can transiently
+        # 400 until the container is ready; the operator retries, so allow
+        # enough time to absorb those retries (matches start_cluster's *5).
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     # Initially service is LoadBalancer, no Traefik resources
@@ -674,6 +693,10 @@ async def test_change_exposure_traefik_to_loadbalancer(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
+        # Bootstrap execs into the pod over a websocket that can transiently
+        # 400 until the container is ready; the operator retries, so allow
+        # enough time to absorb those retries (matches start_cluster's *5).
+        timeout=DEFAULT_TIMEOUT * 5,
     )
 
     # Initially Traefik resources exist

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,6 +73,10 @@ CRATE_VERSION = "5.6.5"
 CRATE_VERSION_WITH_JWT = "5.7.3"
 CRATE_VERSION_WITH_GLOBAL_JWT_CONFIG = "5.10.1"
 DEFAULT_TIMEOUT = 60
+# Cluster create/bootstrap on a busy parallel CI cluster can take several
+# minutes (image pulls, JVM start, node contention), so the bring-up waits get
+# generous headroom -- the operator already retries the bootstrap exec.
+CLUSTER_CREATE_TIMEOUT = DEFAULT_TIMEOUT * 10
 
 
 # Control-plane errors that are transient under load -- AKS/EKS apiserver
@@ -391,12 +395,12 @@ async def start_cluster(
             namespace.metadata.name,
             f"crate-{name}",
             err_msg="Lb service was not ready.",
-            timeout=DEFAULT_TIMEOUT * 10,
+            timeout=CLUSTER_CREATE_TIMEOUT,
         )
 
         host = await asyncio.wait_for(
             get_service_public_hostname(core, namespace.metadata.name, name),
-            timeout=DEFAULT_TIMEOUT * 10,
+            timeout=CLUSTER_CREATE_TIMEOUT,
         )
         password = await get_system_user_password(core, namespace.metadata.name, name)
     else:
@@ -414,7 +418,7 @@ async def start_cluster(
             namespace.metadata.name,
             f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
             err_msg="Cluster has not finished bootstrapping",
-            timeout=DEFAULT_TIMEOUT * 10,
+            timeout=CLUSTER_CREATE_TIMEOUT,
         )
 
         await assert_wait_for(
@@ -423,7 +427,7 @@ async def start_cluster(
             connection_factory(host, password),
             hot_nodes,
             err_msg="Cluster wasn't healthy after 10 minutes.",
-            timeout=DEFAULT_TIMEOUT * 10,
+            timeout=CLUSTER_CREATE_TIMEOUT,
         )
 
     return host, password

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -549,6 +549,55 @@ async def _check_kopf_handler_status(
     return result
 
 
+def _summarize_container_state(cs) -> str:
+    """
+    Render a container status compactly, surfacing the actionable waiting/
+    terminated *reason* (``ImagePullBackOff``, ``CrashLoopBackOff``,
+    ``ErrImagePull``, ``CreateContainerError`` …) rather than a raw blob.
+    """
+    state = cs.state
+    if state is not None and state.waiting is not None:
+        detail = f"waiting/{state.waiting.reason}"
+        if state.waiting.message:
+            detail += f": {state.waiting.message}"
+    elif state is not None and state.terminated is not None:
+        t = state.terminated
+        detail = f"terminated/{t.reason} exit={t.exit_code}"
+    elif state is not None and state.running is not None:
+        detail = "running"
+    else:
+        detail = "unknown"
+    return f"{cs.name}:{detail} ready={cs.ready} restarts={cs.restart_count}"
+
+
+async def describe_pods(core: CoreV1Api, namespace: str) -> str:
+    """
+    A compact, per-pod summary of container states for a namespace, used to
+    explain *why* a handler is stuck when a wait times out (e.g. a pod sitting
+    in ``ImagePullBackOff`` or ``CrashLoopBackOff``). Falls back to pod
+    conditions when no container has been created yet (the ``Pending`` case).
+    """
+    try:
+        pods = await core.list_namespaced_pod(namespace=namespace)
+    except Exception as e:  # diagnostics must never mask the real failure
+        return f"<could not list pods in {namespace}: {e}>"
+    lines = []
+    for p in pods.items:
+        st = p.status
+        states = [
+            _summarize_container_state(cs)
+            for cs in (st.init_container_statuses or []) + (st.container_statuses or [])
+        ]
+        if not states:
+            states = [
+                f"{c.type}={c.status}"
+                + (f"({c.reason})" if c.status != "True" and c.reason else "")
+                for c in (st.conditions or [])
+            ] or ["<no container status>"]
+        lines.append(f"  {p.metadata.name} phase={st.phase}: {', '.join(states)}")
+    return "\n".join(lines) if lines else "  <no pods>"
+
+
 async def wait_for_kopf_handler(
     coapi: CustomObjectsApi,
     name: str,
@@ -575,7 +624,14 @@ async def wait_for_kopf_handler(
             seen = True
         await asyncio.sleep(delay)
 
-    raise AssertionError(f"Handler '{handler_name}' did not finish within {timeout}s")
+    # The wait gives the cluster the full timeout to come up; if it still has
+    # not, include the pods' container states so the failure points at the
+    # cause (image pull, crash loop, unschedulable) instead of a bare timeout.
+    pod_states = await describe_pods(CoreV1Api(coapi.api_client), namespace)
+    raise AssertionError(
+        f"Handler '{handler_name}' did not finish within {timeout}s.\n"
+        f"Pod states:\n{pod_states}"
+    )
 
 
 async def create_test_sys_jobs_table(conn_factory):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -391,12 +391,12 @@ async def start_cluster(
             namespace.metadata.name,
             f"crate-{name}",
             err_msg="Lb service was not ready.",
-            timeout=DEFAULT_TIMEOUT * 5,
+            timeout=DEFAULT_TIMEOUT * 10,
         )
 
         host = await asyncio.wait_for(
             get_service_public_hostname(core, namespace.metadata.name, name),
-            timeout=DEFAULT_TIMEOUT * 5,
+            timeout=DEFAULT_TIMEOUT * 10,
         )
         password = await get_system_user_password(core, namespace.metadata.name, name)
     else:
@@ -414,7 +414,7 @@ async def start_cluster(
             namespace.metadata.name,
             f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
             err_msg="Cluster has not finished bootstrapping",
-            timeout=DEFAULT_TIMEOUT * 5,
+            timeout=DEFAULT_TIMEOUT * 10,
         )
 
         await assert_wait_for(
@@ -422,8 +422,8 @@ async def start_cluster(
             is_cluster_healthy,
             connection_factory(host, password),
             hot_nodes,
-            err_msg="Cluster wasn't healthy after 5 minutes.",
-            timeout=DEFAULT_TIMEOUT * 5,
+            err_msg="Cluster wasn't healthy after 10 minutes.",
+            timeout=DEFAULT_TIMEOUT * 10,
         )
 
     return host, password


### PR DESCRIPTION
Generic e2e/test-stability fixes extracted from the dedicated-master-nodes branch (#845) so master gets them without waiting for that feature. None of these touch master-node logic — they only change `tests/test_exposure.py` and the shared `tests/utils.py` helper. Same spirit as the already-merged #847.

## 1. Stabilise `test_change_exposure_*` / `test_create_traefik_*`
The exposure tests waited only `DEFAULT_TIMEOUT` (60s) for `cluster_create`. During bootstrap the operator execs into the pod over a websocket that can transiently return 400 until the container is ready; the operator retries, but 60s wasn't enough to absorb the retries, so `cluster_create` occasionally timed out (flaky, unrelated to master nodes). Wait `DEFAULT_TIMEOUT * 5`, matching `start_cluster`'s healthy-wait.

## 2. Widen cluster-create/bootstrap waits to 600s under parallel CI
A nightly run showed `test_change_exposure_loadbalancer_to_traefik` time out at 300s while the pod's diagnostic state was fully healthy. The cause isn't a stuck pod or retry cadence — total cluster bring-up (image pulls, JVM start, node contention) on a busy 3-node cluster running clusters in parallel simply exceeded the 300s budget. Bump the *initial* cluster-create/bootstrap waits (`start_cluster`'s bring-up waits and the inline `cluster_create` waits in `test_exposure`) from `*5` to `*10`. This only raises the ceiling — the happy path returns as soon as the handler finishes — and stays well under the operator's 1800s `BOOTSTRAP_TIMEOUT`. Post-create operation waits (`cluster_update`) are left at `*5`.

## 3. Report pod states when `wait_for_kopf_handler` times out
The wait already polls the full timeout to let the cluster come up; when it still times out (most often a stuck bootstrap), raise with each pod's container state instead of a bare "did not finish within Ns". Surfaces the actionable reason — `ImagePullBackOff`, `CrashLoopBackOff`, `ErrImagePull`, `CreateContainerError` — and falls back to pod conditions when no container exists yet (the `Pending` case), so a CI failure explains itself.

## Notes
- Test-only changes; no production behaviour change.
- GitHub Actions skips k8s tests, so these run on the nightly Jenkins integration suite.

LLM-assisted.