### PR TITLE
Support clusters with more than one data node group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ Unreleased
 
 * Fixed rolling restart progress restarting from 1 for every node group.
 
+* Fixed every update failing on clusters with more than one data node group.
+
+* Fixed suspending a cluster with more than one data node group getting stuck.
+
+* Fixed stale shard allocation exclusions after scaling down several data node groups.
+
 2.62.2 (2026-07-22)
 -------------------
 

--- a/crate/operator/handlers/handle_update_cratedb.py
+++ b/crate/operator/handlers/handle_update_cratedb.py
@@ -22,7 +22,7 @@
 import datetime
 import hashlib
 import logging
-from typing import List
+from typing import List, Tuple
 
 import kopf
 
@@ -59,19 +59,23 @@ from crate.operator.utils.notifications import FlushNotificationsSubHandler
 from crate.operator.webhooks import WebhookAction
 
 
-def _data_nodes_cross_zero(diff: kopf.Diff) -> bool:
+def _classify_data_scaling(diff: kopf.Diff) -> Tuple[bool, bool]:
     """
-    Return whether any data node group is scaling to or from zero replicas in
-    this diff, i.e. whether the cluster is being suspended or resumed. Used to
-    distinguish a legitimate (data-driven) suspend/resume from an unsafe
-    standalone master scale.
+    Return ``(resuming, suspending)`` for the data node groups in this diff.
+
+    Suspend and resume are cluster-wide, so one group of several reaching zero is
+    an ordinary scale. Must agree with
+    :func:`crate.operator.scale.classify_data_scaling`, or a ``master.replicas``
+    change to zero gets waved through and the masters go down under the groups
+    still serving (crate/cloud#3038).
     """
     for _, field_path, old_value, new_value in diff:
         if field_path == ("spec", "nodes", "data"):
