### PR TITLE
Give cluster.routing.allocation.enable a single owner per restart

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Unreleased
 
 * Changed ``cluster.routing.allocation.enable`` during restarts to ``primaries``.
 
+* Added a StatefulSet label that stops dc_util also writing
+  ``cluster.routing.allocation.enable`` during an operator-driven restart.
+
 2.62.2 (2026-07-22)
 -------------------
 

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -777,27 +777,28 @@ async def scale_backup_metrics_deployment_if_present(
 async def hold_routing_allocation(conn_factory, logger: logging.Logger) -> None:
     """
     Set ``cluster.routing.allocation.enable`` to
-    :data:`ROUTING_ALLOCATION_DURING_RESTART`, at the ``PERSISTENT`` level, so
-    the value also survives a restart of the whole cluster.
+    :data:`ROUTING_ALLOCATION_DURING_RESTART` at both persistence levels.
 
-    The reset comes first, because a transient value has precedence over a
-    persistent value. Old versions of dc_util wrote a transient value and did not
-    remove it, and such a value hides the value that the operator writes here
-    (crate/cloud#3054).
+    The persistent value survives a restart of the whole cluster. The transient
+    value comes first, because a transient value has precedence, and old versions
+    of dc_util left one behind. Do not use ``RESET GLOBAL`` for that transient
+    value: this function also runs while a node is down, and a reset makes the
+    default ``all`` effective for a moment (crate/cloud#3054).
+
+    ``AfterClusterUpdateSubHandler`` removes both values at the end of the
+    update.
 
     :param conn_factory: The connection factory to connect to CrateDB.
     :param logger: The logger on which we're logging.
     """
-    await reset_cluster_setting(
-        conn_factory, logger, setting="cluster.routing.allocation.enable"
-    )
-    await set_cluster_setting(
-        conn_factory,
-        logger,
-        setting="cluster.routing.allocation.enable",
-        value=ROUTING_ALLOCATION_DURING_RESTART,
-        mode="PERSISTENT",
-    )
+    for mode in ("TRANSIENT", "PERSISTENT"):
+        await set_cluster_setting(
+            conn_factory,
+            logger,
+            setting="cluster.routing.allocation.enable",
+            value=ROUTING_ALLOCATION_DURING_RESTART,
+            mode=mode,
+        )
 
 
 async def _patch_routing_owner_label(
@@ -834,12 +835,25 @@ async def _patch_routing_owner_label(
                 namespace=namespace, label_selector=label_selector
             )
             for sts in all_sts.items:
-                await apps.patch_namespaced_stateful_set(
-                    namespace=namespace, name=sts.metadata.name, body=body
-                )
+                # One try per StatefulSet. A cluster with dedicated master nodes
+                # has more than one, and a partly labelled cluster is worse than
+                # an unlabelled one: dc_util then writes the setting for one node
+                # group only.
+                try:
+                    await apps.patch_namespaced_stateful_set(
+                        namespace=namespace, name=sts.metadata.name, body=body
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to patch the %s label of %s to '%s': %s",
+                        ROUTING_OWNER_LABEL,
+                        sts.metadata.name,
+                        value,
+                        e,
+                    )
     except Exception as e:
-        logger.info(
-            "Patching the %s label to '%s' failed: %s", ROUTING_OWNER_LABEL, value, e
+        logger.warning(
+            "Failed to patch the %s label to '%s': %s", ROUTING_OWNER_LABEL, value, e
         )
 
 
@@ -1749,20 +1763,23 @@ class AfterClusterUpdateSubHandler(StateBasedSubHandler):
     async def _reset_cluster_routing_allocation_setting(
         self, namespace: str, name: str, logger: logging.Logger
     ):
-        async with GlobalApiClient() as api_client:
-            core = CoreV1Api(api_client)
-
-            conn_factory = await _get_connection_factory(core, namespace, name)
-
-            await reset_cluster_setting(
-                conn_factory,
-                logger,
-                setting="cluster.routing.allocation.enable",
-            )
-
         # Remove the label after the reset. If you remove it before the reset,
         # dc_util can write the setting again, and the reset then removes it.
-        await clear_routing_allocation_owner(namespace, name, logger)
+        # The label must go also if the reset fails: while it is present, dc_util
+        # does not protect a pod-level restart (crate/cloud#3054).
+        try:
+            async with GlobalApiClient() as api_client:
+                core = CoreV1Api(api_client)
+
+                conn_factory = await _get_connection_factory(core, namespace, name)
+
+                await reset_cluster_setting(
+                    conn_factory,
+                    logger,
+                    setting="cluster.routing.allocation.enable",
+                )
+        finally:
+            await clear_routing_allocation_owner(namespace, name, logger)
 
 
 async def ensure_cronjob_reenabled(

--- a/crate/operator/operations.py
+++ b/crate/operator/operations.py
@@ -24,6 +24,7 @@ import datetime
 import logging
 import pkgutil
 import re
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, cast
 
@@ -165,10 +166,22 @@ DATA_NODE_GROUP_NAME_MAX_LENGTH = 63
 #: name would share its selector and the two would fight over each other's pods.
 RESERVED_NODE_GROUP_NAMES = frozenset({"master"})
 
-#: Held while nodes are down so replicas are not re-allocated; not
-#: ``new_primaries``, which also blocks a returning node's own primaries from
-#: recovering (crate/crate-operator#863). dc_util writes this too, and wins.
+#: The value of ``cluster.routing.allocation.enable`` while nodes are down. It
+#: prevents the allocation of replicas. Do not use ``new_primaries``: it also
+#: prevents the recovery of a returned node's own primaries
+#: (crate/crate-operator#863).
 ROUTING_ALLOCATION_DURING_RESTART = "primaries"
+
+#: The StatefulSet label that shows which component owns
+#: ``cluster.routing.allocation.enable`` during a restart. dc_util reads the
+#: label in its preStop hook. If the operator owns the setting, dc_util does not
+#: change it (crate/cloud#3054).
+ROUTING_OWNER_LABEL = "dc-util-routing-owner"
+
+#: The owner part of the label value. The full value is
+#: ``<owner>-<unix timestamp>``. dc_util uses the timestamp to take the setting
+#: again if the operator stops before it removes the label.
+ROUTING_OWNER_OPERATOR = "operator"
 
 
 def validate_node_spec(nodes: Dict[str, Any], logger: logging.Logger) -> None:
@@ -761,6 +774,109 @@ async def scale_backup_metrics_deployment_if_present(
         raise
 
 
+async def hold_routing_allocation(conn_factory, logger: logging.Logger) -> None:
+    """
+    Set ``cluster.routing.allocation.enable`` to
+    :data:`ROUTING_ALLOCATION_DURING_RESTART`, at the ``PERSISTENT`` level, so
+    the value also survives a restart of the whole cluster.
+
+    The reset comes first, because a transient value has precedence over a
+    persistent value. Old versions of dc_util wrote a transient value and did not
+    remove it, and such a value hides the value that the operator writes here
+    (crate/cloud#3054).
+
+    :param conn_factory: The connection factory to connect to CrateDB.
+    :param logger: The logger on which we're logging.
+    """
+    await reset_cluster_setting(
+        conn_factory, logger, setting="cluster.routing.allocation.enable"
+    )
+    await set_cluster_setting(
+        conn_factory,
+        logger,
+        setting="cluster.routing.allocation.enable",
+        value=ROUTING_ALLOCATION_DURING_RESTART,
+        mode="PERSISTENT",
+    )
+
+
+async def _patch_routing_owner_label(
+    namespace: str, name: str, value: Optional[str], logger: logging.Logger
+) -> None:
+    """
+    Write the ownership label on each StatefulSet of the cluster. Use ``None``
+    as the value to remove the label.
+
+    Each StatefulSet gets the label, because the operator can restart the pods
+    of any of them. If the Kubernetes API fails, this function writes a log
+    message and continues. The label only tells dc_util to not write the
+    setting. A failure must not stop the restart.
+
+    :param namespace: The Kubernetes namespace of the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param value: The label value, or ``None`` to remove the label.
+    :param logger: The logger on which we're logging.
+    """
+    label_selector = ",".join(
+        f"{k}={v}"
+        for k, v in {
+            LABEL_COMPONENT: "cratedb",
+            LABEL_MANAGED_BY: "crate-operator",
+            LABEL_NAME: name,
+            LABEL_PART_OF: "cratedb",
+        }.items()
+    )
+    body = {"metadata": {"labels": {ROUTING_OWNER_LABEL: value}}}
+    try:
+        async with GlobalApiClient() as api_client:
+            apps = AppsV1Api(api_client)
+            all_sts: V1StatefulSetList = await apps.list_namespaced_stateful_set(
+                namespace=namespace, label_selector=label_selector
+            )
+            for sts in all_sts.items:
+                await apps.patch_namespaced_stateful_set(
+                    namespace=namespace, name=sts.metadata.name, body=body
+                )
+    except Exception as e:
+        logger.info(
+            "Patching the %s label to '%s' failed: %s", ROUTING_OWNER_LABEL, value, e
+        )
+
+
+async def set_routing_allocation_owner(
+    namespace: str, name: str, logger: logging.Logger
+) -> None:
+    """
+    Give the operator the ownership of ``cluster.routing.allocation.enable``.
+    The preStop hook of dc_util then does not write the setting
+    (crate/cloud#3054).
+
+    The operator writes the label again before each pod that it restarts.
+    Therefore the timestamp must only cover the downtime of one pod.
+
+    :param namespace: The Kubernetes namespace of the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param logger: The logger on which we're logging.
+    """
+    await _patch_routing_owner_label(
+        namespace, name, f"{ROUTING_OWNER_OPERATOR}-{int(time.time())}", logger
+    )
+
+
+async def clear_routing_allocation_owner(
+    namespace: str, name: str, logger: logging.Logger
+) -> None:
+    """
+    Remove the ownership of the operator. dc_util then controls
+    ``cluster.routing.allocation.enable`` again for pod-level restarts.
+
+    :param namespace: The Kubernetes namespace of the CrateDB cluster.
+    :param name: The CrateDB custom resource name defining the CrateDB cluster.
+    :param logger: The logger on which we're logging.
+    """
+    await _patch_routing_owner_label(namespace, name, None, logger)
+
+
 def _node_groups_to_restart(
     old: kopf.Body, body: kopf.Body, action: WebhookAction
 ) -> List[NodeGroup]:
@@ -852,16 +968,14 @@ async def restart_cluster(
             operation=WebhookOperation.UPDATE,
             action=action,
         )
+        # Write the label before the pod stops. The preStop hook of dc_util can
+        # then read it.
+        await set_routing_allocation_owner(namespace, name, logger)
+
         try:
             conn_factory = await _get_connection_factory(core, namespace, name)
 
-            await set_cluster_setting(
-                conn_factory,
-                logger,
-                setting="cluster.routing.allocation.enable",
-                value=ROUTING_ALLOCATION_DURING_RESTART,
-                mode="PERSISTENT",
-            )
+            await hold_routing_allocation(conn_factory, logger)
         except Exception as e:
             logger.info(
                 "Setting cluster allocation to '%s' failed: %s",
@@ -1593,18 +1707,14 @@ class BeforeClusterUpdateSubHandler(StateBasedSubHandler):
     async def _set_cluster_routing_allocation_setting(
         self, namespace: str, name: str, logger: logging.Logger
     ):
+        await set_routing_allocation_owner(namespace, name, logger)
+
         async with GlobalApiClient() as api_client:
             core = CoreV1Api(api_client)
 
             conn_factory = await _get_connection_factory(core, namespace, name)
 
-            await set_cluster_setting(
-                conn_factory,
-                logger,
-                setting="cluster.routing.allocation.enable",
-                value=ROUTING_ALLOCATION_DURING_RESTART,
-                mode="PERSISTENT",
-            )
+            await hold_routing_allocation(conn_factory, logger)
 
 
 class AfterClusterUpdateSubHandler(StateBasedSubHandler):
@@ -1649,6 +1759,10 @@ class AfterClusterUpdateSubHandler(StateBasedSubHandler):
                 logger,
                 setting="cluster.routing.allocation.enable",
             )
+
+        # Remove the label after the reset. If you remove it before the reset,
+        # dc_util can write the setting again, and the reset then removes it.
+        await clear_routing_allocation_owner(namespace, name, logger)
 
 
 async def ensure_cronjob_reenabled(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -20,6 +20,7 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import contextlib
+import time
 from unittest import mock
 
 import kopf
@@ -29,11 +30,19 @@ from kubernetes_asyncio.client import ApiException
 from crate.operator.constants import BACKUP_METRICS_DEPLOYMENT_NAME
 from crate.operator.handlers.handle_update_cratedb import _classify_data_scaling
 from crate.operator.operations import (
+    ROUTING_ALLOCATION_DURING_RESTART,
+    ROUTING_OWNER_LABEL,
+    ROUTING_OWNER_OPERATOR,
+    AfterClusterUpdateSubHandler,
+    BeforeClusterUpdateSubHandler,
     check_all_master_nodes_gone,
     check_all_master_nodes_present,
+    clear_routing_allocation_owner,
+    hold_routing_allocation,
     iter_node_groups,
     scale_backup_metrics_deployment_if_present,
     scale_master_statefulset,
+    set_routing_allocation_owner,
     suspend_or_start_cluster,
     validate_node_spec,
 )
@@ -777,3 +786,145 @@ class TestSuspendResumeWithoutBackups:
                 )
 
         assert "data_scale:3" in order
+
+
+@contextlib.contextmanager
+def _apps_api(sts_names, list_error=None):
+    """
+    Mock the AppsV1Api that the routing-ownership helpers use, and give back the
+    mock so a test can read the patch calls.
+    """
+    apps = mock.Mock()
+    apps.list_namespaced_stateful_set = mock.AsyncMock(
+        side_effect=list_error,
+        return_value=mock.Mock(
+            items=[mock.Mock(metadata=mock.Mock(name=n)) for n in sts_names]
+        ),
+    )
+    # Mock(name=...) sets the mock's own name, so set the attribute after.
+    if list_error is None:
+        for item, sts_name in zip(
+            apps.list_namespaced_stateful_set.return_value.items, sts_names
+        ):
+            item.metadata.name = sts_name
+    apps.patch_namespaced_stateful_set = mock.AsyncMock()
+    with mock.patch("crate.operator.operations.GlobalApiClient"):
+        with mock.patch("crate.operator.operations.AppsV1Api", return_value=apps):
+            yield apps
+
+
+class TestRoutingAllocationOwner:
+    @pytest.mark.asyncio
+    async def test_claim_labels_every_statefulset(self):
+        with _apps_api(["crate-master-c", "crate-data-hot-c"]) as apps:
+            await set_routing_allocation_owner("ns", "c", mock.Mock())
+
+        assert apps.patch_namespaced_stateful_set.await_count == 2
+        labelled = set()
+        for call in apps.patch_namespaced_stateful_set.await_args_list:
+            labelled.add(call.kwargs["name"])
+            value = call.kwargs["body"]["metadata"]["labels"][ROUTING_OWNER_LABEL]
+            owner, _, timestamp = value.rpartition("-")
+            assert owner == ROUTING_OWNER_OPERATOR
+            # The timestamp must be readable for dc_util, which drops the label
+            # when it cannot parse it.
+            assert abs(int(timestamp) - time.time()) < 60
+        assert labelled == {"crate-master-c", "crate-data-hot-c"}
+
+    @pytest.mark.asyncio
+    async def test_release_removes_the_label(self):
+        with _apps_api(["crate-data-hot-c"]) as apps:
+            await clear_routing_allocation_owner("ns", "c", mock.Mock())
+
+        apps.patch_namespaced_stateful_set.assert_awaited_once_with(
+            namespace="ns",
+            name="crate-data-hot-c",
+            body={"metadata": {"labels": {ROUTING_OWNER_LABEL: None}}},
+        )
+
+    @pytest.mark.asyncio
+    async def test_api_failure_does_not_stop_the_restart(self):
+        logger = mock.Mock()
+        with _apps_api([], list_error=ApiException(status=403)):
+            # Must not raise. The label is only advice for dc_util.
+            await set_routing_allocation_owner("ns", "c", logger)
+
+        assert logger.info.called
+
+
+class TestRoutingAllocationOwnershipHandlers:
+    @pytest.mark.asyncio
+    async def test_before_update_claims_before_it_writes_the_setting(self):
+        order: list = []
+        with mock.patch(
+            "crate.operator.operations.set_routing_allocation_owner",
+            new=mock.AsyncMock(side_effect=lambda *a: order.append("claim")),
+        ):
+            with mock.patch("crate.operator.operations.GlobalApiClient"):
+                with mock.patch(
+                    "crate.operator.operations._get_connection_factory",
+                    new=mock.AsyncMock(),
+                ):
+                    with mock.patch(
+                        "crate.operator.operations.hold_routing_allocation",
+                        new=mock.AsyncMock(
+                            side_effect=lambda *a, **kw: order.append("set")
+                        ),
+                    ):
+                        await BeforeClusterUpdateSubHandler._set_cluster_routing_allocation_setting(  # noqa: E501
+                            mock.Mock(), "ns", "c", mock.Mock()
+                        )
+
+        assert order == ["claim", "set"]
+
+    @pytest.mark.asyncio
+    async def test_after_update_releases_after_it_resets_the_setting(self):
+        order: list = []
+        with mock.patch(
+            "crate.operator.operations.clear_routing_allocation_owner",
+            new=mock.AsyncMock(side_effect=lambda *a: order.append("release")),
+        ):
+            with mock.patch("crate.operator.operations.GlobalApiClient"):
+                with mock.patch(
+                    "crate.operator.operations._get_connection_factory",
+                    new=mock.AsyncMock(),
+                ):
+                    with mock.patch(
+                        "crate.operator.operations.reset_cluster_setting",
+                        new=mock.AsyncMock(
+                            side_effect=lambda *a, **kw: order.append("reset")
+                        ),
+                    ):
+                        await AfterClusterUpdateSubHandler._reset_cluster_routing_allocation_setting(  # noqa: E501
+                            mock.Mock(), "ns", "c", mock.Mock()
+                        )
+
+        assert order == ["reset", "release"]
+
+
+class TestHoldRoutingAllocation:
+    @pytest.mark.asyncio
+    async def test_clears_a_stale_transient_value_first(self):
+        # A transient value has precedence over a persistent value, so the reset
+        # must come first (crate/cloud#3054).
+        order: list = []
+        with mock.patch(
+            "crate.operator.operations.reset_cluster_setting",
+            new=mock.AsyncMock(
+                side_effect=lambda *a, **kw: order.append(("reset", kw))
+            ),
+        ):
+            with mock.patch(
+                "crate.operator.operations.set_cluster_setting",
+                new=mock.AsyncMock(
+                    side_effect=lambda *a, **kw: order.append(("set", kw))
+                ),
+            ):
+                await hold_routing_allocation(mock.Mock(), mock.Mock())
+
+        assert [step for step, _ in order] == ["reset", "set"]
+        assert order[1][1] == {
+            "setting": "cluster.routing.allocation.enable",
+            "value": ROUTING_ALLOCATION_DURING_RESTART,
+            "mode": "PERSISTENT",
+        }

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -849,7 +849,7 @@ class TestRoutingAllocationOwner:
             # Must not raise. The label is only advice for dc_util.
             await set_routing_allocation_owner("ns", "c", logger)
 
-        assert logger.info.called
+        assert logger.warning.called
 
 
 class TestRoutingAllocationOwnershipHandlers:
@@ -904,27 +904,28 @@ class TestRoutingAllocationOwnershipHandlers:
 
 class TestHoldRoutingAllocation:
     @pytest.mark.asyncio
-    async def test_clears_a_stale_transient_value_first(self):
-        # A transient value has precedence over a persistent value, so the reset
-        # must come first (crate/cloud#3054).
-        order: list = []
+    async def test_writes_the_transient_value_first(self):
+        # A transient value has precedence, and old versions of dc_util left one
+        # behind. The transient write removes such a value without a reset: this
+        # also runs while a node is down, and a reset makes the default "all"
+        # effective for a moment (crate/cloud#3054).
+        writes: list = []
         with mock.patch(
-            "crate.operator.operations.reset_cluster_setting",
-            new=mock.AsyncMock(
-                side_effect=lambda *a, **kw: order.append(("reset", kw))
-            ),
+            "crate.operator.operations.set_cluster_setting",
+            new=mock.AsyncMock(side_effect=lambda *a, **kw: writes.append(kw)),
         ):
             with mock.patch(
-                "crate.operator.operations.set_cluster_setting",
-                new=mock.AsyncMock(
-                    side_effect=lambda *a, **kw: order.append(("set", kw))
-                ),
-            ):
+                "crate.operator.operations.reset_cluster_setting",
+                new=mock.AsyncMock(),
+            ) as mock_reset:
                 await hold_routing_allocation(mock.Mock(), mock.Mock())
 
-        assert [step for step, _ in order] == ["reset", "set"]
-        assert order[1][1] == {
-            "setting": "cluster.routing.allocation.enable",
-            "value": ROUTING_ALLOCATION_DURING_RESTART,
-            "mode": "PERSISTENT",
-        }
+        assert writes == [
+            {
+                "setting": "cluster.routing.allocation.enable",
+                "value": ROUTING_ALLOCATION_DURING_RESTART,
+                "mode": mode,
+            }
+            for mode in ("TRANSIENT", "PERSISTENT")
+        ]
+        mock_reset.assert_not_awaited()

--- a/tests/test_restart_cluster.py
+++ b/tests/test_restart_cluster.py
@@ -9,6 +9,7 @@ from crate.operator.webhooks import WebhookAction
 
 
 @pytest.mark.asyncio
+@patch("crate.operator.operations.set_routing_allocation_owner", new_callable=AsyncMock)
 @patch("crate.operator.operations.reset_cluster_setting", new_callable=AsyncMock)
 @patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
 @patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
@@ -33,6 +34,7 @@ async def test_restart_cluster_calls_set_cluster_setting(
     mock_get_connection_factory,
     mock_set_cluster_setting,
     mock_reset_cluster_setting,
+    _mock_set_routing_owner,
 ):
     # mock 2 pods in statefulset
     mock_get_pods_in_statefulset.return_value = [
@@ -116,11 +118,14 @@ async def test_restart_cluster_calls_set_cluster_setting(
         value="primaries",
         mode="PERSISTENT",
     )
-    mock_reset_cluster_setting.assert_awaited_once_with(
+    mock_reset_cluster_setting.assert_any_await(
         mock_get_connection_factory.return_value,
         logger,
         setting="cluster.routing.allocation.enable",
     )
+    # Two resets: one clears a stale transient value before the persistent write,
+    # one is the unhealthy-cluster path above (crate/cloud#3054).
+    assert mock_reset_cluster_setting.await_count == 2
 
 
 def _res(cpu):
@@ -191,6 +196,7 @@ def _progress_messages(mock_send_notification):
 
 
 @pytest.mark.asyncio
+@patch("crate.operator.operations.set_routing_allocation_owner", new_callable=AsyncMock)
 @patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
 @patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
 @patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
@@ -205,6 +211,7 @@ async def test_restart_progress_counts_across_node_groups(
     mock_get_pods_in_statefulset,
     _mock_set_cluster_setting,
     _mock_get_connection_factory,
+    _mock_set_routing_owner,
 ):
     # Pod ordinals restart at 0 in every StatefulSet, so a masters + data restart
     # used to report 1/6, 2/6, 3/6, 1/6, 2/6, 3/6 (crate/cloud#3039). Progress
@@ -253,6 +260,7 @@ async def test_restart_progress_counts_across_node_groups(
 
 
 @pytest.mark.asyncio
+@patch("crate.operator.operations.set_routing_allocation_owner", new_callable=AsyncMock)
 @patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
 @patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
 @patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
@@ -267,6 +275,7 @@ async def test_restart_progress_total_is_the_pods_this_run_restarts(
     mock_get_pods_in_statefulset,
     _mock_set_cluster_setting,
     _mock_get_connection_factory,
+    _mock_set_routing_owner,
 ):
     # A compute change restarts only the changed groups, so the denominator is
     # that group's pods -- not every pod in the cluster.
@@ -306,6 +315,7 @@ async def test_restart_progress_total_is_the_pods_this_run_restarts(
 
 
 @pytest.mark.asyncio
+@patch("crate.operator.operations.set_routing_allocation_owner", new_callable=AsyncMock)
 @patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
 @patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
 @patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
@@ -320,6 +330,7 @@ async def test_restart_progress_seeds_a_total_for_a_restart_already_in_flight(
     mock_get_pods_in_statefulset,
     _mock_set_cluster_setting,
     _mock_get_connection_factory,
+    _mock_set_routing_owner,
 ):
     # A restart that was already running when pendingPodsTotal was introduced has
     # a queue but no total. Seeding it from what is left and persisting it keeps
@@ -361,3 +372,52 @@ async def test_restart_progress_seeds_a_total_for_a_restart_already_in_flight(
     assert reported == ["1/3", "2/3", "3/3"]
     # The queue was never rebuilt, so no StatefulSet lookup was needed.
     mock_get_pods_in_statefulset.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("crate.operator.operations.set_routing_allocation_owner", new_callable=AsyncMock)
+@patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
+@patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
+@patch("crate.operator.operations.get_pods_in_cluster", new_callable=AsyncMock)
+@patch(
+    "crate.operator.operations.send_operation_progress_notification",
+    new_callable=AsyncMock,
+)
+async def test_restart_claims_routing_ownership_before_the_pod_stops(
+    _mock_send_notification,
+    mock_get_pods_in_cluster,
+    mock_get_pods_in_statefulset,
+    _mock_get_connection_factory,
+    _mock_set_cluster_setting,
+    mock_set_routing_owner,
+):
+    # The preStop hook of dc_util reads the label. The operator must write it
+    # before it deletes the pod (crate/cloud#3054).
+    hot = [{"uid": "h0", "name": "crate-data-hot-c-0"}]
+    # The master group is empty here, so the queue holds one pod only.
+    mock_get_pods_in_statefulset.side_effect = [[], hot]
+    mock_get_pods_in_cluster.return_value = (["h0"], ["crate-data-hot-c-0"])
+
+    order: list = []
+    mock_set_routing_owner.side_effect = lambda *a, **kw: order.append("claim")
+    core = MagicMock()
+    core.delete_namespaced_pod = AsyncMock(
+        side_effect=lambda *a, **kw: order.append("delete")
+    )
+    old = _spec()
+
+    with pytest.raises(kopf.TemporaryError, match="Waiting for pod"):
+        await restart_cluster(
+            core=core,
+            namespace="ns",
+            name="c",
+            old=old,
+            body=old,
+            logger=MagicMock(),
+            patch=kopf.Patch(),
+            status={},
+            action=WebhookAction.UPGRADE,
+        )
+
+    assert order == ["claim", "delete"]

--- a/tests/test_restart_cluster.py
+++ b/tests/test_restart_cluster.py
@@ -118,14 +118,11 @@ async def test_restart_cluster_calls_set_cluster_setting(
         value="primaries",
         mode="PERSISTENT",
     )
-    mock_reset_cluster_setting.assert_any_await(
+    mock_reset_cluster_setting.assert_awaited_once_with(
         mock_get_connection_factory.return_value,
         logger,
         setting="cluster.routing.allocation.enable",
     )
-    # Two resets: one clears a stale transient value before the persistent write,
-    # one is the unhealthy-cluster path above (crate/cloud#3054).
-    assert mock_reset_cluster_setting.await_count == 2
 
 
 def _res(cpu):
@@ -376,7 +373,7 @@ async def test_restart_progress_seeds_a_total_for_a_restart_already_in_flight(
 
 @pytest.mark.asyncio
 @patch("crate.operator.operations.set_routing_allocation_owner", new_callable=AsyncMock)
-@patch("crate.operator.operations.set_cluster_setting", new_callable=AsyncMock)
+@patch("crate.operator.operations.hold_routing_allocation", new_callable=AsyncMock)
 @patch("crate.operator.operations._get_connection_factory", new_callable=AsyncMock)
 @patch("crate.operator.operations.get_pods_in_statefulset", new_callable=AsyncMock)
 @patch("crate.operator.operations.get_pods_in_cluster", new_callable=AsyncMock)
@@ -389,7 +386,7 @@ async def test_restart_claims_routing_ownership_before_the_pod_stops(
     mock_get_pods_in_cluster,
     mock_get_pods_in_statefulset,
     _mock_get_connection_factory,
-    _mock_set_cluster_setting,
+    mock_hold_routing_allocation,
     mock_set_routing_owner,
 ):
     # The preStop hook of dc_util reads the label. The operator must write it
@@ -401,6 +398,7 @@ async def test_restart_claims_routing_ownership_before_the_pod_stops(
 
     order: list = []
     mock_set_routing_owner.side_effect = lambda *a, **kw: order.append("claim")
+    mock_hold_routing_allocation.side_effect = lambda *a, **kw: order.append("hold")
     core = MagicMock()
     core.delete_namespaced_pod = AsyncMock(
         side_effect=lambda *a, **kw: order.append("delete")
@@ -420,4 +418,4 @@ async def test_restart_claims_routing_ownership_before_the_pod_stops(
             action=WebhookAction.UPGRADE,
         )
 
-    assert order == ["claim", "delete"]
+    assert order == ["claim", "hold", "delete"]

--- a/utils/dc_util/CHANGES.md
+++ b/utils/dc_util/CHANGES.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Routing Ownership Label**: `dc-util-routing-owner`, written by crate-operator
+  - Value is `operator-<unix seconds>`; crate-operator writes it before each pod it restarts
+  - While the label is present and fresh, dc_util does not write
+    `cluster.routing.allocation.enable`, does not create the lock file, and does not reset the
+    setting in postStart
+  - dc_util ignores the label after 2 hours, so an operator that stops mid-restart cannot keep the
+    allocation of replicas disabled
+  - Gives one owner per restart: dc_util owns pod-level restarts, the operator owns the restarts it
+    drives itself (crate/cloud#3054)
+
 - **Persistent Logging**: Dual logging to both STDOUT and persistent file with automatic rotation
   - New `--log-file` CLI flag (default: `/resource/heapdump/dc_util.log`)
   - Automatic file rotation when approaching 1MB to prevent disk space issues
@@ -67,6 +77,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PostStart reset left a transient value behind**
+  - The reset was `SET GLOBAL TRANSIENT "cluster.routing.allocation.enable" = 'all'`, which is a
+    write and not a reset, so a transient entry stayed after the restart
+  - A transient value has precedence over a persistent value, so the entry hid the persistent value
+    that crate-operator writes for its own restarts, and the operator's protection did not apply
+  - The reset is now `RESET GLOBAL cluster.routing.allocation.enable`, which clears both levels
+  - Safe only together with the ownership label below: without it, a reset in one pod's postStart
+    would clear the value the operator holds for the pods that come after (crate/cloud#3054)
+
 - **Build produced no binaries and reported success**
   - `go.mod` moved to `go 1.25.0` on 2026-07-28; `deploy/Dockerfile.multi` still pinned
     `golang:1.23-alpine`, and the official images set `GOTOOLCHAIN=local`, so the compile failed
@@ -94,6 +113,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Routing allocation changes now only occur when corresponding PostStart hook exists
   - Prevents permanent cluster misconfiguration in deployments without PostStart hooks
   - More intelligent decision making based on actual StatefulSet configuration
+
+- **Lock File Creation**: Now conditional on dc_util changing the routing allocation
+  - Was created on every preStop, also when the routing allocation was not changed
+  - The lock file is the only signal that makes postStart reset the setting, so one without a
+    change made postStart clear a value from a different owner (crate/cloud#3054)
 
 - **Replica Count Handling**: Early replica count check moved to beginning of decommission process
   - Zero replicas (scaled down): Immediately skips all operations including SQL and lock file creation

--- a/utils/dc_util/CHANGES.md
+++ b/utils/dc_util/CHANGES.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - While the label is present and fresh, dc_util does not write
     `cluster.routing.allocation.enable`, does not create the lock file, and does not reset the
     setting in postStart
+  - postStart keeps an existing lock file in that case: the value behind it comes from a preStop
+    that ran before the operator took the setting, and a later postStart must still reset it
   - dc_util ignores the label after 2 hours, so an operator that stops mid-restart cannot keep the
     allocation of replicas disabled
   - Gives one owner per restart: dc_util owns pod-level restarts, the operator owns the restarts it
@@ -114,10 +116,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Prevents permanent cluster misconfiguration in deployments without PostStart hooks
   - More intelligent decision making based on actual StatefulSet configuration
 
-- **Lock File Creation**: Now conditional on dc_util changing the routing allocation
+- **Lock File Creation**: Now conditional on dc_util sending the routing allocation statement
   - Was created on every preStop, also when the routing allocation was not changed
   - The lock file is the only signal that makes postStart reset the setting, so one without a
     change made postStart clear a value from a different owner (crate/cloud#3054)
+  - Created before the statement, not after a successful response: an error can also come from the
+    response, and a value that is set without a lock file stays after the restart
 
 - **Replica Count Handling**: Early replica count check moved to beginning of decommission process
   - Zero replicas (scaled down): Immediately skips all operations including SQL and lock file creation

--- a/utils/dc_util/README.md
+++ b/utils/dc_util/README.md
@@ -240,7 +240,7 @@ spec:
 - **Label precedence**: StatefulSet labels override CLI parameters
 - **When disabled=true**: dc_util logs a message and exits without performing any decommission work
 - **When no-poststart=true**: PostStart reset-routing behavior is skipped
-- **When the operator owns the routing allocation**: dc_util skips the preStop change, skips the lock file, and skips the PostStart reset. The decommission itself continues.
+- **When the operator owns the routing allocation**: dc_util skips the preStop change, skips the lock file, and skips the PostStart reset. It keeps an existing lock file, so a later PostStart can still do the reset. The decommission itself continues.
 
 ## Sample Logs
 

--- a/utils/dc_util/README.md
+++ b/utils/dc_util/README.md
@@ -379,20 +379,44 @@ For production deployments, consider embedding dc_util in your container image t
 - Supports both single dash (`-reset-routing`) and double dash (`--reset-routing`) flag formats
 - Prevents false positives from similar flag names using precise word boundary matching
 
+**Ownership**: crate-operator drives restarts of its own (upgrade, change-compute, restore). It then holds `cluster.routing.allocation.enable` itself and writes the `dc-util-routing-owner` label. dc_util owns pod-level restarts only -- eviction, node drain, a manual `kubectl delete pod` -- where nothing else coordinates the cluster.
+
 **preStop Process (Enhanced)**:
 
-1. **Checks for postStart hook** with dc_util reset-routing capability
-2. Sets routing allocation to restricted value (`primaries` by default) **only if postStart hook exists**
-3. Creates lock file (configurable via `--lock-file`)
-4. Continues with normal decommission process
+1. **Checks the `dc-util-routing-owner` label**. The operator owns the setting while the label is present and younger than 2 hours
+2. **Checks for postStart hook** with dc_util reset-routing capability
+3. Sets routing allocation to restricted value (`primaries` by default) **only if the operator does not own it and a postStart hook exists**
+4. Creates lock file (configurable via `--lock-file`) **only if it sent that statement**
+5. Continues with normal decommission process
 
 **postStart Process (`--reset-routing`)**:
 
 1. Checks `dc-util-no-poststart` label (exit if `true`)
 2. Checks for lock file existence (exit if not found)
-3. Waits for cluster readiness (10-minute timeout)
-4. Executes: `SET GLOBAL TRANSIENT "cluster.routing.allocation.enable" = 'all';`
-5. Removes lock file (prevents retry loops)
+3. Checks the `dc-util-routing-owner` label. If the operator owns the setting, skips the reset and **keeps** the lock file, so a later postStart can still do it
+4. Waits for cluster readiness (10-minute timeout)
+5. Executes: `RESET GLOBAL cluster.routing.allocation.enable;`
+6. Removes lock file (prevents retry loops)
+
+A reset and not a write of `'all'`: a transient value stays after the restart, a transient value has precedence over a persistent value, and such a value hides the value that crate-operator writes for its own restarts.
+
+```mermaid
+flowchart TD
+    START["Pod stops"] --> PRE{"preStop: label present<br/>and younger than 2 h?"}
+    PRE -->|"yes, operator owns it"| SKIP["No SQL write<br/>No lock file"]
+    PRE -->|"absent, malformed<br/>or stale"| SET["SET GLOBAL TRANSIENT = primaries<br/>Create lock file"]
+    SKIP --> DECOM["alter cluster decommission"]
+    SET --> DECOM
+    DECOM --> UP["Pod starts"]
+
+    UP --> POST{"postStart:<br/>lock file present?"}
+    POST -->|"no"| EXIT["Exit, nothing to reset"]
+    POST -->|"yes"| OWN{"label still owned<br/>by the operator?"}
+    OWN -->|"yes"| KEEP["Skip the reset<br/>Keep the lock file for a later postStart"]
+    OWN -->|"no"| RESET["RESET GLOBAL<br/>Remove the lock file"]
+```
+
+The `KEEP` branch needs a pod-level restart that an operator-driven restart overlapped. A reset there removes the value that the operator needs for the pods that come after, and a removed lock file loses the information that a reset is still necessary.
 
 ### Sample postStart Logs:
 
@@ -403,7 +427,7 @@ ResetRouting: 2025/10/16 19:23:49 Lock file found at /resource/heapdump/dc_util.
 ResetRouting: 2025/10/16 19:23:50 Waiting for cluster readiness (timeout: 10m0s)...
 ResetRouting: 2025/10/16 19:23:52 Cluster is ready after 3 attempts
 ResetRouting: 2025/10/16 19:23:52 Executing routing allocation reset
-ResetRouting: 2025/10/16 19:23:52 Payload: {"stmt":"SET GLOBAL TRANSIENT \"cluster.routing.allocation.enable\" = 'all';"}
+ResetRouting: 2025/10/16 19:23:52 Payload: {"stmt":"RESET GLOBAL cluster.routing.allocation.enable;"}
 ResetRouting: 2025/10/16 19:23:52 Response from server: {"cols":[],"rows":[[]],"rowcount":1,"duration":15.234}
 ResetRouting: 2025/10/16 19:23:52 Routing allocation reset completed successfully
 ResetRouting: 2025/10/16 19:23:52 Removed lock file: /resource/heapdump/dc_util.lock

--- a/utils/dc_util/README.md
+++ b/utils/dc_util/README.md
@@ -213,6 +213,7 @@ As already mentioned `terminationGracePeriodSeconds` MUST be set larger then `--
 - **`dc-util-disabled`**: Disables dc_util decommissioning entirely (values: `true`, `false`, default: `false`)
 - **`dc-util-no-poststart`**: Disables PostStart reset-routing behavior (values: `true`, `false`, default: `false`)
 - **`dc-util-pre-stop-routing-allocation`**: Sets routing allocation value during preStop (values: `primaries`, `new_primaries`, `all`, default: `primaries`)
+- **`dc-util-routing-owner`**: Written by crate-operator, not by an operator of the cluster. It shows that the operator controls `cluster.routing.allocation.enable` for the current restart (value: `operator-<unix seconds>`). dc_util then does not change the setting, and does not create the lock file. dc_util ignores the label after 2 hours, in case the operator stopped before it removed the label.
 
 ## Example StatefulSet with labels:
 
@@ -239,6 +240,7 @@ spec:
 - **Label precedence**: StatefulSet labels override CLI parameters
 - **When disabled=true**: dc_util logs a message and exits without performing any decommission work
 - **When no-poststart=true**: PostStart reset-routing behavior is skipped
+- **When the operator owns the routing allocation**: dc_util skips the preStop change, skips the lock file, and skips the PostStart reset. The decommission itself continues.
 
 ## Sample Logs
 

--- a/utils/dc_util/dc_util.go
+++ b/utils/dc_util/dc_util.go
@@ -502,13 +502,14 @@ func handleResetRouting(hostname string, dryRun bool, lockFile string) error {
 		return nil
 	}
 
-	// 2. SECOND: Do not touch the setting if the operator owns it. This is only
-	// possible with a lock file from an earlier restart. A reset can remove the
-	// value that the operator needs for the pods that come after. Remove the
-	// lock file instead (crate/cloud#3054).
+	// 2. SECOND: Do not touch the setting if the operator owns it. A reset can
+	// remove the value that the operator needs for the pods that come after.
+	// Keep the lock file: this pod's preStop wrote a value before the operator
+	// took the setting, and the next postStart that owns it must still reset
+	// that value (crate/cloud#3054).
 	if operatorOwnsRoutingAllocation(statefulSet.Labels, time.Now()) {
-		log.Println("Operator owns the routing allocation setting, skipping reset")
-		return removeLockFile(dryRun, lockFile)
+		log.Println("Operator owns the routing allocation setting, skipping reset and keeping the lock file")
+		return nil
 	}
 
 	// 3. THIRD: Early exit if not a multi-node cluster
@@ -771,12 +772,15 @@ func run(crateNodePrefix, decommissionTimeout string, pid int, proto, hostname, 
 		preStopRoutingAllocation := getPreStopRoutingAllocationFromLabels(statefulSet.Labels)
 		preStopRoutingStmt := fmt.Sprintf(`SET GLOBAL TRANSIENT "cluster.routing.allocation.enable" = '%s';`, preStopRoutingAllocation)
 
+		// Set the flag before the statement. An error can also come from the
+		// response and not from the statement, and a value that is set without a
+		// lock file stays after the restart.
+		routingAllocationSet = true
+
 		log.Printf("Setting pre-stop routing allocation to: %s", preStopRoutingAllocation)
 		if err := sendSQLStatement(proto, preStopRoutingStmt, dryRun); err != nil {
 			log.Printf("Warning: Failed to set pre-stop routing allocation: %v", err)
 			// Continue with decommission process even if this fails
-		} else {
-			routingAllocationSet = true
 		}
 	}
 

--- a/utils/dc_util/dc_util.go
+++ b/utils/dc_util/dc_util.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -39,6 +40,7 @@ const (
 	labelDisabled                 = "dc-util-disabled"
 	labelNoPostStart              = "dc-util-no-poststart"
 	labelPreStopRoutingAllocation = "dc-util-pre-stop-routing-allocation"
+	labelRoutingOwner             = "dc-util-routing-owner"
 
 	// Default lock file path for tracking dc_util shutdowns
 	defaultDcUtilLockFile = "/resource/heapdump/dc_util.lock"
@@ -50,6 +52,16 @@ const (
 	// also blocks a returning node's own primaries from recovering
 	// (crate/crate-operator#863).
 	defaultPreStopRoutingAllocation = "primaries"
+
+	// The owner that crate-operator writes in the labelRoutingOwner label. The
+	// full value is "operator-<unix seconds>" (crate/cloud#3054).
+	routingOwnerOperator = "operator"
+
+	// How long dc_util obeys the label. The operator writes the label again
+	// before each pod that it restarts, so this must only cover the downtime of
+	// one pod. After this time dc_util takes the setting again. A stopped
+	// operator can then not keep the allocation of replicas disabled.
+	routingOwnerTTL = 2 * time.Hour
 
 	// PostStart readiness timeout (10 minutes)
 	postStartTimeout = 10 * time.Minute
@@ -234,6 +246,67 @@ func getPreStopRoutingAllocationFromLabels(labels map[string]string) string {
 		}
 	}
 	return defaultPreStopRoutingAllocation // default behavior
+}
+
+// operatorOwnsRoutingAllocation returns true when crate-operator owns
+// cluster.routing.allocation.enable. The operator writes a label on the
+// StatefulSet while it does a restart itself (crate/cloud#3054). A label that is
+// absent, unknown or too old gives false. dc_util then writes the setting, as it
+// did before this change.
+func operatorOwnsRoutingAllocation(labels map[string]string, now time.Time) bool {
+	value, exists := labels[labelRoutingOwner]
+	if !exists {
+		return false
+	}
+
+	owner, timestamp, found := strings.Cut(value, "-")
+	if !found || owner != routingOwnerOperator {
+		log.Printf("Unrecognised owner in StatefulSet label '%s': %s, ignoring it",
+			labelRoutingOwner, value)
+		return false
+	}
+
+	seconds, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		log.Printf("Malformed timestamp in StatefulSet label '%s': %s, ignoring it",
+			labelRoutingOwner, value)
+		return false
+	}
+
+	// Use the same limit for a timestamp in the future. A clock error can make
+	// such a timestamp, and without a limit it holds the setting forever.
+	age := now.Sub(time.Unix(seconds, 0))
+	if age < 0 {
+		age = -age
+	}
+	if age > routingOwnerTTL {
+		log.Printf("StatefulSet label '%s' is stale (%s off), reclaiming the routing allocation setting",
+			labelRoutingOwner, age.Round(time.Second))
+		return false
+	}
+
+	log.Printf("Operator owns the routing allocation setting (StatefulSet label %s=%s)",
+		labelRoutingOwner, value)
+	return true
+}
+
+// shouldSetPreStopRoutingAllocation returns true when dc_util must write
+// cluster.routing.allocation.enable before the pod stops. It returns false when
+// the operator owns the setting, and when no postStart hook can undo the change.
+// It writes a log message for each case. A skipped write is not visible in the
+// output of the hook.
+func shouldSetPreStopRoutingAllocation(statefulSet *appsv1.StatefulSet, now time.Time) bool {
+	if operatorOwnsRoutingAllocation(statefulSet.Labels, now) {
+		log.Println("Operator-driven restart, leaving the routing allocation setting to the operator")
+		return false
+	}
+
+	if !hasPostStartHookWithResetRouting(statefulSet) {
+		log.Println("No postStart hook with dc_util --reset-routing or -reset-routing found, skipping pre-stop routing allocation change")
+		return false
+	}
+
+	return true
 }
 
 // hasPostStartHookWithResetRouting checks if the StatefulSet has a postStart hook
@@ -429,7 +502,16 @@ func handleResetRouting(hostname string, dryRun bool, lockFile string) error {
 		return nil
 	}
 
-	// 2. SECOND: Early exit if not a multi-node cluster
+	// 2. SECOND: Do not touch the setting if the operator owns it. This is only
+	// possible with a lock file from an earlier restart. A reset can remove the
+	// value that the operator needs for the pods that come after. Remove the
+	// lock file instead (crate/cloud#3054).
+	if operatorOwnsRoutingAllocation(statefulSet.Labels, time.Now()) {
+		log.Println("Operator owns the routing allocation setting, skipping reset")
+		return removeLockFile(dryRun, lockFile)
+	}
+
+	// 3. THIRD: Early exit if not a multi-node cluster
 	if statefulSet.Spec.Replicas == nil || *statefulSet.Spec.Replicas <= 1 {
 		replicaCount := int32(0)
 		if statefulSet.Spec.Replicas != nil {
@@ -444,7 +526,7 @@ func handleResetRouting(hostname string, dryRun bool, lockFile string) error {
 		return removeLockFile(dryRun, lockFile)
 	}
 
-	// 3. THIRD: Check if poststart is disabled
+	// 4. FOURTH: Check if poststart is disabled
 	noPostStart := getNoPostStartFromLabels(statefulSet.Labels)
 	if noPostStart {
 		log.Println("PostStart is disabled via StatefulSet label, exiting")
@@ -465,7 +547,10 @@ func handleResetRouting(hostname string, dryRun bool, lockFile string) error {
 	}
 
 	// Execute the routing allocation reset (single attempt - no point retrying if other pods aren't running)
-	resetStmt := `SET GLOBAL TRANSIENT "cluster.routing.allocation.enable" = 'all';`
+	// Use RESET GLOBAL and not SET ... = 'all'. A transient value stays after the
+	// restart, and a transient value has precedence over a persistent value. A
+	// transient 'all' thus hides the value of the operator (crate/cloud#3054).
+	resetStmt := `RESET GLOBAL cluster.routing.allocation.enable;`
 	log.Printf("Executing routing allocation reset (single attempt)")
 	if err := sendSQLStatement(proto, resetStmt, dryRun); err != nil {
 		log.Printf("Failed to reset routing allocation: %v", err)
@@ -680,8 +765,9 @@ func run(crateNodePrefix, decommissionTimeout string, pid int, proto, hostname, 
 	}
 
 	// Handle pre-stop routing allocation (BEFORE decommissioning)
-	// Only set routing allocation if there's a postStart hook to reset it
-	if hasPostStartHookWithResetRouting(statefulSet) {
+	// Only set routing allocation if we own it and there's a postStart hook to reset it
+	routingAllocationSet := false
+	if shouldSetPreStopRoutingAllocation(statefulSet, time.Now()) {
 		preStopRoutingAllocation := getPreStopRoutingAllocationFromLabels(statefulSet.Labels)
 		preStopRoutingStmt := fmt.Sprintf(`SET GLOBAL TRANSIENT "cluster.routing.allocation.enable" = '%s';`, preStopRoutingAllocation)
 
@@ -689,20 +775,27 @@ func run(crateNodePrefix, decommissionTimeout string, pid int, proto, hostname, 
 		if err := sendSQLStatement(proto, preStopRoutingStmt, dryRun); err != nil {
 			log.Printf("Warning: Failed to set pre-stop routing allocation: %v", err)
 			// Continue with decommission process even if this fails
+		} else {
+			routingAllocationSet = true
 		}
-	} else {
-		log.Println("No postStart hook with dc_util --reset-routing or -reset-routing found, skipping pre-stop routing allocation change")
 	}
 
-	// Create lock file to indicate dc_util handled this shutdown
-	if dryRun {
-		log.Printf("[DRY-RUN] Would create lock file: %s", lockFile)
+	// Create the lock file only if dc_util changed the routing allocation. The
+	// postStart hook resets the setting when it finds the lock file. A lock file
+	// without a change can thus remove the value of the operator
+	// (crate/cloud#3054).
+	if routingAllocationSet {
+		if dryRun {
+			log.Printf("[DRY-RUN] Would create lock file: %s", lockFile)
+		} else {
+			log.Printf("Creating lock file: %s", lockFile)
+		}
+		if err := createLockFile(dryRun, lockFile); err != nil {
+			log.Printf("Warning: Failed to create lock file: %v", err)
+			// Continue with decommission process even if this fails
+		}
 	} else {
-		log.Printf("Creating lock file: %s", lockFile)
-	}
-	if err := createLockFile(dryRun, lockFile); err != nil {
-		log.Printf("Warning: Failed to create lock file: %v", err)
-		// Continue with decommission process even if this fails
+		log.Printf("Routing allocation not changed by dc_util, skipping lock file: %s", lockFile)
 	}
 
 	// Calculate effective timeout based on terminationGracePeriodSeconds

--- a/utils/dc_util/decommission_test.go
+++ b/utils/dc_util/decommission_test.go
@@ -1808,6 +1808,150 @@ func TestResetRoutingReplicaCount(t *testing.T) {
 	}
 }
 
+func TestOperatorOwnsRoutingAllocation(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	stamp := func(offset time.Duration) string {
+		return fmt.Sprintf("operator-%d", now.Add(offset).Unix())
+	}
+
+	tests := []struct {
+		name     string
+		labels   map[string]string
+		expected bool
+	}{
+		{
+			name:     "No label present - dc_util owns the setting",
+			labels:   map[string]string{},
+			expected: false,
+		},
+		{
+			name:     "Fresh operator marker",
+			labels:   map[string]string{"dc-util-routing-owner": stamp(0)},
+			expected: true,
+		},
+		{
+			name:     "Marker just inside the TTL",
+			labels:   map[string]string{"dc-util-routing-owner": stamp(-routingOwnerTTL + time.Minute)},
+			expected: true,
+		},
+		{
+			name:     "Stale marker - operator likely died mid-restart",
+			labels:   map[string]string{"dc-util-routing-owner": stamp(-routingOwnerTTL - time.Minute)},
+			expected: false,
+		},
+		{
+			name:     "Clock skew within the TTL is honoured",
+			labels:   map[string]string{"dc-util-routing-owner": stamp(time.Minute)},
+			expected: true,
+		},
+		{
+			name:     "Far future timestamp would pin the setting forever",
+			labels:   map[string]string{"dc-util-routing-owner": stamp(routingOwnerTTL + time.Minute)},
+			expected: false,
+		},
+		{
+			name:     "Unknown owner",
+			labels:   map[string]string{"dc-util-routing-owner": "someone-else-1786000000"},
+			expected: false,
+		},
+		{
+			name:     "No timestamp",
+			labels:   map[string]string{"dc-util-routing-owner": "operator"},
+			expected: false,
+		},
+		{
+			name:     "Malformed timestamp",
+			labels:   map[string]string{"dc-util-routing-owner": "operator-not-a-number"},
+			expected: false,
+		},
+		{
+			name:     "Empty value",
+			labels:   map[string]string{"dc-util-routing-owner": ""},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := operatorOwnsRoutingAllocation(tt.labels, now)
+			if result != tt.expected {
+				t.Errorf("operatorOwnsRoutingAllocation() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestShouldSetPreStopRoutingAllocation(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	freshMarker := fmt.Sprintf("operator-%d", now.Unix())
+	staleMarker := fmt.Sprintf("operator-%d", now.Add(-routingOwnerTTL-time.Minute).Unix())
+
+	// If dc_util does not write the setting, it does not create the lock file.
+	// The postStart hook then does not reset a value of a different owner
+	// (crate/cloud#3054).
+	sts := func(labels map[string]string, withPostStart bool) *appsv1.StatefulSet {
+		container := corev1.Container{Name: "crate"}
+		if withPostStart {
+			container.Lifecycle = &corev1.Lifecycle{
+				PostStart: &corev1.LifecycleHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"/bin/sh", "-c", "dc_util --reset-routing"},
+					},
+				},
+			}
+		}
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels},
+			Spec: appsv1.StatefulSetSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{container}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		sts      *appsv1.StatefulSet
+		expected bool
+	}{
+		{
+			name:     "No marker, postStart hook present - dc_util sets it",
+			sts:      sts(map[string]string{}, true),
+			expected: true,
+		},
+		{
+			name:     "Operator owns it - dc_util keeps out",
+			sts:      sts(map[string]string{"dc-util-routing-owner": freshMarker}, true),
+			expected: false,
+		},
+		{
+			name:     "Stale marker - dc_util takes the setting again",
+			sts:      sts(map[string]string{"dc-util-routing-owner": staleMarker}, true),
+			expected: true,
+		},
+		{
+			name:     "No postStart hook to undo the change",
+			sts:      sts(map[string]string{}, false),
+			expected: false,
+		},
+		{
+			name:     "Marker wins over a missing postStart hook",
+			sts:      sts(map[string]string{"dc-util-routing-owner": freshMarker}, false),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldSetPreStopRoutingAllocation(tt.sts, now)
+			if result != tt.expected {
+				t.Errorf("shouldSetPreStopRoutingAllocation() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
 // Helper function to get int32 pointer
 func int32Ptr(i int32) *int32 {
 	return &i


### PR DESCRIPTION
## Summary of changes

The operator writes `cluster.routing.allocation.enable` at the `PERSISTENT` level, dc_util writes it at the `TRANSIENT` level, and neither cleans up in a way the other can rely on. Transient wins over persistent, so the transient `'all'` that dc_util's postStart hook left behind shadowed the operator's write indefinitely -- the protection was not in force and nothing logged that it wasn't.

Ownership is now decided by who started the restart:

- **Operator-driven restarts** (upgrade, change-compute, restore, explicit restart): the operator stamps a timestamped `dc-util-routing-owner` label on every StatefulSet of the cluster before it restarts a pod, and clears it in `AfterClusterUpdateSubHandler` next to the existing `RESET GLOBAL`. dc_util sees the label, leaves the setting alone, and does not create the lock file -- which is how it also skips the postStart reset.
- **Pod-level restarts** (eviction, node drain, manual delete): unchanged, dc_util owns them, because nothing else is coordinating.

That makes `RESET GLOBAL` safe in dc_util's postStart hook, replacing `SET GLOBAL TRANSIENT ... = 'all'`. This is the actual fix for the shadowing. It was unsafe before the split: `RESET GLOBAL` clears both levels, so a dc_util reset during an operator-driven restart would drop the value the operator holds for the pods still to come.

Two further points worth a reviewer's attention:

- **The operator writes both levels, and never resets mid-restart.** A transient value from an older dc_util would otherwise still shadow the persistent write, and dc_util no longer masks it with a transient write of its own. Doing this by resetting first was the obvious approach and is wrong: `restart_cluster` re-enters the terminating-pod branch every 15s for the whole termination, so the reset would be re-issued dozens of times *while that node is down*, each time leaving allocation at the default `all` until the following `SET` landed. Writing `primaries` transiently and then persistently is idempotent and never makes the cluster less restrictive. `AfterClusterUpdateSubHandler` clears both levels at the end.
- **The marker carries a timestamp (TTL 2h).** dc_util's unconditional postStart write was an accidental safety net: an operator that died mid-restart got the cluster unstuck anyway. Removing that would leave allocation pinned indefinitely and silently, so dc_util reclaims the setting once the label goes stale. The operator keeps clear of the TTL by re-stamping before every pod, so it only has to cover one pod's downtime, not a whole rolling restart.

Mixed versions degrade safely in both directions. An old dc_util ignores an unknown label and behaves as it does today. A new dc_util against an old operator never sees a marker, and its `RESET GLOBAL` lands between pods, when nothing is down and the operator re-sets the value before it deletes the next one.

Known and accepted: the suspend flow takes the label and has no After handler to clear it, and a restore longer than the TTL lets dc_util reclaim. Both are bounded by the TTL and neither leaves the cluster less protected than it is today -- a suspended cluster has no pods for dc_util to act on, and a restore does not restart pods.

## Flow

An operator-driven restart. dc_util still decommissions every node; it just stops writing the setting:

```mermaid
sequenceDiagram
    autonumber
    participant OP as crate-operator
    participant STS as StatefulSet labels
    participant DB as CrateDB
    participant DC as dc_util hooks

    OP->>STS: dc-util-routing-owner = operator-TIMESTAMP
    OP->>DB: SET TRANSIENT = primaries
    OP->>DB: SET PERSISTENT = primaries
    Note over OP,DB: transient first, so a value from an older<br/>dc_util cannot shadow the persistent one

    loop once per pod
        OP->>STS: re-stamp the label (fresh timestamp)
        OP->>DB: SET TRANSIENT / PERSISTENT = primaries
        OP->>DC: delete pod
        DC->>STS: read the labels
        Note over DC: operator owns it:<br/>no SQL write, no lock file
        DC->>DB: alter cluster decommission
        Note over DC: pod starts, postStart finds<br/>no lock file, exits
        OP->>DB: wait for GREEN
    end

    OP->>DB: RESET GLOBAL (clears both levels)
    OP->>STS: remove the label (in a finally block)
```

The decision dc_util makes in each hook. Every path that skips a write also skips the lock file, and every path that resets requires one:

```mermaid
flowchart TD
    START["Pod stops"] --> PRE{"preStop: label present<br/>and younger than 2 h?"}
    PRE -->|"yes, operator owns it"| SKIP["No SQL write<br/>No lock file"]
    PRE -->|"absent, malformed<br/>or stale"| SET["SET GLOBAL TRANSIENT = primaries<br/>Create lock file"]
    SKIP --> DECOM["alter cluster decommission"]
    SET --> DECOM
    DECOM --> UP["Pod starts"]

    UP --> POST{"postStart:<br/>lock file present?"}
    POST -->|"no"| EXIT["Exit, nothing to reset"]
    POST -->|"yes"| OWN{"label still owned<br/>by the operator?"}
    OWN -->|"yes"| KEEP["Skip the reset<br/>Keep the lock file for a later postStart"]
    OWN -->|"no"| RESET["RESET GLOBAL<br/>Remove the lock file"]
```

The `KEEP` branch is only reachable when a pod-level restart began before an operator-driven one overlapped it. Resetting there would drop the value the operator holds for the pods still to come, and deleting the lock file would lose the fact that a reset is still owed.

### Deploying

The dc_util half does **not** ride the operator release -- the binary is fetched from the in-cluster fileserver at hook runtime, so it needs `make rebuild-multi` in `utils/dc_util` plus a `kubectl delete pod` of the fileserver in each region, verified by checksum. See crate/cloud#3055 for why `rollout restart` is not reliable there. The two halves are independent, which is what the mixed-version behaviour above is for.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3054
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
