### PR TITLE
Validate data node group names, and count restart progress properly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Unreleased
 
 * Added support for STACKIT Kubernetes Engine via ``CLOUD_PROVIDER=stackit``.
 
+* Added validation of data node group names when creating a cluster.
+
+* Fixed rolling restart progress restarting from 1 for every node group.
+
 2.62.2 (2026-07-22)
 -------------------
 

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -156,8 +156,22 @@ def get_master_nodes_names(nodes: Dict[str, Any]) -> List[str]:
 #: A data node group's name ends up in the StatefulSet name
 #: (``crate-data-<group>-<cluster>``) and in the CrateDB node names
 #: (``data-<group>-<i>``), so it has to be a valid Kubernetes name fragment:
-#: lowercase alphanumeric and dashes, starting and ending alphanumeric.
-DATA_NODE_GROUP_NAME = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+#: lowercase alphanumeric and dashes, starting and ending alphanumeric. Matched
+#: with ``fullmatch`` -- with ``match``, ``$`` would also accept a trailing
+#: newline, which is not a valid Kubernetes name.
+DATA_NODE_GROUP_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
+
+#: The name also becomes the ``node-name`` label value verbatim, and Kubernetes
+#: caps label values at 63 characters. This does not bound the *composite*
+#: StatefulSet name, which also carries the cluster name -- that needs the
+#: cluster name, which this validation does not get (crate/cloud#3039).
+DATA_NODE_GROUP_NAME_MAX_LENGTH = 63
+
+#: ``master`` is reserved for the dedicated master group, which is created with
+#: ``node_name="master"``. A data group of that name would get the same
+#: ``node-name`` label, so its StatefulSet selector would be identical to the
+#: master StatefulSet's and the two would fight over each other's pods.
+RESERVED_NODE_GROUP_NAMES = frozenset({"master"})
 
 
 def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
@@ -172,14 +186,20 @@ def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
     are configured their replica count must be odd and at least three, so the
     masters can always form a quorum.
 
