### PR TITLE
Use primaries rather than new_primaries while nodes are down

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Unreleased
 
 * Fixed stale shard allocation exclusions after scaling down several data node groups.
 
+* Changed ``cluster.routing.allocation.enable`` during restarts to ``primaries``.
+
 2.62.2 (2026-07-22)
 -------------------
 

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -165,6 +165,11 @@ DATA_NODE_GROUP_NAME_MAX_LENGTH = 63
 #: name would share its selector and the two would fight over each other's pods.
 RESERVED_NODE_GROUP_NAMES = frozenset({"master"})
 
+#: Held while nodes are down so replicas are not re-allocated; not
+#: ``new_primaries``, which also blocks a returning node's own primaries from
+#: recovering (crate/crate-operator#863). dc_util writes this too, and wins.
+ROUTING_ALLOCATION_DURING_RESTART = "primaries"
+
 
 def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
     """
@@ -854,12 +859,13 @@ async def restart_cluster(
                 conn_factory,
                 logger,
                 setting="cluster.routing.allocation.enable",
-                value="new_primaries",
+                value=ROUTING_ALLOCATION_DURING_RESTART,
                 mode="PERSISTENT",
             )
         except Exception as e:
             logger.info(
-                "Setting cluster allocation to 'new_primaries' failed: %s",
+                "Setting cluster allocation to '%s' failed: %s",
+                ROUTING_ALLOCATION_DURING_RESTART,
                 str(e),
             )
 
@@ -1596,7 +1602,7 @@ class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
                 conn_factory,
                 logger,
                 setting="cluster.routing.allocation.enable",
-                value="new_primaries",
+                value=ROUTING_ALLOCATION_DURING_RESTART,
                 mode="PERSISTENT",
             )
 

--- a/tests/test_change_compute.py
+++ b/tests/test_change_compute.py
@@ -180,7 +180,7 @@ async def test_change_compute_from_request_to_limit(
         True,
         cluster_routing_allocation_enable_equals,
         connection_factory(*require_connection(host, password)),
-        "new_primaries",
+        "primaries",
         err_msg="Cluster routing allocation setting has not been updated",
         timeout=DEFAULT_TIMEOUT * 5,
     )

--- a/tests/test_handle_update_cratedb.py
+++ b/tests/test_handle_update_cratedb.py
@@ -145,7 +145,7 @@ class TestSuspendResumeIsClusterWide:
     decides the same way (``scale.classify_data_scaling``); if this dispatch
     disagreed it would skip ``after_cluster_update`` on what is then carried out
     as an ordinary scale, leaving ``cluster.routing.allocation.enable`` pinned to
-    ``new_primaries``.
+    ``primaries``.
     """
 
     @pytest.mark.asyncio

--- a/tests/test_restart_cluster.py
+++ b/tests/test_restart_cluster.py
@@ -79,7 +79,7 @@ async def test_restart_cluster_calls_set_cluster_setting(
         }
     }
 
