### PR TITLE
Fix suspend/resume failing on clusters without backups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Fixed suspend/resume getting stuck on clusters without backups configured.
+
 2.62.0 (2026-07-15)
 -------------------
 

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -660,6 +660,37 @@ async def scale_backup_metrics_deployment(
         await update_deployment_replicas(apps, namespace, backup_metrics_name, replicas)
 
 
+async def scale_backup_metrics_deployment_if_present(
+    apps: AppsV1Api,
+    namespace: str,
+    name: str,
+    replicas: int,
+    logger: logging.Logger,
+):
+    """
+    Scale the backup-metrics Deployment to ``replicas`` if it exists.
+
+    :param apps: An instance of the Kubernetes Apps V1 API.
+    :param namespace: The Kubernetes namespace for the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param replicas: The new number of replicas for the Deployment.
+    :param logger: The logger on which we're logging.
+    """
+    backup_metrics_name = BACKUP_METRICS_DEPLOYMENT_NAME.format(name=name)
+    try:
+        await update_deployment_replicas(apps, namespace, backup_metrics_name, replicas)
+    except ApiException as e:
+        if e.status == 404:
+            logger.info(
+                "No backup-metrics deployment %s found (no backups configured); "
+                "skipping scaling to %d replicas.",
+                backup_metrics_name,
+                replicas,
+            )
+            return
+        raise
+
+
 def _node_groups_to_restart(
     old: kopf.Body, body: kopf.Body, action: WebhookAction
 ) -> List[NodeGroup]:
@@ -1006,12 +1037,10 @@ async def suspend_or_start_cluster(
                         new_replicas,
                     )
                     if scale_backup_metrics:
-                        # scale backup-metrics deployment back up
-                        backup_metrics_name = BACKUP_METRICS_DEPLOYMENT_NAME.format(
-                            name=name
-                        )
-                        await update_deployment_replicas(
-                            apps, namespace, backup_metrics_name, 1
+                        # scale backup-metrics deployment back up (no-op when the
+                        # cluster has no backups configured and thus no deployment)
+                        await scale_backup_metrics_deployment_if_present(
+                            apps, namespace, name, 1, logger
                         )
                     # scale grand central deployment back up if it exists
                     await suspend_or_start_grand_central(
@@ -1064,12 +1093,10 @@ async def suspend_or_start_cluster(
                         apps, namespace, sts_name, statefulset, new_replicas
                     )
                     if scale_backup_metrics:
-                        # scale backup-metrics deployment down
-                        backup_metrics_name = BACKUP_METRICS_DEPLOYMENT_NAME.format(
-                            name=name
-                        )
-                        await update_deployment_replicas(
-                            apps, namespace, backup_metrics_name, 0
+                        # scale backup-metrics deployment down (no-op when the
+                        # cluster has no backups configured and thus no deployment)
+                        await scale_backup_metrics_deployment_if_present(
+                            apps, namespace, name, 0, logger
                         )
                     # scale grand central deployment down if it exists
                     await suspend_or_start_grand_central(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -24,12 +24,15 @@ from unittest import mock
 
 import kopf
 import pytest
+from kubernetes_asyncio.client import ApiException
 
+from crate.operator.constants import BACKUP_METRICS_DEPLOYMENT_NAME
 from crate.operator.handlers.handle_update_cratedb import _data_nodes_cross_zero
 from crate.operator.operations import (
     check_all_master_nodes_gone,
     check_all_master_nodes_present,
     iter_node_groups,
+    scale_backup_metrics_deployment_if_present,
     scale_master_statefulset,
     suspend_or_start_cluster,
     validate_node_spec,
@@ -420,3 +423,73 @@ class TestSuspendResumeOrdering:
         assert order.index("data_scale:0") < order.index("master_scale:0")
         assert order.index("data_gone") < order.index("master_scale:0")
         assert order.index("master_scale:0") < order.index("masters_gone")
+
+
+class TestScaleBackupMetricsIfPresent:
+    @pytest.mark.asyncio
+    async def test_scales_when_deployment_exists(self):
+        apps = mock.Mock()
+        with mock.patch(
+            "crate.operator.operations.update_deployment_replicas",
+            new=mock.AsyncMock(),
+        ) as mock_update:
+            await scale_backup_metrics_deployment_if_present(
+                apps, "ns", "c", 1, mock.Mock()
+            )
+        mock_update.assert_awaited_once_with(
+            apps, "ns", BACKUP_METRICS_DEPLOYMENT_NAME.format(name="c"), 1
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_deployment_is_a_noop(self):
+        apps = mock.Mock()
+        with mock.patch(
+            "crate.operator.operations.update_deployment_replicas",
+            new=mock.AsyncMock(side_effect=ApiException(status=404)),
+        ):
+            # should not raise.
+            await scale_backup_metrics_deployment_if_present(
+                apps, "ns", "c", 0, mock.Mock()
+            )
+
+    @pytest.mark.asyncio
+    async def test_other_api_errors_propagate(self):
+        apps = mock.Mock()
+        with mock.patch(
+            "crate.operator.operations.update_deployment_replicas",
+            new=mock.AsyncMock(side_effect=ApiException(status=409)),
+        ):
+            with pytest.raises(ApiException):
+                await scale_backup_metrics_deployment_if_present(
+                    apps, "ns", "c", 1, mock.Mock()
+                )
+
+
+class TestSuspendResumeWithoutBackups:
+    @pytest.mark.asyncio
+    async def test_resume_does_not_wedge_when_no_backup_metrics_deployment(self):
+        order: list = []
+        old = {"spec": {"nodes": {"data": [{"name": "hot", "replicas": 0}]}}}
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(
+            return_value=_statefulset(spec_replicas=0)
+        )
+
+        with _suspend_resume_patches(order):
+            with mock.patch(
+                "crate.operator.operations.update_deployment_replicas",
+                new=mock.AsyncMock(side_effect=ApiException(status=404)),
+            ):
+                # should complete without raising despite the missing deployment.
+                await suspend_or_start_cluster(
+                    apps,
+                    mock.Mock(),
+                    "ns",
+                    "c",
+                    old,
+                    _data_scaling_diff(0, 3),
+                    True,
+                    mock.Mock(),
+                )
+
+        assert "data_scale:3" in order


### PR DESCRIPTION
## Summary of changes
Suspend/resume (scaling data nodes to `0` and back) got stuck on clusters without backups configured, because the backup-metrics deployment only exists when backups are configured. Scaling it during suspend/resume now no-ops on a 404 instead of failing.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3016
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
