### PR TITLE
Fix the dc_util build, which produced no binaries and reported success

### DIFF
--- a/.github/workflows/build-and-release-dc_util.yaml
+++ b/.github/workflows/build-and-release-dc_util.yaml
@@ -23,7 +23,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23'
+          # Keep in sync with the `go` directive in utils/dc_util/go.mod
+          go-version: '1.25'
 
       - name: Build dc_util
         run: |

--- a/utils/dc_util/CHANGES.md
+++ b/utils/dc_util/CHANGES.md
@@ -65,6 +65,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Eliminates need for separate configuration files for different node architectures
   - Graceful error handling for unsupported architectures
 
+### Fixed
+
+- **Build produced no binaries and reported success**
+  - `go.mod` moved to `go 1.25.0` on 2026-07-28; `deploy/Dockerfile.multi` still pinned
+    `golang:1.23-alpine`, and the official images set `GOTOOLCHAIN=local`, so the compile failed
+  - `compile-binaries.sh` logged the error, continued, wrote the version index and exited 0, so the
+    fileserver image built and pushed cleanly with an empty binary directory
+  - Every pod's preStop hook would then 404 on the download and skip decommission silently, since
+    the hook ends in `|| true`
+  - The script now exits non-zero when any version fails, and the build summary reports `MISSING`
+    instead of a blank size
+- **Builder stage pinned to `$BUILDPLATFORM`** - the binaries are cross-compiled with `GOOS`/`GOARCH`,
+  so forcing the whole build to the target platform put the Go toolchain under emulation, where it
+  segfaults on an arm64 host
+- **`--platform` on the Makefile's docker targets** (default `linux/amd64`) - the fileserver runs on
+  amd64 nodes, and an arm64 build host silently produced an image that cannot exec there
+
 ### Changed
 
 - **Default PreStop Routing Allocation**: `new_primaries` -> `primaries`

--- a/utils/dc_util/Makefile
+++ b/utils/dc_util/Makefile
@@ -8,6 +8,9 @@ REGISTRY = cloud.registry.cr8.net
 IMAGE_NAME = dc-util-fileserver
 TAG ?= latest
 VERSIONS ?= latest
+# The fileserver runs on amd64 nodes; without this an arm64 build host produces
+# an image that cannot exec there.
+PLATFORM ?= linux/amd64
 FULL_IMAGE = $(REGISTRY)/$(IMAGE_NAME):$(TAG)
 
 # Default target
@@ -43,13 +46,14 @@ docker-build: build-binaries
 	cp $(BINARY_NAME)-linux-amd64 deploy/
 	cp $(BINARY_NAME)-linux-arm64 deploy/
 	@echo "Building container image..."
-	cd deploy && docker build -t $(FULL_IMAGE) .
+	cd deploy && docker build --platform $(PLATFORM) -t $(FULL_IMAGE) .
 
 # Multi-version Docker build
 .PHONY: docker-build-multi
 docker-build-multi:
 	@echo "Building multi-version container with versions: $(VERSIONS)"
 	docker build \
+		--platform $(PLATFORM) \
 		--no-cache \
 		--build-arg VERSIONS="$(VERSIONS)" \
 		--build-arg GITHUB_REPO="https://github.com/crate/crate-operator.git" \

--- a/utils/dc_util/deploy/Dockerfile.multi
+++ b/utils/dc_util/deploy/Dockerfile.multi
@@ -1,4 +1,8 @@
-FROM golang:1.23-alpine AS builder
+# Pinned to BUILDPLATFORM so the toolchain runs natively: the binaries are
+# cross-compiled with GOOS/GOARCH below, and an emulated Go compiler segfaults.
+# The version must satisfy the `go` directive in go.mod; the official images set
+# GOTOOLCHAIN=local, so a lower version fails the build instead of upgrading.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 # Install required tools
 RUN apk add --no-cache git curl

--- a/utils/dc_util/deploy/scripts/compile-binaries.sh
+++ b/utils/dc_util/deploy/scripts/compile-binaries.sh
@@ -10,6 +10,11 @@ set -e
 VERSIONS=${VERSIONS:-"latest"}
 GITHUB_REPO=${GITHUB_REPO:-"https://github.com/crate/crate-operator.git"}
 
+# Versions that failed to build. Collected rather than aborted on, so a
+# multi-version build still produces the ones that work - but the script must
+# exit non-zero at the end, or the image ships with binaries missing.
+failed_versions=""
+
 echo "=== DC Util Binary Compiler ==="
 echo "Versions: $VERSIONS"
 echo "Repository: $GITHUB_REPO"
@@ -51,6 +56,7 @@ for version_spec in $VERSIONS; do
         echo "Cloning repository..."
         if ! git clone --depth 1 --branch "$git_tag" "$GITHUB_REPO" "crate-operator-$git_tag"; then
             echo "ERROR: Failed to clone git tag '$git_tag'"
+            failed_versions="$failed_versions $user_version"
             continue
         fi
 
@@ -65,6 +71,7 @@ for version_spec in $VERSIONS; do
                 echo "ERROR: dc_util.go not found in $git_tag"
                 echo "Available files:"
                 ls -la
+                failed_versions="$failed_versions $user_version"
                 continue
             fi
         fi