-    # simulate a first restart (new_primaries)
+    # simulate a first restart (primaries)
     with pytest.raises(kopf.TemporaryError, match="Waiting for pod"):
         await restart_cluster(
             core=core,
@@ -113,7 +113,7 @@ async def test_restart_cluster_calls_set_cluster_setting(
         mock_get_connection_factory.return_value,
         logger,
         setting="cluster.routing.allocation.enable",
-        value="new_primaries",
+        value="primaries",
         mode="PERSISTENT",
     )
     mock_reset_cluster_setting.assert_awaited_once_with(

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -126,7 +126,7 @@ async def test_upgrade_cluster(
         True,
         cluster_routing_allocation_enable_equals,
         connection_factory(*require_connection(host, password)),
-        "new_primaries",
+        "primaries",
         err_msg="Cluster routing allocation setting has not been updated",
         timeout=DEFAULT_TIMEOUT * 5,
     )
@@ -390,7 +390,7 @@ async def test_upgrade_rollback_on_failure(
         True,
         cluster_routing_allocation_enable_equals,
         connection_factory(*require_connection(host, password)),
-        "new_primaries",
+        "primaries",
         err_msg="Cluster routing allocation setting has not been updated",
         timeout=DEFAULT_TIMEOUT * 5,
     )

--- a/utils/dc_util/CHANGES.md
+++ b/utils/dc_util/CHANGES.md
@@ -67,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Default PreStop Routing Allocation**: `new_primaries` -> `primaries`
+  - `new_primaries` also blocks a returning node from recovering its own primaries from disk, so
+    the cluster stays yellow until the PostStart reset lands
+  - Matches the CrateDB rolling-upgrade recommendation (crate/crate#19751)
+  - `new_primaries` remains a valid `dc-util-pre-stop-routing-allocation` value
+
 - **Routing Allocation Logic**: Enhanced PreStop process with PostStart hook detection
   - Routing allocation changes now only occur when corresponding PostStart hook exists
   - Prevents permanent cluster misconfiguration in deployments without PostStart hooks

--- a/utils/dc_util/README.md
+++ b/utils/dc_util/README.md
@@ -212,7 +212,7 @@ As already mentioned `terminationGracePeriodSeconds` MUST be set larger then `--
 - **`dc-util-graceful-stop`**: Controls graceful stop force setting (values: `true`, `false`, default: `true`)
 - **`dc-util-disabled`**: Disables dc_util decommissioning entirely (values: `true`, `false`, default: `false`)
 - **`dc-util-no-poststart`**: Disables PostStart reset-routing behavior (values: `true`, `false`, default: `false`)
-- **`dc-util-pre-stop-routing-allocation`**: Sets routing allocation value during preStop (values: `new_primaries`, `all`, default: `new_primaries`)
+- **`dc-util-pre-stop-routing-allocation`**: Sets routing allocation value during preStop (values: `primaries`, `new_primaries`, `all`, default: `primaries`)
 
 ## Example StatefulSet with labels:
 
@@ -226,7 +226,7 @@ metadata:
     dc-util-graceful-stop: "false"
     dc-util-disabled: "false"
     dc-util-no-poststart: "false"
-    dc-util-pre-stop-routing-allocation: "new_primaries"
+    dc-util-pre-stop-routing-allocation: "primaries"
 spec:
   # ... rest of StatefulSet spec
 ```
@@ -380,7 +380,7 @@ For production deployments, consider embedding dc_util in your container image t
 **preStop Process (Enhanced)**:
 
 1. **Checks for postStart hook** with dc_util reset-routing capability
-2. Sets routing allocation to restricted value (`new_primaries` by default) **only if postStart hook exists**
+2. Sets routing allocation to restricted value (`primaries` by default) **only if postStart hook exists**
 3. Creates lock file (configurable via `--lock-file`)
 4. Continues with normal decommission process
 

--- a/utils/dc_util/dc_util.go
+++ b/utils/dc_util/dc_util.go
@@ -46,8 +46,10 @@ const (
 	// Default log file path
 	defaultLogFile = "/resource/heapdump/dc_util.log"
 
-	// Default routing allocation value for preStop
-	defaultPreStopRoutingAllocation = "new_primaries"
+	// Default routing allocation value for preStop. Not "new_primaries", which
+	// also blocks a returning node's own primaries from recovering
+	// (crate/crate-operator#863).
+	defaultPreStopRoutingAllocation = "primaries"
 
 	// PostStart readiness timeout (10 minutes)
 	postStartTimeout = 10 * time.Minute
@@ -221,7 +223,9 @@ func getNoPostStartFromLabels(labels map[string]string) bool {
 func getPreStopRoutingAllocationFromLabels(labels map[string]string) string {
 	if value, exists := labels[labelPreStopRoutingAllocation]; exists {
 		switch value {
-		case "new_primaries", "all":
+		// "new_primaries" stays accepted so existing labels keep their meaning
+		// now that it is no longer the default (crate/crate-operator#863).
+		case "primaries", "new_primaries", "all":
 			log.Printf("Using pre-stop routing allocation from StatefulSet label: %s", value)
 			return value
 		default:

--- a/utils/dc_util/decommission_test.go
+++ b/utils/dc_util/decommission_test.go
@@ -946,10 +946,15 @@ func TestGetPreStopRoutingAllocationFromLabels(t *testing.T) {
 		{
 			name:     "No label present - use default",
 			labels:   map[string]string{},
-			expected: "new_primaries",
+			expected: "primaries",
 		},
 		{
-			name:     "Valid new_primaries value",
+			name:     "Valid primaries value",
+			labels:   map[string]string{"dc-util-pre-stop-routing-allocation": "primaries"},
+			expected: "primaries",
+		},
+		{
+			name:     "Valid new_primaries value - still accepted",
 			labels:   map[string]string{"dc-util-pre-stop-routing-allocation": "new_primaries"},
 			expected: "new_primaries",
 		},
@@ -961,7 +966,7 @@ func TestGetPreStopRoutingAllocationFromLabels(t *testing.T) {
 		{
 			name:     "Invalid value - use default",
 			labels:   map[string]string{"dc-util-pre-stop-routing-allocation": "invalid"},
-			expected: "new_primaries",
+			expected: "primaries",
 		},
 	}
 
@@ -1023,7 +1028,7 @@ func TestResetRoutingIntegration(t *testing.T) {
 			labels:                    map[string]string{},
 			dryRun:                    false,
 			expectedNoPreStart:        false,
-			expectedRoutingAllocation: "new_primaries",
+			expectedRoutingAllocation: "primaries",
 			description:               "Default behavior",
 		},
 		{
@@ -1033,7 +1038,7 @@ func TestResetRoutingIntegration(t *testing.T) {
 			},
 			dryRun:                    false,
 			expectedNoPreStart:        true,
-			expectedRoutingAllocation: "new_primaries",
+			expectedRoutingAllocation: "primaries",
 			description:               "PostStart should be skipped",
 		},
 		{


### PR DESCRIPTION
## Summary of changes

Switches `cluster.routing.allocation.enable` from `new_primaries` to `primaries` while nodes are
taken down, in both places that write it.

Both values suppress replica allocation, which is why the setting is held across a restart at all.
`new_primaries` additionally returns `NO` for `EXISTING_STORE` recovery, so a node that comes back
cannot recover its own primaries from local disk while the setting is in force. `primaries` permits
that, and is what the CrateDB rolling-upgrade docs now recommend (crate/crate#19751).

**The Go half is the one that lands.** dc_util writes the same setting from its preStop hook — later
than the operator, and as `TRANSIENT` rather than `PERSISTENT`. `Metadata` builds the effective
settings as persistent with transient on top, so dc_util's value applies to every restart outside
OpenShift. Changing `operations.py` alone, as the issue proposes, would have been inert. The Python
constant keeps the operator's two call sites in agreement with the Go default.

`new_primaries` stays a valid `dc-util-pre-stop-routing-allocation` label value — rejecting it would
silently flip clusters that set it explicitly over to the default at the same moment the default
changes.

No change to the fallback: `restart_cluster` still resets the setting when the cluster is unhealthy
after a pod returns, and `RESET GLOBAL` clears both levels. `primaries` only makes that path rarer,
since reaching GREEN no longer depends on dc_util's postStart reset landing.

`--min-availability PRIMARIES` in the preStop hook is `cluster.graceful_stop.min_availability`, a
different setting that shares the word. Untouched.

Rollout: the binary is fetched from the fileserver at hook runtime, so the dc_util change takes
effect on the next pod restart without an operator release.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/crate-operator/issues/863
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)