### PR TITLE
Prepare release 2.62.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+2.62.0 (2026-07-15)
+-------------------
+
 * Fixed AWS load balancers being orphaned when switching
   ``spec.cluster.exposure`` from ``loadbalancer`` to ``traefik`` by keeping the
   ``aws-load-balancer-type`` annotation so Kubernetes deletes the NLB.
@@ -12,8 +15,9 @@ Unreleased
 * Replaced grand-central Ingress with HTTPRoute and Traefik Middlewares when
   ``spec.cluster.exposure`` is set to ``traefik``.
 
-* Made dedicated master nodes (``spec.nodes.master``) behave consistently
-  across all cluster operations.
+* Added first-class support for dedicated master nodes via
+  ``spec.nodes.master``, handling them consistently across suspend/resume,
+  change-compute, volume expansion, health checks, and webhook feedback.
 
 * Added optional ``spec.grandCentral.exposure`` field (``nginx`` or
   ``traefik``) to decouple grand-central routing from the CrateDB service

--- a/deploy/charts/crate-operator-crds/Chart.yaml
+++ b/deploy/charts/crate-operator-crds/Chart.yaml
@@ -6,13 +6,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.61.0
+version: 2.62.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.61.0"
+appVersion: "2.62.0"
 
 maintainers:
   - name: Crate.io

--- a/deploy/charts/crate-operator/Chart.yaml
+++ b/deploy/charts/crate-operator/Chart.yaml
@@ -6,17 +6,17 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.61.0
+version: 2.62.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.61.0"
+appVersion: "2.62.0"
 
 dependencies:
 - name: crate-operator-crds
-  version: 2.61.0
+  version: 2.62.0
   repository: "file://../crate-operator-crds"
   condition: crate-operator-crds.enabled
 


### PR DESCRIPTION
## Summary of changes

Release prep for 2.62.0 — bumps the Helm charts and dates the changelog. Highlights:

- First-class dedicated master node support (`spec.nodes.master`)
- grand-central now served via HTTPRoute + Traefik Middlewares when exposure is `traefik`
- New `spec.grandCentral.exposure` switch to decouple GC routing from cluster exposure
- Fixed orphaned AWS load balancers when switching exposure to `traefik`
- sql_exporter bumped to 0.24.3 for CVE fixes

## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