-    Data node group names must be valid Kubernetes name fragments and unique
-    within the cluster. The CRD schema is looser than Kubernetes itself on both
-    counts, and neither shape can start (crate/cloud#3039): a name with an
-    underscore or a capital produces a StatefulSet the API server rejects with an
-    opaque 422, and two groups sharing a name produce the *same* StatefulSet
-    name, where the second create is a 409 that ``call_kubeapi`` swallows -- so
-    one group silently gets no StatefulSet while its replicas still count towards
-    ``gateway.expected_data_nodes``, and the cluster never forms.
+    Data node group names must be valid Kubernetes name fragments, not clash with
+    the reserved ``master`` group, and be unique within the cluster. The CRD
+    schema is looser than Kubernetes itself, and none of the shapes it lets
+    through can start (crate/cloud#3039):
+
+    - a name with an underscore or a capital, or one over 63 characters,
+      produces a StatefulSet the API server rejects with an opaque 422;
+    - two groups sharing a name produce the *same* StatefulSet name, where the
+      second create is a 409 that ``call_kubeapi`` swallows -- so one group
+      silently gets no StatefulSet while its replicas still count towards
+      ``gateway.expected_data_nodes``, and the cluster never forms;
+    - a group named ``master`` gets the same ``node-name`` label as the
+      dedicated master group, so the two StatefulSets end up with identical
+      selectors and fight over each other's pods.
 
     :param nodes: The ``spec.nodes`` from a CrateDB custom resource.
     :param logger: Logger used to record why the spec was rejected.
@@ -196,7 +216,9 @@ def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
     invalid = [
         name
         for name in names
-        if not isinstance(name, str) or not DATA_NODE_GROUP_NAME.match(name)
+        if not isinstance(name, str)
+        or not DATA_NODE_GROUP_NAME.fullmatch(name)
+        or len(name) > DATA_NODE_GROUP_NAME_MAX_LENGTH
     ]
     if invalid:
         logger.error(
@@ -205,7 +227,19 @@ def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
         raise kopf.PermanentError(
             "Data node group names (spec.nodes.data[].name) must be lowercase "
             "alphanumeric or '-', starting and ending with an alphanumeric "
-            f"character. Invalid: {', '.join(repr(name) for name in invalid)}."
+            f"character, and at most {DATA_NODE_GROUP_NAME_MAX_LENGTH} characters. "
+            f"Invalid: {', '.join(repr(name) for name in invalid)}."
+        )
+
+    reserved = sorted(set(names) & RESERVED_NODE_GROUP_NAMES)
+    if reserved:
+        logger.error(
+            "CrateDB spec rejected: reserved data node group names %s.", reserved
+        )
+        raise kopf.PermanentError(
+            "Data node group names (spec.nodes.data[].name) must not use the "
+            "reserved name of the dedicated master group, which would give both "
+            f"StatefulSets the same selector. Reserved: {', '.join(reserved)}."
         )
 
     duplicates = sorted({name for name in names if names.count(name) > 1})
@@ -809,9 +843,12 @@ async def restart_cluster(
     # restart at 0 in every StatefulSet, so a masters + data restart reported
     # 1/6, 2/6, 3/6, 1/6, ... (crate/cloud#3039). The total is what *this* run set
     # out to restart, which for a compute change is only the changed groups. A
-    # restart already running when this field was introduced has none recorded,
-    # hence the floor.
-    total_pods = max(total_pods, len(pending_pods))
+    # restart already in flight when this field was introduced has none recorded,
+    # so seed it from what is left and persist it - re-deriving it every pass
+    # would track the shrinking queue and report 1/5, 1/4, 1/3, ...
+    if not total_pods:
+        total_pods = len(pending_pods)
+        patch.status["pendingPodsTotal"] = total_pods
     node_progress = f"{total_pods - len(pending_pods) + 1}/{total_pods}"
 
     all_pod_uids, all_pod_names = await get_pods_in_cluster(core, namespace, name)

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -153,24 +153,16 @@ def get_master_nodes_names(nodes: Dict[str, Any]) -> List[str]:
         return [f"data-{node_name}-{i}" for i in range(node["replicas"])]
 
 
-#: A data node group's name ends up in the StatefulSet name
-#: (``crate-data-<group>-<cluster>``) and in the CrateDB node names
-#: (``data-<group>-<i>``), so it has to be a valid Kubernetes name fragment:
-#: lowercase alphanumeric and dashes, starting and ending alphanumeric. Matched
-#: with ``fullmatch`` -- with ``match``, ``$`` would also accept a trailing
-#: newline, which is not a valid Kubernetes name.
+#: Valid Kubernetes name fragment; ``fullmatch`` so a trailing newline is
+#: rejected. The name ends up in the StatefulSet name and CrateDB node names.
 DATA_NODE_GROUP_NAME = re.compile(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 
-#: The name also becomes the ``node-name`` label value verbatim, and Kubernetes
-#: caps label values at 63 characters. This does not bound the *composite*
-#: StatefulSet name, which also carries the cluster name -- that needs the
-#: cluster name, which this validation does not get (crate/cloud#3039).
+#: The name is the ``node-name`` label value verbatim; Kubernetes caps those
+#: at 63. Does not bound the composite StatefulSet name (crate/cloud#3039).
 DATA_NODE_GROUP_NAME_MAX_LENGTH = 63
 
-#: ``master`` is reserved for the dedicated master group, which is created with
-#: ``node_name="master"``. A data group of that name would get the same
-#: ``node-name`` label, so its StatefulSet selector would be identical to the
-#: master StatefulSet's and the two would fight over each other's pods.
+#: ``master`` is the dedicated master group's node name; a data group of that
+#: name would share its selector and the two would fight over each other's pods.
 RESERVED_NODE_GROUP_NAMES = frozenset({"master"})
 
 
@@ -186,20 +178,10 @@ def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
     are configured their replica count must be odd and at least three, so the
     masters can always form a quorum.
 
-    Data node group names must be valid Kubernetes name fragments, not clash with
-    the reserved ``master`` group, and be unique within the cluster. The CRD
-    schema is looser than Kubernetes itself, and none of the shapes it lets
-    through can start (crate/cloud#3039):
-
-    - a name with an underscore or a capital, or one over 63 characters,
-      produces a StatefulSet the API server rejects with an opaque 422;
-    - two groups sharing a name produce the *same* StatefulSet name, where the
-      second create is a 409 that ``call_kubeapi`` swallows -- so one group
-      silently gets no StatefulSet while its replicas still count towards
-      ``gateway.expected_data_nodes``, and the cluster never forms;
-    - a group named ``master`` gets the same ``node-name`` label as the
-      dedicated master group, so the two StatefulSets end up with identical
-      selectors and fight over each other's pods.
+    Data node group names must be valid Kubernetes name fragments, not clash
+    with the reserved ``master`` group, and be unique within the cluster. The
+    CRD schema is looser than Kubernetes on all three, and none of the shapes it
+    lets through can start (crate/cloud#3039).
 
     :param nodes: The ``spec.nodes`` from a CrateDB custom resource.
     :param logger: Logger used to record why the spec was rejected.
@@ -242,6 +224,10 @@ def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
             f"StatefulSets the same selector. Reserved: {', '.join(reserved)}."
         )
 
+    # Two groups of the same name means one StatefulSet name, and the second
+    # create is a 409 that ``call_kubeapi`` swallows -- so a group silently ends
+    # up with no StatefulSet while its replicas still count towards
+    # ``gateway.expected_data_nodes``, and the cluster never forms.
     duplicates = sorted({name for name in names if names.count(name) > 1})
     if duplicates:
         logger.error(
@@ -839,13 +825,10 @@ async def restart_cluster(
     next_pod_uid = pending_pods[0]["uid"]
     next_pod_name = pending_pods[0]["name"]
 
-    # Progress is counted off the pods still to do, not the pod's ordinal: those
-    # restart at 0 in every StatefulSet, so a masters + data restart reported
-    # 1/6, 2/6, 3/6, 1/6, ... (crate/cloud#3039). The total is what *this* run set
-    # out to restart, which for a compute change is only the changed groups. A
-    # restart already in flight when this field was introduced has none recorded,
-    # so seed it from what is left and persist it - re-deriving it every pass
-    # would track the shrinking queue and report 1/5, 1/4, 1/3, ...
+    # Count off the pods still to do, not the pod's ordinal (which restarts at 0
+    # per StatefulSet). Seed and persist a total for a restart already in flight
+    # when this field shipped; re-deriving it would track the shrinking queue.
+    # (crate/cloud#3039)
     if not total_pods:
         total_pods = len(pending_pods)
         patch.status["pendingPodsTotal"] = total_pods

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -23,6 +23,7 @@ import asyncio
 import datetime
 import logging
 import pkgutil
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -152,6 +153,13 @@ def get_master_nodes_names(nodes: Dict[str, Any]) -> List[str]:
         return [f"data-{node_name}-{i}" for i in range(node["replicas"])]
 
 
+#: A data node group's name ends up in the StatefulSet name
+#: (``crate-data-<group>-<cluster>``) and in the CrateDB node names
+#: (``data-<group>-<i>``), so it has to be a valid Kubernetes name fragment:
+#: lowercase alphanumeric and dashes, starting and ending alphanumeric.
+DATA_NODE_GROUP_NAME = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+
+
 def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
     """
     Validate the ``spec.nodes`` of a CrateDB resource, raising a
@@ -164,6 +172,15 @@ def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
     are configured their replica count must be odd and at least three, so the
     masters can always form a quorum.
 
+    Data node group names must be valid Kubernetes name fragments and unique
+    within the cluster. The CRD schema is looser than Kubernetes itself on both
+    counts, and neither shape can start (crate/cloud#3039): a name with an
+    underscore or a capital produces a StatefulSet the API server rejects with an
+    opaque 422, and two groups sharing a name produce the *same* StatefulSet
+    name, where the second create is a 409 that ``call_kubeapi`` swallows -- so
+    one group silently gets no StatefulSet while its replicas still count towards
+    ``gateway.expected_data_nodes``, and the cluster never forms.
+
     :param nodes: The ``spec.nodes`` from a CrateDB custom resource.
     :param logger: Logger used to record why the spec was rejected.
     """
@@ -172,6 +189,34 @@ def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
         raise kopf.PermanentError(
             "A CrateDB cluster must define at least one data node group "
             "(spec.nodes.data)."
+        )
+
+    names = [group.get("name") for group in nodes["data"]]
+
+    invalid = [
+        name
+        for name in names
+        if not isinstance(name, str) or not DATA_NODE_GROUP_NAME.match(name)
+    ]
+    if invalid:
+        logger.error(
+            "CrateDB spec rejected: invalid data node group names %s.", invalid
+        )
+        raise kopf.PermanentError(
+            "Data node group names (spec.nodes.data[].name) must be lowercase "
+            "alphanumeric or '-', starting and ending with an alphanumeric "
+            f"character. Invalid: {', '.join(repr(name) for name in invalid)}."
+        )
+
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        logger.error(
+            "CrateDB spec rejected: duplicate data node group names %s.", duplicates
+        )
+        raise kopf.PermanentError(
+            "Data node group names (spec.nodes.data[].name) must be unique, "
+            f"because each one names a StatefulSet. Duplicated: "
+            f"{', '.join(duplicates)}."
         )
 
     if "master" in nodes:
@@ -741,27 +786,38 @@ async def restart_cluster(
         changed (and therefore need restarting) for a compute change.
     """
     pending_pods: List[Dict[str, str]] = status.get("pendingPods") or []
+    total_pods: int = status.get("pendingPodsTotal") or 0
     if not pending_pods:
         for group in _node_groups_to_restart(old, body, action):
             pending_pods.extend(
                 await get_pods_in_statefulset(core, namespace, name, group.name)
             )
+        total_pods = len(pending_pods)
         patch.status["pendingPods"] = pending_pods
+        patch.status["pendingPodsTotal"] = total_pods
 
     if not pending_pods:
         # We're all done
         patch.status["pendingPods"] = None  # Remove attribute from status stanza
+        patch.status["pendingPodsTotal"] = None
         return
 
     next_pod_uid = pending_pods[0]["uid"]
     next_pod_name = pending_pods[0]["name"]
 
+    # Progress is counted off the pods still to do, not the pod's ordinal: those
+    # restart at 0 in every StatefulSet, so a masters + data restart reported
+    # 1/6, 2/6, 3/6, 1/6, ... (crate/cloud#3039). The total is what *this* run set
+    # out to restart, which for a compute change is only the changed groups. A
+    # restart already running when this field was introduced has none recorded,
+    # hence the floor.
+    total_pods = max(total_pods, len(pending_pods))
+    node_progress = f"{total_pods - len(pending_pods) + 1}/{total_pods}"
+
     all_pod_uids, all_pod_names = await get_pods_in_cluster(core, namespace, name)
     if next_pod_uid in all_pod_uids:
         # The next to-be-terminated pod still appears to be running.
         logger.info("Terminating pod '%s'", next_pod_name)
-        node_index = int(next_pod_name[next_pod_name.rindex("-") + 1 :])
-        node_progress = f"{node_index + 1}/{len(all_pod_uids)}"
         await send_operation_progress_notification(
             namespace=namespace,
             name=name,
@@ -798,8 +854,6 @@ async def restart_cluster(
     elif next_pod_name in all_pod_names:
         total_nodes = get_total_nodes_count(old["spec"]["nodes"], "all")
         # The new pod has been spawned. Only a matter of time until it's ready.
-        node_index = int(next_pod_name[next_pod_name.rindex("-") + 1 :])
-        node_progress = f"{node_index + 1}/{len(all_pod_uids)}"
         await send_operation_progress_notification(
             namespace=namespace,
             name=name,
@@ -826,6 +880,7 @@ async def restart_cluster(
             else:
                 # We're all done
                 patch.status["pendingPods"] = None  # Remove attribute from `.status`
+                patch.status["pendingPodsTotal"] = None
                 return
         else:
             try:

--- a/crate/operator/rollback.py
+++ b/crate/operator/rollback.py
@@ -112,6 +112,9 @@ class FinalRollbackSubHandler(StateBasedSubHandler):
                 if "pendingPods" in status:
                     logger.info("Clearing pendingPods from status.")
                     patch.status["pendingPods"] = None
+                    # Cleared together with the queue it counts, so the two
+                    # never outlive each other in the status stanza.
+                    patch.status["pendingPodsTotal"] = None
             except Exception as e:
                 logger.warning(f"Failed to clear pendingPods during rollback: {e}")
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -302,6 +302,37 @@ class TestValidateDataNodeGroupNames:
         with pytest.raises(kopf.PermanentError, match="must be lowercase"):
             validate_node_spec({"data": [{"replicas": 1}]}, mock.Mock())
 
+    def test_rejects_trailing_newline(self):
+        # ``$`` also matches before a final newline, so this needs ``fullmatch``.
+        with pytest.raises(kopf.PermanentError, match="must be lowercase"):
+            validate_node_spec(self._nodes("hot\n"), mock.Mock())
+
+    def test_rejects_names_over_the_label_value_limit(self):
+        # The name is the ``node-name`` label value verbatim, capped at 63 by
+        # Kubernetes.
+        validate_node_spec(self._nodes("a" * 63), mock.Mock())
+        with pytest.raises(kopf.PermanentError, match="at most 63"):
+            validate_node_spec(self._nodes("a" * 64), mock.Mock())
+
+    def test_rejects_a_group_named_master(self):
+        # ``master`` is the dedicated master group's node-name label, so a data
+        # group of that name gives both StatefulSets the same selector and they
+        # fight over each other's pods.
+        with pytest.raises(kopf.PermanentError, match="reserved name"):
+            validate_node_spec(
+                {
+                    "master": {"replicas": 3},
+                    "data": [{"name": "master", "replicas": 1}],
+                },
+                mock.Mock(),
+            )
+
+    def test_rejects_a_group_named_master_without_dedicated_masters(self):
+        # Rejected regardless: the cluster may gain dedicated masters later, and
+        # the name is reserved either way.
+        with pytest.raises(kopf.PermanentError, match="reserved name"):
+            validate_node_spec(self._nodes("master"), mock.Mock())
+
     def test_name_validity_is_reported_before_uniqueness(self):
         # Two invalid *and* duplicated names: the format message is the more
         # actionable one, and it also keeps the duplicate report free of None.

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -263,6 +263,52 @@ class TestValidateNodeSpec:
             )
 
 
+class TestValidateDataNodeGroupNames:
+    """
+    The CRD schema is looser than Kubernetes on both name validity and
+    uniqueness, and neither shape it lets through can actually start
+    (crate/cloud#3039).
+    """
+
+    @staticmethod
+    def _nodes(*names):
+        return {"data": [{"name": name, "replicas": 1} for name in names]}
+
+    def test_accepts_several_distinct_groups(self):
+        validate_node_spec(self._nodes("hot", "warm", "cold-2"), mock.Mock())
+
+    def test_rejects_duplicate_names(self):
+        # Both groups would name the same StatefulSet; the second create is a 409
+        # that call_kubeapi swallows, so one group silently gets none.
+        with pytest.raises(kopf.PermanentError, match="must be unique"):
+            validate_node_spec(self._nodes("hot", "hot"), mock.Mock())
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Hot",  # uppercase: rejected by the API server
+            "hot_tier",  # underscore: not valid in a Kubernetes name
+            "",  # empty: yields "crate-data--<cluster>"
+            "-hot",  # must start alphanumeric
+            "hot-",  # must end alphanumeric
+            "hot.tier",  # dot: breaks the pod hostname
+        ],
+    )
+    def test_rejects_names_kubernetes_would_not_accept(self, name):
+        with pytest.raises(kopf.PermanentError, match="must be lowercase"):
+            validate_node_spec(self._nodes(name), mock.Mock())
+
+    def test_rejects_missing_name(self):
+        with pytest.raises(kopf.PermanentError, match="must be lowercase"):
+            validate_node_spec({"data": [{"replicas": 1}]}, mock.Mock())
+
+    def test_name_validity_is_reported_before_uniqueness(self):
+        # Two invalid *and* duplicated names: the format message is the more
+        # actionable one, and it also keeps the duplicate report free of None.
+        with pytest.raises(kopf.PermanentError, match="must be lowercase"):
+            validate_node_spec(self._nodes("Hot", "Hot"), mock.Mock())
+
+
 def _suspend_resume_patches(order, master_replicas=3, data_groups=None):
     """
     Patch every collaborator ``suspend_or_start_cluster`` calls so the function

--- a/tests/test_restart_cluster.py
+++ b/tests/test_restart_cluster.py
@@ -180,3 +180,126 @@ def test_upgrade_restarts_all_groups_regardless_of_change():
     # An upgrade must roll every node (new image), even with no resource change.
     groups = _node_groups_to_restart(_spec(), _spec(), WebhookAction.UPGRADE)
     assert [g.name for g in groups] == ["master", "hot"]
+
+
+def _progress_messages(mock_send_notification):
+    """The ``N/M`` fragments of the progress notifications, in order."""
+    return [
+        call.kwargs["message"].split("node ", 1)[1].split(" ", 1)[0]
+        for call in mock_send_notification.await_args_list
+    ]
+
+
+@pytest.mark.asyncio
+@patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
+@patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_cluster", new_callable=AsyncMock)
+@patch(
+    "crate.operator.operations.send_operation_progress_notification",
+    new_callable=AsyncMock,
+)
+async def test_restart_progress_counts_across_node_groups(
+    mock_send_notification,
+    mock_get_pods_in_cluster,
+    mock_get_pods_in_statefulset,
+    _mock_set_cluster_setting,
+    _mock_get_connection_factory,
+):
+    # Pod ordinals restart at 0 in every StatefulSet, so a masters + data restart
+    # used to report 1/6, 2/6, 3/6, 1/6, 2/6, 3/6 (crate/cloud#3039). Progress
+    # must instead count off the pods still to do.
+    masters = [{"uid": f"m{i}", "name": f"crate-master-c-{i}"} for i in range(3)]
+    hot = [{"uid": f"h{i}", "name": f"crate-data-hot-c-{i}"} for i in range(3)]
+    mock_get_pods_in_statefulset.side_effect = [masters, hot]
+
+    all_pods = masters + hot
+    mock_get_pods_in_cluster.return_value = (
+        [p["uid"] for p in all_pods],
+        [p["name"] for p in all_pods],
+    )
+
+    core = MagicMock()
+    core.delete_namespaced_pod = AsyncMock()
+    patch_obj = kopf.Patch()
+    status: dict[str, Any] = {}
+    old = _spec()
+
+    reported = []
+    for _ in range(len(all_pods)):
+        # Every pass terminates the pod at the head of the queue and reruns.
+        with pytest.raises(kopf.TemporaryError, match="Waiting for pod"):
+            await restart_cluster(
+                core=core,
+                namespace="ns",
+                name="c",
+                old=old,
+                body=old,
+                logger=MagicMock(),
+                patch=patch_obj,
+                status=status,
+                action=WebhookAction.UPGRADE,
+            )
+        reported.extend(_progress_messages(mock_send_notification))
+        mock_send_notification.reset_mock()
+        # The handler only builds the queue on the first pass, so pick it up from
+        # the patch once and then keep it here, dropping the pod just terminated.
+        if "pendingPods" not in status:
+            status["pendingPods"] = patch_obj.status["pendingPods"]
+            status["pendingPodsTotal"] = patch_obj.status["pendingPodsTotal"]
+        status["pendingPods"] = status["pendingPods"][1:]
+
+    assert reported == ["1/6", "2/6", "3/6", "4/6", "5/6", "6/6"]
+
+
+@pytest.mark.asyncio
+@patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
+@patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_cluster", new_callable=AsyncMock)
+@patch(
+    "crate.operator.operations.send_operation_progress_notification",
+    new_callable=AsyncMock,
+)
+async def test_restart_progress_total_is_the_pods_this_run_restarts(
+    mock_send_notification,
+    mock_get_pods_in_cluster,
+    mock_get_pods_in_statefulset,
+    _mock_set_cluster_setting,
+    _mock_get_connection_factory,
+):
+    # A compute change restarts only the changed groups, so the denominator is
+    # that group's pods -- not every pod in the cluster.
+    hot = [{"uid": f"h{i}", "name": f"crate-data-hot-c-{i}"} for i in range(2)]
+    mock_get_pods_in_statefulset.side_effect = [hot]
+    mock_get_pods_in_cluster.return_value = (
+        ["m0", "m1", "m2", "h0", "h1"],
+        [
+            "crate-master-c-0",
+            "crate-master-c-1",
+            "crate-master-c-2",
+            "crate-data-hot-c-0",
+            "crate-data-hot-c-1",
+        ],
+    )
+
+    core = MagicMock()
+    core.delete_namespaced_pod = AsyncMock()
+    patch_obj = kopf.Patch()
+    old = _spec(hot_cpu=2)
+    new = _spec(hot_cpu=4)
+
+    with pytest.raises(kopf.TemporaryError, match="Waiting for pod"):
+        await restart_cluster(
+            core=core,
+            namespace="ns",
+            name="c",
+            old=old,
+            body=new,
+            logger=MagicMock(),
+            patch=patch_obj,
+            status={},
+            action=WebhookAction.CHANGE_COMPUTE,
+        )
+
+    assert _progress_messages(mock_send_notification) == ["1/2"]

--- a/tests/test_restart_cluster.py
+++ b/tests/test_restart_cluster.py
@@ -303,3 +303,61 @@ async def test_restart_progress_total_is_the_pods_this_run_restarts(
         )
 
     assert _progress_messages(mock_send_notification) == ["1/2"]
+
+
+@pytest.mark.asyncio
+@patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
+@patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_cluster", new_callable=AsyncMock)
+@patch(
+    "crate.operator.operations.send_operation_progress_notification",
+    new_callable=AsyncMock,
+)
+async def test_restart_progress_seeds_a_total_for_a_restart_already_in_flight(
+    mock_send_notification,
+    mock_get_pods_in_cluster,
+    mock_get_pods_in_statefulset,
+    _mock_set_cluster_setting,
+    _mock_get_connection_factory,
+):
+    # A restart that was already running when pendingPodsTotal was introduced has
+    # a queue but no total. Seeding it from what is left and persisting it keeps
+    # the numerator moving; re-deriving it each pass would track the shrinking
+    # queue and report 1/3, 1/2, 1/1.
+    hot = [{"uid": f"h{i}", "name": f"crate-data-hot-c-{i}"} for i in range(3)]
+    mock_get_pods_in_cluster.return_value = (
+        [p["uid"] for p in hot],
+        [p["name"] for p in hot],
+    )
+
+    core = MagicMock()
+    core.delete_namespaced_pod = AsyncMock()
+    old = _spec()
+    # Mid-restart status as an older operator version left it.
+    status: dict[str, Any] = {"pendingPods": list(hot)}
+    patch_obj = kopf.Patch()
+
+    reported = []
+    for _ in range(len(hot)):
+        with pytest.raises(kopf.TemporaryError, match="Waiting for pod"):
+            await restart_cluster(
+                core=core,
+                namespace="ns",
+                name="c",
+                old=old,
+                body=old,
+                logger=MagicMock(),
+                patch=patch_obj,
+                status=status,
+                action=WebhookAction.UPGRADE,
+            )
+        reported.extend(_progress_messages(mock_send_notification))
+        mock_send_notification.reset_mock()
+        # The seeded total is persisted, so it carries into the next pass.
+        status["pendingPodsTotal"] = patch_obj.status["pendingPodsTotal"]
+        status["pendingPods"] = status["pendingPods"][1:]
+
+    assert reported == ["1/3", "2/3", "3/3"]
+    # The queue was never rebuilt, so no StatefulSet lookup was needed.
+    mock_get_pods_in_statefulset.assert_not_awaited()


### PR DESCRIPTION
## Summary of changes

Two unrelated node-group bugs, both cheap, from the same review as #3037.

**Data node group names are now validated.** `validate_node_spec()` rejects names Kubernetes will not accept, the reserved `master` name, and names that repeat within a cluster. The CRD schema is looser than Kubernetes on all of these, and none of the shapes it lets through can actually start:

- an underscore, a capital, a trailing newline, or more than 63 characters produces a StatefulSet the API server rejects with an opaque 422;
- two groups sharing a name produce the **same** StatefulSet name, where the second create is a 409 that `call_kubeapi` swallows — so one group silently gets no StatefulSet while its replicas still count towards `gateway.expected_data_nodes`, and the cluster never forms;
- a group named `master` gets the same `node-name` label as the dedicated master group, so the two StatefulSets end up with **identical selectors** and fight over each other's pods — and it collapses the `{name: group}` dict in `iter_changed_compute_groups`, so a master-only compute change is diffed against the wrong spec.

The 63-character bound covers the `node-name` label value, which is the name verbatim. It does not bound the composite StatefulSet name, which also carries the cluster name — `validate_node_spec()` does not receive that, so it stays unbounded as before.

**Rolling restart progress counts properly.** It reported the pod's ordinal as a cluster-wide index, but ordinals restart at 0 in every StatefulSet, so restarting a cluster with dedicated masters sent `1/6, 2/6, 3/6, 1/6, 2/6, 3/6` to the webhook consumer. It now counts off the pods still to do, against what *this* run set out to restart — which for a compute change is only the changed groups, not every pod in the cluster.

That needed the run's initial pod count in a new `status.pendingPodsTotal`, alongside the existing `pendingPods`. A restart already in flight when this ships has no total recorded, so it is seeded from the remaining queue and **persisted** — re-deriving it each pass would track the shrinking queue and report `1/5, 1/4, 1/3`, with the numerator stuck and the denominator going backwards. It is cleared with `pendingPods` on both completion paths and in `rollback.py`, so the two never outlive each other.

### The CRD schema is deliberately left alone

The issue proposed tightening the `name` pattern and adding `uniqueItems`. I did neither:

- **Tightening the pattern** would also validate every future write to CrateDB resources that *already exist*, so a cluster carrying a name the new pattern rejects could no longer be updated at all. Whether such a cluster exists is still the open question on #3039, and the blast radius is much larger than the check added here.
- **`uniqueItems` would not help.** It compares whole items, so two groups named the same but differing in `replicas` are distinct values and stay allowed.

`validate_node_spec()` runs on create only (`handle_create_cratedb.py`), so this closes the hole for new clusters and cannot affect a running one. For the same reason it is not called from the update handler: that would block every subsequent update to a cluster whose name is already bad. The CRD question stays open on the issue.

Not covered by a test: the one-line `pendingPodsTotal` clear in `rollback.py`. No existing test exercises that path and standing up the rollback machinery for a status-hygiene line looked disproportionate — say the word and I will add it.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3039
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary (no doc describes CRD field constraints)
- [x] Changed code does not contain any breaking changes (or this is a major version change)
