### PR TITLE
Keep aws-load-balancer-type when switching exposure to traefik

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Unreleased
 ----------
 
+* Fixed AWS load balancers being orphaned when switching
+  ``spec.cluster.exposure`` from ``loadbalancer`` to ``traefik`` by keeping the
+  ``aws-load-balancer-type`` annotation so Kubernetes deletes the NLB.
+
 * Replaced grand-central Ingress with HTTPRoute and Traefik Middlewares when
   ``spec.cluster.exposure`` is set to ``traefik``.
 

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -1253,13 +1253,19 @@ def _lb_annotations_to_add(dns_record: Optional[str]) -> dict:
 
 def _lb_annotations_to_remove() -> dict:
     """
-    Return all LB annotations set to None to remove them via merge patch.
+    Return the LB tuning annotations set to None to remove them via merge patch.
+
+    The ``aws-load-balancer-type`` annotation is deliberately NOT removed: the
+    in-tree service controller reads it in ``EnsureLoadBalancerDeleted`` to tell
+    an NLB from a Classic ELB. Dropping it while switching the service to
+    ClusterIP makes the controller fall back to the Classic ELB path, fail to
+    find the NLB, and orphan it on AWS (crate/cloud#2976, kubernetes#95042). The
+    annotation is inert on a ClusterIP service, so leaving it is safe.
     """
     return {
         "service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled": None,  # noqa
         "service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout": None,  # noqa
         "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout": None,
-        "service.beta.kubernetes.io/aws-load-balancer-type": None,
         "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": None,  # noqa
         "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": None,
         "service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout": None,

--- a/crate/operator/exposure.py
+++ b/crate/operator/exposure.py
@@ -487,8 +487,8 @@ async def patch_service_exposure(
 
     new_annotations: dict[str, Optional[str]] = {}
     if use_traefik:
-        # When switching to traefik, explicitly null out all LB-specific annotations
-        # so they don't linger on the ClusterIP service.
+        # Drop the LB tuning annotations, but keep aws-load-balancer-type so the
+        # service controller can delete the NLB instead of orphaning it.
         new_annotations.update(_lb_annotations_to_remove())
     else:
         new_annotations.update(_lb_annotations_to_add(dns_record))

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -52,6 +52,7 @@ from crate.operator.constants import (
     CloudProvider,
 )
 from crate.operator.create import (
+    _lb_annotations_to_remove,
     build_cratedb_labels,
     create_services,
     create_sql_exporter_config,
@@ -1192,6 +1193,18 @@ class TestServiceModels:
                 ]
                 == dns
             )
+
+    def test_lb_type_annotation_retained_when_switching_to_clusterip(self):
+        # Switching to traefik (LoadBalancer -> ClusterIP) must keep
+        # aws-load-balancer-type so the service controller can identify and
+        # delete the NLB; dropping it orphans the LB on AWS (crate/cloud#2976).
+        removed = _lb_annotations_to_remove()
+        assert "service.beta.kubernetes.io/aws-load-balancer-type" not in removed
+        assert all(value is None for value in removed.values())
+        assert (
+            "service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled"
+            in removed
+        )
 
     def test_data_service_selector_excludes_masters_with_dedicated_masters(self, faker):
         name = faker.domain_word()


### PR DESCRIPTION
## What

When `spec.cluster.exposure` is switched from `loadbalancer` to `traefik`, the operator patches the data service from `type: LoadBalancer` to `type: ClusterIP` in place. That same patch also nulled out **every** LB annotation — including `service.beta.kubernetes.io/aws-load-balancer-type: nlb`.

The in-tree service controller reads that annotation in `EnsureLoadBalancerDeleted` to distinguish an NLB from a Classic ELB. With it gone, the controller falls back to the Classic ELB API, can't find the NLB, **removes the `service.kubernetes.io/load-balancer-cleanup` finalizer anyway**, and the NLB is left orphaned on AWS.

## Fix

Retain `aws-load-balancer-type` through the switch so the controller correctly identifies and deletes the NLB. The annotation is inert on a `ClusterIP` service (the controller only acts when `type == LoadBalancer`), so leaving it is safe. The remaining tuning annotations (connection draining, idle timeout, cross-zone) and the external-dns hostname are still removed.

This is also correct for legacy Classic-ELB clusters: with no annotation present the controller already uses the Classic ELB path, which deletes correctly.

## Testing

- `pre-commit` (black, flake8, isort, mypy, yamllint) passes.
- Added `TestServiceModels::test_lb_type_annotation_retained_when_switching_to_clusterip`, pairing with the existing `test_get_data_service` which asserts the annotation is *added* on create.

## Caveats for the reviewer

- **Not verifiable on minikube.** The actual NLB deletion is AWS in-tree-controller behavior; the test asserts the annotation contract, not the AWS-side delete. Worth a real EKS smoke test before release.
- **Not retroactive.** This prevents *future* orphans. NLBs already orphaned by the previous behavior need a one-time manual cleanup on AWS.

Refs: crate/cloud#2976, kubernetes/kubernetes#95042 crate/crate-operator#851