### PR TITLE
Fixed the grand-central-cors middleware.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 
 * Fixed suspend/resume getting stuck on clusters without backups configured.
 
+* Fixed the ``grand-central-cors`` when ``spec.cluster.settings.http.cors.allow-origin``
+  is not set (which might be the case on older clusters)
+
 2.62.0 (2026-07-15)
 -------------------
 

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -555,8 +555,12 @@ def get_grand_central_middleware_cors(
     Build the ``grand-central-cors`` Traefik Middleware manifest.
 
     The CrateDB setting accepts a comma-separated list of origins; these are
-    split into individual entries. Falls back to ``["*"]`` when the setting
-    is absent.
+    split into individual entries. When the setting is absent, all origins
+    are allowed via ``accessControlAllowOriginListRegex`` rather than a
+    literal ``"*"`` in ``accessControlAllowOriginList``: Traefik's headers
+    middleware returns the literal ``"*"`` for the latter, which browsers
+    reject on credentialed requests, whereas a regex match reflects the
+    actual request Origin.
 
     :param owner_references: Owner references to set on the resource.
     :param name: The CrateDB custom resource name defining the CrateDB cluster.
@@ -564,28 +568,30 @@ def get_grand_central_middleware_cors(
     :param spec: The ``spec`` section of the CrateDB custom resource, used to
         read ``cluster.settings.http.cors.allow-origin``.
     """
-    raw_origin = (
-        spec["cluster"].get("settings", {}).get("http.cors.allow-origin") or "*"
-    )
-    origin_list = [o.strip() for o in raw_origin.split(",") if o.strip()]
+    raw_origin = spec["cluster"].get("settings", {}).get("http.cors.allow-origin")
+
+    headers: Dict[str, Any] = {
+        "accessControlAllowCredentials": True,
+        "accessControlAllowMethods": [
+            "GET",
+            "POST",
+            "PUT",
+            "PATCH",
+            "OPTIONS",
+            "DELETE",
+        ],
+        "accessControlAllowHeaders": ["Content-Type", "Authorization"],
+        "accessControlMaxAge": 7200,
+    }
+    if raw_origin:
+        headers["accessControlAllowOriginList"] = [
+            o.strip() for o in raw_origin.split(",") if o.strip()
+        ]
+    else:
+        headers["accessControlAllowOriginListRegex"] = [".*"]
 
     body = _build_middleware_base(name, _MIDDLEWARE_CORS, labels, owner_references)
-    body["spec"] = {
-        "headers": {
-            "accessControlAllowOriginList": origin_list,
-            "accessControlAllowCredentials": True,
-            "accessControlAllowMethods": [
-                "GET",
-                "POST",
-                "PUT",
-                "PATCH",
-                "OPTIONS",
-                "DELETE",
-            ],
-            "accessControlAllowHeaders": ["Content-Type", "Authorization"],
-            "accessControlMaxAge": 7200,
-        }
-    }
+    body["spec"] = {"headers": headers}
     return body
 
 

--- a/tests/test_create_grand_central.py
+++ b/tests/test_create_grand_central.py
@@ -383,9 +383,15 @@ async def test_create_grand_central_traefik(
     ]
     assert cors_headers["accessControlAllowCredentials"] is True
     assert cors_headers["accessControlMaxAge"] == 7200
-    assert cors_headers["accessControlAllowOriginList"] == [
-        "*"
-    ], "Expected default origin list ['*'] when no cors setting is configured"
+    assert cors_headers.get("accessControlAllowOriginList") is None, (
+        "Expected no literal accessControlAllowOriginList when no cors setting "
+        "is configured, since Traefik returns the literal '*' for it, which "
+        "browsers reject on credentialed requests"
+    )
+    assert cors_headers["accessControlAllowOriginListRegex"] == [".*"], (
+        "Expected a regex match-all when no cors setting is configured, so "
+        "Traefik reflects the request Origin"
+    )
 
     # No nginx Ingress should be created
     await assert_wait_for(


### PR DESCRIPTION
## Summary of changes
Switch the default case to `accessControlAllowOriginListRegex: [".*"]` when ``spec.cluster.settings.http.cors.allow-origin`` is not set (which might be the case on older clusters)

```
/account/organizations/21095b48-a276-46a7-95fd-64479f4d409d/projects/fc7ada71-5d28-4d49-8203-ff4649dbd13c/clusters/5e52d9b3-3b92-4568-a3a4-620ed9d1d445/monitoring/cluster:1 
Access to fetch at 'https://devbrain.gc.aks1.eastus2.azure.cratedb.net/api/health' from origin 'https://console.cratedb.cloud' has been blocked by CORS policy:
The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.
```
## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