@@ -76,6 +83,7 @@ for version_spec in $VERSIONS; do
         echo "Current directory: $(pwd)"
         echo "Available files:"
         ls -la
+        failed_versions="$failed_versions $user_version"
         continue
     fi
 
@@ -85,6 +93,7 @@ for version_spec in $VERSIONS; do
     echo "Building AMD64 binary..."
     if ! GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o "/binaries/$user_version/dc_util-linux-amd64" dc_util.go; then
         echo "ERROR: Failed to build AMD64 binary for $user_version"
+        failed_versions="$failed_versions $user_version"
         continue
     fi
 
@@ -92,6 +101,7 @@ for version_spec in $VERSIONS; do
     echo "Building ARM64 binary..."
     if ! GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o "/binaries/$user_version/dc_util-linux-arm64" dc_util.go; then
         echo "ERROR: Failed to build ARM64 binary for $user_version"
+        failed_versions="$failed_versions $user_version"
         continue
     fi
 
@@ -175,10 +185,25 @@ for dir in */; do
     if [ -d "$dir" ] && [ "$dir" != "./" ]; then
         version=${dir%/}
         echo "  📦 $version"
-        echo "     - AMD64: $(ls -lh "$version/dc_util-linux-amd64" 2>/dev/null | awk '{print $5}' || echo 'missing')"
-        echo "     - ARM64: $(ls -lh "$version/dc_util-linux-arm64" 2>/dev/null | awk '{print $5}' || echo 'missing')"
+        for arch in amd64 arm64; do
+            binary="$version/dc_util-linux-$arch"
+            # Tested with -f rather than relying on ls failing: the old form piped
+            # into awk, which succeeds on empty input, so a missing binary printed
+            # as blank instead of 'missing'.
+            if [ -f "$binary" ]; then
+                echo "     - $arch: $(ls -lh "$binary" | awk '{print $5}')"
+            else
+                echo "     - $arch: MISSING"
+            fi
+        done
     fi
 done
+
+if [ -n "$failed_versions" ]; then
+    echo
+    echo "❌ Binary compilation FAILED for:$failed_versions"
+    exit 1
+fi
 
 echo
 echo "🎉 Binary compilation completed successfully!"


### PR DESCRIPTION
## Summary of changes

The dc_util fileserver build has been broken since 2026-07-28 and reporting success. Found while
trying to deploy the #863 fix.

Dependabot moved `utils/dc_util/go.mod` to `go 1.25.0` (#857) but `deploy/Dockerfile.multi` still
pinned `golang:1.23-alpine`. The official Go images set `GOTOOLCHAIN=local`, so the toolchain refuses
instead of upgrading:

```
go: go.mod requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)
ERROR: Failed to build AMD64 binary for latest
...
🎉 Binary compilation completed successfully!      <- exit 0
```

`compile-binaries.sh` logged the error, `continue`d, wrote the version index and exited 0. The
builder stage succeeded with an empty `/binaries`, so the image built and pushed cleanly with nothing
in it. The one visible symptom was a blank size in the build summary, because the `ls | awk` there
cannot report a missing file — awk succeeds on empty input.

**Blast radius had it been pushed:** the binaries the fileserver serves today are dated 2025-11-11.
The tag is the mutable shared `:multi`, `imagePullPolicy: Always`, and both lifecycle hooks end in
`|| true` — so every pod's preStop would have 404ed on the download and terminated with no graceful
decommission, silently, on every cluster.

### What changed

- **`Dockerfile.multi`**: builder bumped to `golang:1.25-alpine` to satisfy `go.mod`, and pinned to
  `$BUILDPLATFORM`. It cross-compiles both architectures with `GOOS`/`GOARCH`, so it never needed to
  run as the target platform — and forcing it there puts the Go toolchain under emulation, where it
  segfaults compiling `crypto/ed25519` on an arm64 host.
- **`compile-binaries.sh`**: collects failed versions and exits non-zero, so a build that cannot
  produce binaries cannot produce an image. Failures are still collected rather than aborted on, so a
  multi-version build yields the versions that work and names the ones that did not. Build summary
  reports `MISSING` instead of a blank size.
- **`Makefile`**: `--platform` on the docker targets, default `linux/amd64`. The fileserver runs on
  amd64 nodes; the documented targets on an Apple Silicon host produced an arm64 image that cannot
  exec there.
- **`build-and-release-dc_util.yaml`**: `go-version` pin raised to match `go.mod` — same latent
  breakage in the release workflow.

`dc_util.go` is deliberately untouched; this changes only how the binary is built.

### Verified

Built with the fixes applied: binaries present (33.3M amd64 / 31.3M arm64), correct ELF
architectures, checksums verify, final image `linux/amd64`. Confirmed the pre-fix build produces an
empty `latest/` and that the script now fails loudly instead.

Note that whether a *running* pod has a given dc_util build still cannot be determined — the binary
carries no version string. That is crate/cloud#3055.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3055 (related; this is the build-side blocker found while deploying https://github.com/crate/crate-operator/issues/863)
- [x] Relevant changes are reflected in `CHANGES.rst` — n/a for the operator; entry added to `utils/dc_util/CHANGES.md`
- [x] Added or changed code is covered by tests — build-path change, verified by building and by confirming the failure mode aborts
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)