### PR TITLE
Add separate spec.grandCentral.exposure switch to decouple GC routing from cluster exposure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ Unreleased
 * Made dedicated master nodes (``spec.nodes.master``) behave consistently
   across all cluster operations.
 
+* Added optional ``spec.grandCentral.exposure`` field (``nginx`` or
+  ``traefik``) to decouple grand-central routing from the CrateDB service
+  exposure.
+
 2.61.0 (2026-06-02)
 -------------------
 

--- a/crate/operator/exposure.py
+++ b/crate/operator/exposure.py
@@ -40,6 +40,7 @@ from crate.operator.grand_central import (
     create_grand_central_exposure,
     delete_grand_central_ingress,
     delete_grand_central_traefik_resources,
+    grand_central_uses_traefik,
     read_grand_central_deployment,
 )
 from crate.operator.utils import crate
@@ -525,6 +526,50 @@ async def patch_service_exposure(
     )
 
 
+async def migrate_grand_central_exposure(
+    namespace: str,
+    name: str,
+    spec: kopf.Spec,
+    meta: kopf.Meta,
+    old_use_traefik: bool,
+    new_use_traefik: bool,
+    logger: logging.Logger,
+) -> None:
+    """
+    Migrate grand-central routing resources from one exposure to the other.
+
+    Creates the routing resources for ``new_use_traefik`` and deletes the
+    resources belonging to the old exposure. Does nothing if grand-central is
+    not deployed for this cluster.
+
+    :param namespace: The Kubernetes namespace for the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param spec: The ``spec`` section of the CrateDB custom resource.
+    :param meta: The ``metadata`` section of the CrateDB custom resource.
+    :param old_use_traefik: Whether grand-central was previously on Traefik.
+    :param new_use_traefik: Whether grand-central should now be on Traefik.
+    :param logger: Logger for operation tracking.
+    """
+    gc_deployment = await read_grand_central_deployment(namespace, name)
+    if not gc_deployment:
+        logger.info("Grand-central not deployed; skipping GC exposure migration")
+        return
+
+    await create_grand_central_exposure(
+        namespace=namespace,
+        name=name,
+        spec=spec,
+        meta=meta,
+        logger=logger,
+        use_traefik=new_use_traefik,
+    )
+
+    if old_use_traefik:
+        await delete_grand_central_traefik_resources(namespace, name, logger)
+    else:
+        await delete_grand_central_ingress(namespace, name, logger)
+
+
 class CreateTraefikResourcesSubHandler(StateBasedSubHandler):
     """
     Creates Traefik resources during cluster creation.
@@ -621,19 +666,59 @@ class ChangeExposureSubHandler(StateBasedSubHandler):
                 logger,
             )
 
-        # grand-central: only if GC is deployed in this cluster
-        gc_deployment = await read_grand_central_deployment(namespace, name)
-        if gc_deployment:
-            await create_grand_central_exposure(
-                namespace=namespace,
-                name=name,
-                spec=spec,
+        gc_exposure_explicit = bool((spec.get("grandCentral") or {}).get("exposure"))
+        if gc_exposure_explicit:
+            logger.info(
+                "Grand-central has its own exposure setting; "
+                "not migrating it on cluster exposure change"
+            )
+        else:
+            await migrate_grand_central_exposure(
+                namespace,
+                name,
+                spec,
                 meta=body["metadata"],
+                old_use_traefik=(old_exposure == "traefik"),
+                new_use_traefik=(new_exposure == "traefik"),
                 logger=logger,
-                use_traefik=(new_exposure == "traefik"),
             )
 
-            if old_exposure == "traefik":
-                await delete_grand_central_traefik_resources(namespace, name, logger)
-            else:
-                await delete_grand_central_ingress(namespace, name, logger)
+
+class ChangeGrandCentralExposureSubHandler(StateBasedSubHandler):
+    """
+    Handles changes to ``spec.grandCentral.exposure`` between 'nginx' and
+    'traefik', migrating only the grand-central routing resources and leaving
+    the CrateDB service untouched.
+    """
+
+    @crate.on.error(error_handler=crate.send_update_failed_notification)
+    async def handle(
+        self,
+        namespace: str,
+        name: str,
+        body: kopf.Body,
+        old: kopf.Body,
+        logger: logging.Logger,
+        **kwargs: Any,
+    ):
+        old_use_traefik = grand_central_uses_traefik(old["spec"])
+        new_use_traefik = grand_central_uses_traefik(body["spec"])
+
+        if old_use_traefik == new_use_traefik:
+            logger.info("Grand-central exposure unchanged")
+            return
+
+        logger.info(
+            "Changing grand-central exposure "
+            f"(traefik={old_use_traefik} -> traefik={new_use_traefik})"
+        )
+
+        await migrate_grand_central_exposure(
+            namespace,
+            name,
+            body["spec"],
+            meta=body["metadata"],
+            old_use_traefik=old_use_traefik,
+            new_use_traefik=new_use_traefik,
+            logger=logger,
+        )

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -739,6 +739,27 @@ async def read_grand_central_httproute(
             return None
 
 
+def get_grand_central_exposure(spec: kopf.Spec) -> str:
+    """
+    Resolve the effective exposure mode for grand-central.
+
+    :param spec: The ``spec`` section of the CrateDB custom resource.
+    """
+    explicit = (spec.get("grandCentral") or {}).get("exposure")
+    if explicit:
+        return explicit
+    return spec.get("cluster", {}).get("exposure", "loadbalancer")
+
+
+def grand_central_uses_traefik(spec: kopf.Spec) -> bool:
+    """
+    Return whether grand-central should be exposed via Traefik.
+
+    :param spec: The ``spec`` section of the CrateDB custom resource.
+    """
+    return get_grand_central_exposure(spec) == "traefik"
+
+
 async def create_grand_central_exposure(
     namespace: str,
     name: str,

--- a/crate/operator/handlers/handle_create_grand_central.py
+++ b/crate/operator/handlers/handle_create_grand_central.py
@@ -27,6 +27,7 @@ from crate.operator.config import config
 from crate.operator.grand_central import (
     create_grand_central_backend,
     create_grand_central_user,
+    grand_central_uses_traefik,
 )
 from crate.operator.utils.kopf import subhandler_partial
 from crate.operator.utils.kubeapi import get_cratedb_resource
@@ -45,8 +46,7 @@ async def create_grand_central(
         new is not None and new.get("backendEnabled")
     ):
         cratedb = await get_cratedb_resource(namespace, name)
-        exposure = cratedb["spec"]["cluster"].get("exposure", "loadbalancer")
-        use_traefik = exposure == "traefik"
+        use_traefik = grand_central_uses_traefik(cratedb["spec"])
         kopf.register(
             fn=subhandler_partial(
                 create_grand_central_backend,

--- a/crate/operator/handlers/handle_update_allowed_cidrs.py
+++ b/crate/operator/handlers/handle_update_allowed_cidrs.py
@@ -28,6 +28,7 @@ from kubernetes_asyncio.client import CoreV1Api, NetworkingV1Api
 from crate.operator.constants import GRAND_CENTRAL_RESOURCE_PREFIX
 from crate.operator.exposure import update_traefik_ip_restriction
 from crate.operator.grand_central import (
+    grand_central_uses_traefik,
     read_grand_central_httproute,
     read_grand_central_ingress,
     update_grand_central_ip_allowlist,
@@ -92,6 +93,9 @@ async def update_service_allowed_cidrs(
         if exposure == "traefik":
             await update_traefik_ip_restriction(namespace, name, new_cidrs, logger)
 
+        # Grand-central IP allowlist follows its own exposure, which
+        # may differ from the CrateDB service exposure.
+        if grand_central_uses_traefik(cratedb["spec"]):
             httproute = await read_grand_central_httproute(
                 namespace=namespace, name=name
             )
@@ -103,6 +107,8 @@ async def update_service_allowed_cidrs(
                     logger=logger,
                 )
         else:
+            # grand-central is on nginx Ingress (e.g. cluster on Traefik but
+            # GC explicitly on nginx) - patch its whitelist annotation instead.
             ingress = await read_grand_central_ingress(namespace=namespace, name=name)
 
             if ingress:

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -33,7 +33,10 @@ from crate.operator.change_compute import (
 from crate.operator.config import config
 from crate.operator.constants import CLUSTER_UPDATE_ID, OperationType
 from crate.operator.expand_volume import ExpandVolumeSubHandler
-from crate.operator.exposure import ChangeExposureSubHandler
+from crate.operator.exposure import (
+    ChangeExposureSubHandler,
+    ChangeGrandCentralExposureSubHandler,
+)
 from crate.operator.operations import (
     DELAY_CRONJOB,
     AfterClusterUpdateSubHandler,
@@ -140,6 +143,7 @@ async def update_cratedb(
     do_scale = False
     do_expand_volume = False
     exposure_changed = False
+    gc_exposure_changed = False
 
     operation = OperationType.UNKNOWN
 
@@ -210,6 +214,12 @@ async def update_cratedb(
                 do_before_update = False
                 do_after_update = False
                 operation = OperationType.CHANGE_EXPOSURE
+        elif field_path == ("spec", "grandCentral", "exposure"):
+            if old_spec != new_spec:
+                gc_exposure_changed = True
+                do_before_update = False
+                do_after_update = False
+                operation = OperationType.CHANGE_EXPOSURE
         elif field_path == ("spec", "nodes", "data"):
             for node_spec_idx in range(len(old_spec)):
                 old_spec = old_spec[node_spec_idx]
@@ -254,6 +264,7 @@ async def update_cratedb(
         and not do_expand_volume
         and not do_change_compute
         and not exposure_changed
+        and not gc_exposure_changed
     ):
         return
 
@@ -319,6 +330,11 @@ async def update_cratedb(
 
     if exposure_changed:
         register_exposure_change_handlers(
+            namespace, name, change_hash, context, depends_on
+        )
+
+    if gc_exposure_changed:
+        register_gc_exposure_change_handlers(
             namespace, name, change_hash, context, depends_on
         )
 
@@ -599,6 +615,19 @@ def register_exposure_change_handlers(
         backoff=get_backoff(),
     )
     depends_on.append(f"{CLUSTER_UPDATE_ID}/change_exposure")
+
+
+def register_gc_exposure_change_handlers(
+    namespace, name, change_hash, context, depends_on
+):
+    kopf.register(
+        fn=ChangeGrandCentralExposureSubHandler(
+            namespace, name, change_hash, context, depends_on=depends_on.copy()
+        )(),
+        id="change_gc_exposure",
+        backoff=get_backoff(),
+    )
+    depends_on.append(f"{CLUSTER_UPDATE_ID}/change_gc_exposure")
 
 
 def get_backoff() -> int:

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -82,6 +82,7 @@ from crate.operator.grand_central import (
     create_grand_central_exposure,
     delete_grand_central_ingress,
     delete_grand_central_traefik_resources,
+    grand_central_uses_traefik,
     read_grand_central_deployment,
     read_grand_central_httproute,
     read_grand_central_ingress,
@@ -1139,12 +1140,11 @@ async def suspend_or_start_grand_central(
     if not deployment:
         return
 
-    # Determine which exposure mode is active
+    # Determine which exposure mode is active for grand-central
     cratedb = await get_cratedb_resource(namespace, name)
     spec = cratedb["spec"]
     meta = cratedb["metadata"]
-    exposure = spec.get("cluster", {}).get("exposure", "loadbalancer")
-    use_traefik = exposure == "traefik"
+    use_traefik = grand_central_uses_traefik(spec)
 
     if suspend:
         # Scale the deployment to 0 first, then remove the routing resource

--- a/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
+++ b/deploy/charts/crate-operator-crds/templates/cratedbs-cloud-crate-io.yaml
@@ -585,6 +585,10 @@ spec:
                   apiUrl:
                     description: The CrateDB Cloud API URL.
                     type: string
+                  exposure:
+                    description: Grand Central routing exposure type.
+                    type: string
+                    enum: ["nginx", "traefik"]
                 required:
                 - backendImage
                 - jwkUrl

--- a/tests/test_grand_central_exposure.py
+++ b/tests/test_grand_central_exposure.py
@@ -1,0 +1,72 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import pytest
+
+from crate.operator.grand_central import (
+    get_grand_central_exposure,
+    grand_central_uses_traefik,
+)
+
+
+@pytest.mark.parametrize(
+    "spec, expected_use_traefik",
+    [
+        ({"cluster": {"exposure": "traefik"}}, True),
+        ({"cluster": {"exposure": "loadbalancer"}}, False),
+        ({"cluster": {}}, False),
+        ({}, False),
+        ({"cluster": {"exposure": "traefik"}, "grandCentral": {}}, True),
+        ({"cluster": {"exposure": "traefik"}, "grandCentral": None}, True),
+        # Decoupled: cluster on LoadBalancer, grand-central explicitly on Traefik.
+        (
+            {
+                "cluster": {"exposure": "loadbalancer"},
+                "grandCentral": {"exposure": "traefik"},
+            },
+            True,
+        ),
+        # Decoupled (opposite): cluster on Traefik, grand-central explicitly on
+        # nginx -> resolves to False so the nginx Ingress path is taken.
+        (
+            {
+                "cluster": {"exposure": "traefik"},
+                "grandCentral": {"exposure": "nginx"},
+            },
+            False,
+        ),
+    ],
+)
+def test_grand_central_uses_traefik(spec, expected_use_traefik):
+    assert grand_central_uses_traefik(spec) is expected_use_traefik
+
+
+def test_explicit_grand_central_exposure_wins_over_cluster():
+    spec = {
+        "cluster": {"exposure": "loadbalancer"},
+        "grandCentral": {"exposure": "traefik"},
+    }
+    assert get_grand_central_exposure(spec) == "traefik"
+
+
+def test_grand_central_exposure_falls_back_to_cluster():
+    spec = {"cluster": {"exposure": "traefik"}}
+    assert get_grand_central_exposure(spec) == "traefik"


### PR DESCRIPTION
## Summary of changes
Adds an optional, independent switch `spec.grandCentral.exposure` (`nginx` | `traefik`) so grand-central routing can be migrated to Traefik while the CrateDB service stays on a LoadBalancer.

- Unset -> falls back to `spec.cluster.exposure`, so existing clusters behave identically
- Set -> fully decouples grand-central from the CrateDB service, e.g. `cluster.exposure: loadbalancer` + `grandCentral.exposure: traefik`.
- Considered on create, suspend/resume, exposure changes, and allowed-CIDR updates.

 New CRD field is optional with no `default`, so existing clusters are untouched and the update handler does not fire on operator deploy.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/2744
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