-            for old_spec, new_spec in zip(old_value, new_value):
-                if old_spec.get("replicas") == 0 or new_spec.get("replicas") == 0:
-                    return True
-    return False
+            return (
+                all(group.get("replicas", 0) == 0 for group in old_value),
+                all(group.get("replicas", 0) == 0 for group in new_value),
+            )
+    return False, False
 
 
 async def update_cratedb(
@@ -147,7 +151,9 @@ async def update_cratedb(
 
     operation = OperationType.UNKNOWN
 
-    data_nodes_cross_zero = _data_nodes_cross_zero(diff)
+    # One decision, used both to guard the master scale and to classify the data
+    # groups - two would drift apart, and this one gates a master scale to zero.
+    data_resuming, data_suspending = _classify_data_scaling(diff)
 
     for _, field_path, old_spec, new_spec in diff:
         if field_path in {
@@ -166,10 +172,11 @@ async def update_cratedb(
                 old_master = old_spec or 0
                 new_master = new_spec or 0
                 if old_master == 0 or new_master == 0:
-                    # When data is also crossing zero, suspend_or_start_cluster
-                    # scales the masters itself - reject only a standalone
-                    # across-zero change.
-                    if not data_nodes_cross_zero:
+                    # Only safe for a whole-cluster suspend/resume, where
+                    # suspend_or_start_cluster scales the masters itself in the
+                    # right order. On an ordinary scale, scale_cluster would take
+                    # them down under the groups still serving.
+                    if not (data_resuming or data_suspending):
                         raise kopf.PermanentError(
                             "Scaling master nodes to or from zero is only "
                             "supported as part of a full cluster "
@@ -221,15 +228,21 @@ async def update_cratedb(
                 do_after_update = False
                 operation = OperationType.CHANGE_EXPOSURE
         elif field_path == ("spec", "nodes", "data"):
-            for node_spec_idx in range(len(old_spec)):
-                old_spec = old_spec[node_spec_idx]
-                new_spec = new_spec[node_spec_idx]
+            if len(old_spec) != len(new_spec):
+                # ScaleSubHandler rejects this too but never gets registered from
+                # here, so without this the update is a silent no-op.
+                raise kopf.PermanentError(
+                    "Adding and removing node specs is not supported at this "
+                    f"time (spec.nodes.data went from {len(old_spec)} to "
+                    f"{len(new_spec)} groups)."
+                )
 
-                if old_spec.get("replicas") != new_spec.get("replicas"):
+            for old_group, new_group in zip(old_spec, new_spec):
+                if old_group.get("replicas") != new_group.get("replicas"):
                     do_scale = True
                     operation = OperationType.SCALE
                     # When resuming the cluster do not register before_update
-                    if old_spec.get("replicas") == 0:
+                    if data_resuming:
                         do_before_update = False
                         operation = OperationType.RESUME
 
@@ -237,21 +250,21 @@ async def update_cratedb(
                         await set_cronjob_delay(patch)
 
                     # When suspending the cluster do not register after_update
-                    elif new_spec.get("replicas") == 0:
+                    elif data_suspending:
                         do_after_update = False
                         operation = OperationType.SUSPEND
 
                         # Do not re-enable the cronjobs if the cluster is suspended
                         patch.status[DELAY_CRONJOB] = False
 
-                elif old_spec.get("resources", {}).get("disk", {}).get(
+                elif old_group.get("resources", {}).get("disk", {}).get(
                     "size"
-                ) != new_spec.get("resources", {}).get("disk", {}).get("size"):
+                ) != new_group.get("resources", {}).get("disk", {}).get("size"):
                     do_expand_volume = True
                     if config.NO_DOWNTIME_STORAGE_EXPANSION:
                         do_before_update = False
                         do_after_update = False
-                elif has_compute_changed(old_spec, new_spec):
+                elif has_compute_changed(old_group, new_group):
                     do_change_compute = True
                     operation = OperationType.CHANGE_COMPUTE
                     # pod resources won't change until each pod is recreated

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -1145,68 +1145,84 @@ async def suspend_or_start_cluster(
                     f"data-{node_name}",
                     logger,
                 )
-            elif old_replicas > new_replicas:
-                # suspend the cluster -> scale down to 0 replicas
-                index_path, *_ = field_path
-                index = int(index_path)
-                node_spec = old["spec"]["nodes"]["data"][index]
-                node_name = node_spec["name"]
-                sts_name = f"crate-data-{node_name}-{name}"
-                statefulset = await apps.read_namespaced_stateful_set(
-                    namespace=namespace, name=sts_name
-                )
-                current_replicas = statefulset.spec.replicas
-                if current_replicas != new_replicas:
-                    # Only gate on health while data nodes remain - a
-                    # masters-only remainder always reports unhealthy and would
-                    # deadlock the suspend.
-                    conn_factory = await _get_connection_factory(core, namespace, name)
-                    await check_cluster_healthy(
-                        name, namespace, apps, conn_factory, logger
-                    )
-                    await update_statefulset_replicas(
-                        apps, namespace, sts_name, statefulset, new_replicas
-                    )
-                    if scale_backup_metrics:
-                        # scale backup-metrics deployment down (no-op when the
-                        # cluster has no backups configured and thus no deployment)
-                        await scale_backup_metrics_deployment_if_present(
-                            apps, namespace, name, 0, logger
-                        )
-                    # scale grand central deployment down if it exists
-                    await suspend_or_start_grand_central(
-                        apps, namespace, name, suspend=True, logger=logger
-                    )
-                await send_operation_progress_notification(
-                    namespace=namespace,
-                    name=name,
-                    message="Suspending cluster.",
-                    logger=logger,
-                    status=WebhookStatus.IN_PROGRESS,
-                    operation=WebhookOperation.UPDATE,
-                    action=(
-                        WebhookAction.SUSPEND
-                        if new_replicas == 0
-                        else WebhookAction.SCALE
-                    ),
-                )
-                if scale_backup_metrics:
-                    await check_backup_metrics_pod_gone(
-                        core,
-                        namespace,
-                        name,
-                    )
-                await check_all_data_nodes_gone(core, namespace, name, old)
 
-                # Delete the service and Traefik resources (if any) when suspending
-                if use_traefik:
-                    # Delete Traefik resources (IngressRouteTCPs and MiddlewareTCP)
-                    await delete_traefik_resources(namespace, name)
-                    # Also delete the ClusterIP service
-                    await delete_clusterip_service(core, namespace, name)
-                else:
-                    # Delete the LoadBalancer service
-                    await delete_lb_service(core, namespace, name)
+        # Collected up front so the cluster-wide steps - the health gate, the wait
+        # for pods, the service teardown - run once around every group. Per group
+        # both waits deadlock: a half-suspended cluster is never healthy, and all
+        # data pods cannot be gone while later groups still run (crate/cloud#3038).
+        targets: List[Tuple[str, V1StatefulSet, int]] = []
+        for _, group_path, group_old, group_new in data_diff_items:
+            if group_old > group_new:
+                group_index, *_ = group_path
+                group_name = old["spec"]["nodes"]["data"][int(group_index)]["name"]
+                group_sts_name = f"crate-data-{group_name}-{name}"
+                targets.append(
+                    (
+                        group_sts_name,
+                        await apps.read_namespaced_stateful_set(
+                            namespace=namespace, name=group_sts_name
+                        ),
+                        group_new,
+                    )
+                )
+
+        if targets:
+            pending = [t for t in targets if t[1].spec.replicas != t[2]]
+            if len(pending) == len(targets):
+                # Nothing is down yet, so the cluster can still be healthy.
+                # Skipping once anything is down is what keeps a retry of the wait
+                # below from deadlocking here instead - though it cannot tell a
+                # retry from a StatefulSet scaled down out of band.
+                conn_factory = await _get_connection_factory(core, namespace, name)
+                await check_cluster_healthy(name, namespace, apps, conn_factory, logger)
+
+            for sts_name, statefulset, new_replicas in pending:
+                await update_statefulset_replicas(
+                    apps, namespace, sts_name, statefulset, new_replicas
+                )
+
+            if pending:
+                if scale_backup_metrics:
+                    # scale backup-metrics deployment down (no-op when the
+                    # cluster has no backups configured and thus no deployment)
+                    await scale_backup_metrics_deployment_if_present(
+                        apps, namespace, name, 0, logger
+                    )
+                # scale grand central deployment down if it exists
+                await suspend_or_start_grand_central(
+                    apps, namespace, name, suspend=True, logger=logger
+                )
+
+            await send_operation_progress_notification(
+                namespace=namespace,
+                name=name,
+                message="Suspending cluster.",
+                logger=logger,
+                status=WebhookStatus.IN_PROGRESS,
+                operation=WebhookOperation.UPDATE,
+                action=(
+                    WebhookAction.SUSPEND
+                    if all(replicas == 0 for _, _, replicas in targets)
+                    else WebhookAction.SCALE
+                ),
+            )
+            if scale_backup_metrics:
+                await check_backup_metrics_pod_gone(
+                    core,
+                    namespace,
+                    name,
+                )
+            await check_all_data_nodes_gone(core, namespace, name, old)
+
+            # Delete the service and Traefik resources (if any) when suspending
+            if use_traefik:
+                # Delete Traefik resources (IngressRouteTCPs and MiddlewareTCP)
+                await delete_traefik_resources(namespace, name)
+                # Also delete the ClusterIP service
+                await delete_clusterip_service(core, namespace, name)
+            else:
+                # Delete the LoadBalancer service
+                await delete_lb_service(core, namespace, name)
 
     if has_dedicated_masters and is_suspend:
         await scale_master_statefulset(apps, namespace, name, 0, logger)

--- a/crate/operator/scale.py
+++ b/crate/operator/scale.py
@@ -581,9 +581,14 @@ async def scale_cluster(
                 node_spec = spec["nodes"]["data"][index]
                 node_name = node_spec["name"]
                 sts_name = f"crate-data-{node_name}-{name}"
-                excess_nodes = [
+                group_excess_nodes = [
                     f"data-{node_name}-{i}" for i in range(new_replicas, old_replicas)
                 ]
+                # Accumulated because ``reset_allocation`` below runs once and has
+                # to clear every node it excluded. Anything left behind stays
+                # excluded in the persistent cluster state, so a later scale-up
+                # returns those nodes holding no shards (crate/cloud#3038).
+                excess_nodes += group_excess_nodes
                 statefulset = await apps.read_namespaced_stateful_set(
                     namespace=namespace, name=sts_name
                 )
@@ -598,7 +603,7 @@ async def scale_cluster(
                     await deallocate_nodes(
                         conn_factory,
                         new_num_data_nodes,
-                        excess_nodes,
+                        group_excess_nodes,
                         logger,
                     )
 

--- a/tests/test_handle_update_cratedb.py
+++ b/tests/test_handle_update_cratedb.py
@@ -1,0 +1,269 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import datetime
+from typing import Any, Dict, List, Tuple
+from unittest import mock
+
+import kopf
+import pytest
+
+from crate.operator.constants import CLUSTER_UPDATE_ID
+from crate.operator.handlers.handle_update_cratedb import update_cratedb
+from crate.operator.operations import DELAY_CRONJOB
+
+
+def _group(name: str, replicas: int, cpu: int = 2) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "replicas": replicas,
+        "resources": {
+            "limits": {"cpu": cpu, "memory": "4Gi"},
+            "disk": {"size": "16GiB", "count": 1},
+        },
+    }
+
+
+def _data_diff(old_groups, new_groups) -> kopf.Diff:
+    """
+    A diff over ``spec.nodes.data``. kopf does not recurse into lists, so the
+    whole list arrives as one item -- which is what makes iterating the groups
+    correctly this handler's job.
+    """
+    return kopf.Diff(
+        [
+            kopf.DiffItem(
+                kopf.DiffOperation.CHANGE,
+                ("spec", "nodes", "data"),
+                old_groups,
+                new_groups,
+            )
+        ]
+    )
+
+
+async def _run(diff: kopf.Diff, new_groups) -> Tuple[List[str], kopf.Patch]:
+    """
+    Run ``update_cratedb`` with ``kopf.register`` stubbed out and return the ids
+    of the sub-handlers it registered, plus the patch it produced.
+    """
+    registered: List[str] = []
+    patch = kopf.Patch()
+    body = kopf.Body(
+        {
+            "metadata": {"annotations": {}},
+            "spec": {"cluster": {"version": "5.9.0"}, "nodes": {"data": new_groups}},
+        }
+    )
+
+    with mock.patch(
+        "crate.operator.handlers.handle_update_cratedb.kopf.register",
+        side_effect=lambda fn, id, **kwargs: registered.append(id),
+    ):
+        await update_cratedb(
+            namespace="ns",
+            name="c",
+            patch=patch,
+            body=body,
+            status={},
+            diff=diff,
+            started=datetime.datetime.now(datetime.timezone.utc),
+            logger=mock.Mock(),
+        )
+    return registered, patch
+
+
+class TestSeveralDataGroups:
+    """
+    ``spec.nodes.data`` is a list, and the dispatch used to rebind its loop
+    variable to the first element -- so a cluster with two or more data groups
+    raised ``KeyError`` before any sub-handler was registered, and no update of
+    any kind could complete (crate/cloud#3038).
+    """
+
+    @pytest.mark.asyncio
+    async def test_scaling_one_of_two_groups_is_dispatched(self):
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 3), _group("cold", 4)]
+
+        registered, _ = await _run(_data_diff(old, new), new)
+
+        assert "scale" in registered
+
+    @pytest.mark.asyncio
+    async def test_compute_change_on_the_second_group_is_detected(self):
+        # The old dispatch never looked past the first group, so a change that
+        # only touches a later group went unnoticed.
+        old = [_group("hot", 3), _group("cold", 2, cpu=2)]
+        new = [_group("hot", 3), _group("cold", 2, cpu=8)]
+
+        registered, _ = await _run(_data_diff(old, new), new)
+
+        assert "change_compute" in registered
+        assert "restart" in registered
+
+    @pytest.mark.asyncio
+    async def test_disk_change_on_the_second_group_is_detected(self):
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 3), _group("cold", 2)]
+        new[1]["resources"]["disk"]["size"] = "32GiB"
+
+        registered, _ = await _run(_data_diff(old, new), new)
+
+        assert "expand_volume" in registered
+
+    @pytest.mark.asyncio
+    async def test_no_change_registers_nothing(self):
+        groups = [_group("hot", 3), _group("cold", 2)]
+
+        registered, _ = await _run(_data_diff(groups, groups), groups)
+
+        assert registered == []
+
+
+class TestSuspendResumeIsClusterWide:
+    """
+    Suspend and resume take *every* data group across zero. The scale handler
+    decides the same way (``scale.classify_data_scaling``); if this dispatch
+    disagreed it would skip ``after_cluster_update`` on what is then carried out
+    as an ordinary scale, leaving ``cluster.routing.allocation.enable`` pinned to
+    ``new_primaries``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_groups_to_zero_is_a_suspend(self):
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 0), _group("cold", 0)]
+
+        registered, patch = await _run(_data_diff(old, new), new)
+
+        assert "scale" in registered
+        # A suspend skips after_cluster_update and keeps the cronjobs disabled.
+        assert "after_cluster_update" not in registered
+        assert patch.status[DELAY_CRONJOB] is False
+
+    @pytest.mark.asyncio
+    async def test_all_groups_from_zero_is_a_resume(self):
+        old = [_group("hot", 0), _group("cold", 0)]
+        new = [_group("hot", 3), _group("cold", 2)]
+
+        registered, patch = await _run(_data_diff(old, new), new)
+
+        assert "scale" in registered
+        # A resume skips before_cluster_update and delays the cronjobs.
+        assert "before_cluster_update" not in registered
+        assert patch.status[DELAY_CRONJOB] is True
+
+    @pytest.mark.asyncio
+    async def test_one_group_to_zero_is_an_ordinary_scale(self):
+        # ``cold`` going to zero while ``hot`` keeps serving is not a suspend, so
+        # after_cluster_update must still run and reset the allocation setting.
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 3), _group("cold", 0)]
+
+        registered, patch = await _run(_data_diff(old, new), new)
+
+        assert "scale" in registered
+        assert "before_cluster_update" in registered
+        assert "after_cluster_update" in registered
+        assert DELAY_CRONJOB not in patch.status
+
+    @pytest.mark.asyncio
+    async def test_single_group_cluster_still_suspends(self):
+        # The shape every cluster in use has today: one group, so "all groups"
+        # and "this group" are the same thing.
+        registered, patch = await _run(
+            _data_diff([_group("hot", 3)], [_group("hot", 0)]), [_group("hot", 0)]
+        )
+
+        assert "scale" in registered
+        assert "after_cluster_update" not in registered
+        assert patch.status[DELAY_CRONJOB] is False
+
+    @pytest.mark.asyncio
+    async def test_master_to_zero_is_rejected_unless_every_group_suspends(self):
+        # The dangerous case: `cold` alone goes to zero, so this is an ordinary
+        # scale. scale_cluster would honour the master change literally and take
+        # every master down while `hot` is still serving, so the dispatch has to
+        # reject it rather than wave it through.
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 3), _group("cold", 0)]
+        diff = kopf.Diff(
+            [
+                kopf.DiffItem(
+                    kopf.DiffOperation.CHANGE,
+                    ("spec", "nodes", "master", "replicas"),
+                    3,
+                    0,
+                ),
+                _data_diff(old, new)[0],
+            ]
+        )
+
+        with pytest.raises(kopf.PermanentError, match="full cluster"):
+            await _run(diff, new)
+
+    @pytest.mark.asyncio
+    async def test_master_to_zero_is_allowed_when_the_whole_cluster_suspends(self):
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 0), _group("cold", 0)]
+        diff = kopf.Diff(
+            [
+                kopf.DiffItem(
+                    kopf.DiffOperation.CHANGE,
+                    ("spec", "nodes", "master", "replicas"),
+                    3,
+                    0,
+                ),
+                _data_diff(old, new)[0],
+            ]
+        )
+
+        registered, _ = await _run(diff, new)
+
+        assert "scale" in registered
+
+    @pytest.mark.asyncio
+    async def test_adding_a_data_group_is_rejected_rather_than_ignored(self):
+        # Without this the update is a silent no-op: nothing is registered, the
+        # handler returns early, and the CRD and the cluster diverge quietly.
+        old = [_group("hot", 3)]
+        new = [_group("hot", 3), _group("cold", 2)]
+
+        with pytest.raises(kopf.PermanentError, match="Adding and removing"):
+            await _run(_data_diff(old, new), new)
+
+    @pytest.mark.asyncio
+    async def test_removing_a_data_group_is_rejected(self):
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 3)]
+
+        with pytest.raises(kopf.PermanentError, match="Adding and removing"):
+            await _run(_data_diff(old, new), new)
+
+    @pytest.mark.asyncio
+    async def test_update_context_is_stored(self):
+        old = [_group("hot", 3), _group("cold", 2)]
+        new = [_group("hot", 3), _group("cold", 4)]
+
+        _, patch = await _run(_data_diff(old, new), new)
+
+        assert "ref" in patch.status[CLUSTER_UPDATE_ID]

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -27,7 +27,7 @@ import pytest
 from kubernetes_asyncio.client import ApiException
 
 from crate.operator.constants import BACKUP_METRICS_DEPLOYMENT_NAME
-from crate.operator.handlers.handle_update_cratedb import _data_nodes_cross_zero
+from crate.operator.handlers.handle_update_cratedb import _classify_data_scaling
 from crate.operator.operations import (
     check_all_master_nodes_gone,
     check_all_master_nodes_present,
@@ -101,15 +101,42 @@ class TestIterNodeGroups:
         assert "name" not in groups[0].spec
 
 
-class TestDataNodesCrossZero:
+def _multi_group_data_diff(old_replicas, new_replicas):
+    """A ``spec.nodes.data`` diff over several groups, ``(old, new)`` per group."""
+    names = ["hot", "cold", "frozen"]
+    return kopf.Diff(
+        [
+            kopf.DiffItem(
+                kopf.DiffOperation.CHANGE,
+                ("spec", "nodes", "data"),
+                [
+                    {"name": name, "replicas": replicas}
+                    for name, replicas in zip(names, old_replicas)
+                ],
+                [
+                    {"name": name, "replicas": replicas}
+                    for name, replicas in zip(names, new_replicas)
+                ],
+            )
+        ]
+    )
+
+
+class TestClassifyDataScaling:
+    """
+    Must agree with ``scale.classify_data_scaling``: suspend and resume are
+    cluster-wide, and this decision gates a ``master.replicas`` change to zero
+    (crate/cloud#3038).
+    """
+
     def test_suspend_is_detected(self):
-        assert _data_nodes_cross_zero(_data_diff(3, 0)) is True
+        assert _classify_data_scaling(_data_diff(3, 0)) == (False, True)
 
     def test_resume_is_detected(self):
-        assert _data_nodes_cross_zero(_data_diff(0, 3)) is True
+        assert _classify_data_scaling(_data_diff(0, 3)) == (True, False)
 
     def test_plain_scale_is_not_suspend_or_resume(self):
-        assert _data_nodes_cross_zero(_data_diff(3, 2)) is False
+        assert _classify_data_scaling(_data_diff(3, 2)) == (False, False)
 
     def test_master_only_diff_is_not_detected(self):
         # A standalone master.replicas change with no data transition: this is
@@ -124,7 +151,35 @@ class TestDataNodesCrossZero:
                 )
             ]
         )
-        assert _data_nodes_cross_zero(diff) is False
+        assert _classify_data_scaling(diff) == (False, False)
+
+    def test_all_groups_to_zero_is_a_suspend(self):
+        assert _classify_data_scaling(_multi_group_data_diff([3, 2], [0, 0])) == (
+            False,
+            True,
+        )
+
+    def test_all_groups_from_zero_is_a_resume(self):
+        assert _classify_data_scaling(_multi_group_data_diff([0, 0], [3, 2])) == (
+            True,
+            False,
+        )
+
+    def test_one_group_of_several_reaching_zero_is_neither(self):
+        # The dangerous case: with per-group ("any group touches zero") semantics
+        # this read as a suspend, which waves a master scale to zero past the
+        # guard -- and the scale handler then takes the masters down while the
+        # remaining group is still serving.
+        assert _classify_data_scaling(_multi_group_data_diff([3, 2], [3, 0])) == (
+            False,
+            False,
+        )
+
+    def test_one_group_of_several_leaving_zero_is_neither(self):
+        assert _classify_data_scaling(_multi_group_data_diff([3, 0], [3, 2])) == (
+            False,
+            False,
+        )
 
 
 def _statefulset(spec_replicas=None, ready_replicas=None):
@@ -441,6 +496,31 @@ def _data_scaling_diff(old_replicas, new_replicas):
     )
 
 
+def _multi_data_scaling_diff(pairs):
+    """
+    A scaling diff over several data groups: one ``(old, new)`` pair per group,
+    in spec order.
+    """
+    return kopf.Diff(
+        [
+            kopf.DiffItem(kopf.DiffOperation.CHANGE, (str(index), "replicas"), old, new)
+            for index, (old, new) in enumerate(pairs)
+        ]
+    )
+
+
+def _statefulsets_by_replicas(replicas_by_sts_name):
+    """
+    An ``apps.read_namespaced_stateful_set`` stub returning a distinct
+    StatefulSet per name, so a multi-group cluster can be modelled.
+    """
+
+    async def _read(namespace, name):
+        return _statefulset(spec_replicas=replicas_by_sts_name[name])
+
+    return mock.AsyncMock(side_effect=_read)
+
+
 class TestSuspendResumeOrdering:
     @pytest.mark.asyncio
     async def test_resume_brings_masters_up_before_data(self):
@@ -500,6 +580,133 @@ class TestSuspendResumeOrdering:
         assert order.index("data_scale:0") < order.index("master_scale:0")
         assert order.index("data_gone") < order.index("master_scale:0")
         assert order.index("master_scale:0") < order.index("masters_gone")
+
+
+class TestSuspendWithSeveralDataGroups:
+    """
+    Suspending is cluster-wide, so the steps that concern the whole cluster have
+    to run once around every data group rather than once per group
+    (crate/cloud#3038).
+    """
+
+    OLD = {
+        "spec": {
+            "nodes": {
+                "data": [
+                    {"name": "hot", "replicas": 3},
+                    {"name": "cold", "replicas": 2},
+                ]
+            }
+        }
+    }
+    SUSPENDED_GROUPS = [
+        {"name": "hot", "replicas": 0},
+        {"name": "cold", "replicas": 0},
+    ]
+
+    @pytest.mark.asyncio
+    async def test_every_group_is_scaled_down_before_waiting_for_pods(self):
+        # Waiting for *all* data pods to be gone after the first group could
+        # never succeed while the second group is still running, so the wait has
+        # to come after both groups are down.
+        order: list = []
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = _statefulsets_by_replicas(
+            {"crate-data-hot-c": 3, "crate-data-cold-c": 2}
+        )
+
+        with _suspend_resume_patches(order, data_groups=self.SUSPENDED_GROUPS):
+            await suspend_or_start_cluster(
+                apps,
+                mock.Mock(),
+                "ns",
+                "c",
+                self.OLD,
+                _multi_data_scaling_diff([(3, 0), (2, 0)]),
+                False,
+                mock.Mock(),
+            )
+
+        assert order.count("data_scale:0") == 2
+        assert order.count("data_gone") == 1
+        last_scale = max(i for i, step in enumerate(order) if step == "data_scale:0")
+        assert last_scale < order.index("data_gone")
+
+    @pytest.mark.asyncio
+    async def test_health_is_gated_once_before_the_first_group_goes_down(self):
+        # A half-suspended cluster never reports healthy, so gating per group
+        # would deadlock on the second group.
+        order: list = []
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = _statefulsets_by_replicas(
+            {"crate-data-hot-c": 3, "crate-data-cold-c": 2}
+        )
+
+        with _suspend_resume_patches(order, data_groups=self.SUSPENDED_GROUPS):
+            await suspend_or_start_cluster(
+                apps,
+                mock.Mock(),
+                "ns",
+                "c",
+                self.OLD,
+                _multi_data_scaling_diff([(3, 0), (2, 0)]),
+                False,
+                mock.Mock(),
+            )
+
+        assert order.count("health_check") == 1
+        assert order.index("health_check") < order.index("data_scale:0")
+
+    @pytest.mark.asyncio
+    async def test_health_is_not_rechecked_once_a_group_is_already_down(self):
+        # The retry after the wait for pods: ``hot`` is already at zero, so the
+        # cluster cannot be healthy and the gate must be skipped rather than
+        # deadlock the rest of the suspend.
+        order: list = []
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = _statefulsets_by_replicas(
+            {"crate-data-hot-c": 0, "crate-data-cold-c": 2}
+        )
+
+        with _suspend_resume_patches(order, data_groups=self.SUSPENDED_GROUPS):
+            await suspend_or_start_cluster(
+                apps,
+                mock.Mock(),
+                "ns",
+                "c",
+                self.OLD,
+                _multi_data_scaling_diff([(3, 0), (2, 0)]),
+                False,
+                mock.Mock(),
+            )
+
+        assert "health_check" not in order
+        assert order.count("data_scale:0") == 1
+        assert "data_gone" in order
+
+    @pytest.mark.asyncio
+    async def test_masters_go_down_after_every_data_group(self):
+        order: list = []
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = _statefulsets_by_replicas(
+            {"crate-data-hot-c": 3, "crate-data-cold-c": 2}
+        )
+
+        with _suspend_resume_patches(order, data_groups=self.SUSPENDED_GROUPS):
+            await suspend_or_start_cluster(
+                apps,
+                mock.Mock(),
+                "ns",
+                "c",
+                self.OLD,
+                _multi_data_scaling_diff([(3, 0), (2, 0)]),
+                False,
+                mock.Mock(),
+            )
+
+        last_scale = max(i for i, step in enumerate(order) if step == "data_scale:0")
+        assert last_scale < order.index("master_scale:0")
+        assert order.index("data_gone") < order.index("master_scale:0")
 
 
 class TestScaleBackupMetricsIfPresent:

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -20,9 +20,11 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import asyncio
+import contextlib
 import sys
 from unittest import mock
 
+import kopf
 import pytest
 from kubernetes_asyncio.client import (
     AppsV1Api,
@@ -48,6 +50,7 @@ from crate.operator.scale import (
     parse_replicas,
     patch_command,
     reset_allocation,
+    scale_cluster,
 )
 from crate.operator.utils.kubeapi import get_host
 from crate.operator.webhooks import WebhookEvent, WebhookStatus
@@ -218,6 +221,133 @@ async def test_reset_allocation_noop_when_nodes_not_present(
             ),
         ]
     )
+
+
+class TestScaleDownAllocationReset:
+    """
+    ``deallocate_nodes`` excludes the nodes it is about to remove from shard
+    allocation, and ``reset_allocation`` clears those exclusions once at the end.
+    With several data groups scaling down, the reset has to cover every group -
+    anything left behind stays excluded in the persistent cluster state, so a
+    later scale-up returns those nodes to the cluster holding no shards
+    (crate/cloud#3038).
+    """
+
+    @staticmethod
+    def _old_body(groups):
+        return {
+            "spec": {
+                "cluster": {"version": "5.9.0"},
+                "nodes": {"data": groups},
+            }
+        }
+
+    @staticmethod
+    def _scale_down_diff(pairs):
+        return kopf.Diff(
+            [
+                kopf.DiffItem(
+                    kopf.DiffOperation.CHANGE, (str(index), "replicas"), old, new
+                )
+                for index, (old, new) in enumerate(pairs)
+            ]
+        )
+
+    async def _run(self, names, pairs, mock_cratedb_connection):
+        """
+        Run ``scale_cluster`` over ``names``, each scaling by its ``(old, new)``
+        pair. ``old["spec"]`` carries the *old* replica counts, as it does in
+        production, so the total-node arithmetic the function does on the way is
+        modelled faithfully rather than incidentally.
+        """
+        groups = [
+            {"name": name, "replicas": old} for name, (old, _) in zip(names, pairs)
+        ]
+        replicas_by_sts = {
+            f"crate-data-{name}-c": old for name, (old, _) in zip(names, pairs)
+        }
+
+        async def _read(namespace, name):
+            return mock.Mock(**{"spec.replicas": replicas_by_sts[name]})
+
+        apps = mock.Mock()
+        apps.read_namespaced_stateful_set = mock.AsyncMock(side_effect=_read)
+        M = "crate.operator.scale."
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                mock.patch(M + "get_host", new=mock.AsyncMock(return_value="host"))
+            )
+            stack.enter_context(
+                mock.patch(
+                    M + "get_system_user_password",
+                    new=mock.AsyncMock(return_value="password"),
+                )
+            )
+            stack.enter_context(
+                mock.patch(M + "_ensure_cluster_healthy", new=mock.AsyncMock())
+            )
+            deallocate = stack.enter_context(
+                mock.patch(M + "deallocate_nodes", new=mock.AsyncMock())
+            )
+            reset = stack.enter_context(
+                mock.patch(M + "reset_allocation", new=mock.AsyncMock())
+            )
+            for fn in (
+                "update_statefulset",
+                "scale_cluster_patch_total_nodes",
+                "check_nodes_present_or_gone",
+            ):
+                stack.enter_context(mock.patch(M + fn, new=mock.AsyncMock()))
+
+            await scale_cluster(
+                apps,
+                mock.Mock(),
+                "ns",
+                "c",
+                self._old_body(groups),
+                None,
+                self._scale_down_diff(pairs),
+                mock.Mock(),
+            )
+        return deallocate, reset
+
+    @pytest.mark.asyncio
+    async def test_reset_covers_every_group_that_scaled_down(
+        self, mock_cratedb_connection
+    ):
+        _, reset = await self._run(
+            ["hot", "cold"], [(3, 1), (3, 1)], mock_cratedb_connection
+        )
+
+        reset.assert_awaited_once()
+        assert sorted(reset.await_args.args[1]) == [
+            "data-cold-1",
+            "data-cold-2",
+            "data-hot-1",
+            "data-hot-2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_each_group_is_deallocated_with_only_its_own_nodes(
+        self, mock_cratedb_connection
+    ):
+        # The exclusions accumulate in CrateDB (``deallocate_nodes`` unions them),
+        # so each call still passes just the group it is removing.
+        deallocate, _ = await self._run(
+            ["hot", "cold"], [(3, 1), (3, 1)], mock_cratedb_connection
+        )
+
+        assert [sorted(call.args[2]) for call in deallocate.await_args_list] == [
+            ["data-hot-1", "data-hot-2"],
+            ["data-cold-1", "data-cold-2"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_single_group_is_unchanged(self, mock_cratedb_connection):
+        _, reset = await self._run(["hot"], [(3, 1)], mock_cratedb_connection)
+
+        reset.assert_awaited_once()
+        assert sorted(reset.await_args.args[1]) == ["data-hot-1", "data-hot-2"]
 
 
 @pytest.mark.k8s


### PR DESCRIPTION
## Summary of changes

Four bugs made a cluster with two or more data node groups unusable — three from #3038 plus one this branch initially reintroduced (see the second commit). They go together: the first is what currently stops the others from being reached, so fixing it alone would trade a loud retry loop for silent failures.

**Every update raised `KeyError`.** `update_cratedb()` rebound the loop variable it was iterating, so the second group's lookup indexed a dict with an integer. It threw before any sub-handler was registered, so scale, suspend, resume, disk expansion and compute change were all dead. Now iterates `(old, new)` pairs under their own names.

**Suspend deadlocked.** `check_cluster_healthy()` and `check_all_data_nodes_gone()` were called inside the per-group loop, and both deadlock there: a half-suspended cluster is never GREEN, and waiting for *every* data pod to be gone cannot succeed while the groups behind the current one are still running. The StatefulSets are now collected first so both run once around the whole set, with the health gate skipped once anything is already down — which is also what keeps the retry after the wait from deadlocking in the gate instead. (That signal cannot distinguish a retry from a StatefulSet scaled down out of band; noted in the code.)

**Scale-down leaked allocation exclusions.** `excess_nodes` was overwritten per group, so `reset_allocation()` cleared only the last one. The rest stayed excluded in the persistent cluster state, and a later scale-up returned those nodes to the cluster holding no shards. Now accumulated across groups, while `deallocate_nodes()` still gets only the group it is removing.

**A master scale to zero could be waved through — found in review of the first commit, and caused by it.** Suspend/resume was being decided in two places with different rules: the data dispatch asked whether *every* group crosses zero (matching `scale.classify_data_scaling`), while `_data_nodes_cross_zero` asked whether *any* group does — and that one gates `master.replicas`. On a two-group cluster, `master.replicas: 3 → 0` together with `cold: 2 → 0` passed the guard, then `classify_data_scaling` routed it to `scale_cluster` rather than `suspend_or_start_cluster`, which honoured the master change literally and took **every master down while `hot` was still serving**. Before this branch the `KeyError` aborted the update first, so the first commit is what made it reachable. Replaced with a single `_classify_data_scaling()` returning `(resuming, suspending)`, used by both sites so they cannot drift again.

**Adding or removing a data group is now rejected** instead of silently ignored. `zip` truncates, so adding a group as the only change registered no sub-handler at all and the handler returned early: no error, no resources, and the CRD and the cluster quietly diverged. `ScaleSubHandler` already rejects this but never gets registered from here. Not a regression — it behaved the same before this branch — but it is a silent failure in code this branch is already fixing, and it answers one of the open questions on #3038.

Suspend and resume are now decided from every group rather than per group throughout. Without that, one group of several going to zero counted as a suspend in the dispatch while the scale handler performed an ordinary scale, and the mismatch skipped `after_cluster_update`, leaving `cluster.routing.allocation.enable` pinned to `new_primaries`.

Tests sit next to each module's existing ones — `tests/test_handle_update_cratedb.py` (new), `TestSuspendWithSeveralDataGroups` in `tests/test_operations.py`, `TestScaleDownAllocationReset` in `tests/test_scale.py`. There was no two-data-group fixture anywhere before this. Each is a real regression guard, confirmed by restoring the old behaviour and watching them fail.

No backfill needed — there is no cluster with more than one data node group today, so nothing is carrying leaked exclusions.

### Follow-ups this surfaced, deliberately not in scope

All three need a multi-group cluster to manifest, so none can bite today. The first two change what the webhook consumer receives, so they want agreement from that side rather than a unilateral edit here:

- **`change_compute.py:148`** builds the `COMPUTE_CHANGED` payload from `data[0]`. A compute change on a later group now dispatches correctly (it used to `KeyError`), but the payload carries no delta, so billing sees a compute change that changed nothing. `iter_changed_compute_groups` is the right source; the payload shape needs a group.
- **`webhooks.py` `WebhookAction.for_diff`** still labels a single group crossing zero as `suspend`, so a failed partial scale-down sends a failure notification labelled `suspend`. Same `any`/`all` mismatch, cosmetic.
- **`operation` is overwritten by later groups**, so a diff that scales one group and changes another's compute ends up labelled by whichever comes last in the spec. Picking a precedence is a design call, and it sits with the `if/elif`-chain limitation already listed on #3038.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3038
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary (no doc describes this behaviour)
- [x] Changed code does not contain any breaking changes (or this is a major version change)
