### PR TITLE
Remove pip's bundled SBOM to clear false-positive Trivy findings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 Unreleased
 ----------
 
+* Removed pip's bundled SBOM from the Docker image to avoid false-positive
+  Trivy findings for libraries vendored inside pip.
+
 * Fixed only the first node group of a cluster getting a ``PodDisruptionBudget``.
 
 * Added support for STACKIT Kubernetes Engine via ``CLOUD_PROVIDER=stackit``.

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=build /src/dist /wheels
 RUN pip install --no-cache-dir -U pip wheel setuptools==${SETUPTOOLS_VERSION} && \
     pip install --no-cache-dir /wheels/*.whl && \
     rm -rf /wheels && \
+    rm -f /usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json && \
     ln -s "$(python -c "import pkgutil; main = pkgutil.get_loader('crate.operator.main'); print(main.path)")"
 
 USER crate-operator


### PR DESCRIPTION
## Summary of changes
Delete pip's bundled CycloneDX SBOM (pip/_vendor/bom.cdx.json) from the Docker image after installing dependencies, so the trivy scan reflects what we actually install. pip's vendored code is never executed when the container runs, so this changes nothing at runtime. rm -f won't error if a future pip drops the file.

## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
