### PR TITLE
Fix the GC exposure test that failed on a finished cluster_create handler

### DIFF
--- a/tests/test_create_grand_central.py
+++ b/tests/test_create_grand_central.py
@@ -499,6 +499,10 @@ async def test_gc_change_exposure_loadbalancer_to_traefik(
         coapi,
         1,
         wait_for_healthy=False,
+        # The test only looks at the Ingress and the HTTPRoute, so it does not
+        # need the load balancer address. Waiting for one costs minutes on a
+        # cloud provider and delays the handler wait below.
+        wait_for_lb=False,
         additional_cluster_spec={
             "externalDNS": f"{name}.example.com",
         },
@@ -508,7 +512,6 @@ async def test_gc_change_exposure_loadbalancer_to_traefik(
         name,
         namespace.metadata.name,
         f"{KOPF_STATE_STORE_PREFIX}/cluster_create",
-        timeout=DEFAULT_TIMEOUT * 5,
     )
     await _start_gc_on_cluster(coapi, name, namespace.metadata.name)
 

--- a/tests/test_kopf_handler_wait.py
+++ b/tests/test_kopf_handler_wait.py
@@ -1,0 +1,110 @@
+# CrateDB Kubernetes Operator
+#
+# Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.utils import wait_for_kopf_handler
+
+HANDLER = "operator.cloud.crate.io/cluster_create"
+
+# Short enough to keep the timeout cases quick, long enough for several polls.
+TIMEOUT = 0.3
+DELAY = 0.02
+
+
+def _cratedb(annotation=None, status=None):
+    annotations = {HANDLER: json.dumps(annotation)} if annotation else {}
+    return {"metadata": {"annotations": annotations}, "status": status or {}}
+
+
+def _coapi(*bodies):
+    """A CustomObjectsApi whose reads return ``bodies`` in order, repeating the
+    last one once exhausted."""
+    coapi = MagicMock()
+    remaining = list(bodies)
+
+    async def _get(**_kwargs):
+        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
+
+    coapi.get_namespaced_custom_object = AsyncMock(side_effect=_get)
+    return coapi
+
+
+def _no_pods():
+    return patch(
+        "tests.utils.describe_pods", new_callable=AsyncMock, return_value="  <no pods>"
+    )
+
+
+async def _wait(coapi):
+    await wait_for_kopf_handler(coapi, "n", "ns", HANDLER, timeout=TIMEOUT, delay=DELAY)
+
+
+@pytest.mark.asyncio
+async def test_returns_when_handler_finished_before_first_poll():
+    """The regression: kopf purges the annotation in the same patch that ends
+    the cycle, so a wait that starts afterwards only ever sees it absent."""
+    status = {"cluster_create/bootstrap": {"success": True}}
+    await _wait(_coapi(_cratedb(status=status)))
+
+
+@pytest.mark.asyncio
+async def test_returns_when_annotation_is_purged_while_polling():
+    await _wait(
+        _coapi(
+            _cratedb(annotation={"started": "2026-08-11T04:32:30+00:00"}),
+            _cratedb(status={"cluster_create": {}}),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_times_out_while_handler_is_still_running():
+    coapi = _coapi(_cratedb(annotation={"started": "2026-08-11T04:32:30+00:00"}))
+    with _no_pods():
+        with pytest.raises(AssertionError, match="did not finish within"):
+            await _wait(coapi)
+
+
+@pytest.mark.asyncio
+async def test_times_out_when_handler_never_started():
+    """An empty status must not be read as "already done"."""
+    with _no_pods():
+        with pytest.raises(AssertionError, match="did not finish within"):
+            await _wait(_coapi(_cratedb()))
+
+
+@pytest.mark.asyncio
+async def test_ignores_status_of_an_unrelated_handler():
+    coapi = _coapi(_cratedb(status={"cluster_update/restart": {"success": True}}))
+    with _no_pods():
+        with pytest.raises(AssertionError, match="did not finish within"):
+            await _wait(coapi)
+
+
+@pytest.mark.asyncio
+async def test_raises_on_permanent_failure():
+    coapi = _coapi(_cratedb(annotation={"failure": True, "message": "boom"}))
+    with pytest.raises(AssertionError, match="boom"):
+        await _wait(coapi)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -540,12 +540,24 @@ async def is_kopf_handler_finished(
     return handler_status is None
 
 
+def _handler_ran(cratedb: dict, handler_name: str) -> bool:
+    """Whether the resource still records that ``handler_name`` ran.
+
+    kopf deletes the progress annotations, but the sub-handler records it
+    leaves in ``status`` survive. They tell an already-finished handler apart
+    from one that has not started yet, which the annotation alone cannot.
+    """
+    handler_id = handler_name.rsplit("/", 1)[-1]
+    status = cratedb.get("status") or {}
+    return any(key == handler_id or key.startswith(f"{handler_id}/") for key in status)
+
+
 async def _check_kopf_handler_status(
     coapi: CustomObjectsApi, name, namespace: str, handler_name: str
 ):
     """
-    Returns True if handler succeeded, False if still running, None if not yet seen.
-    Raises AssertionError if handler failed permanently.
+    Returns True if the handler finished, False if still running, None if it has
+    not started yet. Raises AssertionError if the handler failed permanently.
     """
     cratedb = await coapi.get_namespaced_custom_object(
         group=API_GROUP,
@@ -558,7 +570,10 @@ async def _check_kopf_handler_status(
     raw = annotations.get(handler_name)
 
     if raw is None:
-        return None
+        # kopf purges every progress annotation of a handling cycle in one
+        # patch and never persists a terminal ``success`` there, so an absent
+        # annotation means "done" only if the resource kept a status record.
+        return True if _handler_ran(cratedb, handler_name) else None
 
     try:
         status = json.loads(raw)
@@ -631,11 +646,14 @@ async def wait_for_kopf_handler(
     name: str,
     namespace: str,
     handler_name: str,
-    timeout: float = DEFAULT_TIMEOUT,
+    timeout: float = CLUSTER_CREATE_TIMEOUT,
     delay: float = 2,
 ):
     """
-    Wait for a kopf handler to complete, handling kopf's annotation cleanup lifecycle.
+    Wait for a kopf handler to complete, handling kopf's annotation cleanup
+    lifecycle. The wait does not have to observe the handler while it runs: a
+    handler that already finished before the first poll is detected from the
+    status records it left behind.
     """
     deadline = asyncio.get_running_loop().time() + timeout
     seen = False
@@ -643,7 +661,7 @@ async def wait_for_kopf_handler(
     while asyncio.get_running_loop().time() < deadline:
         result = await _check_kopf_handler_status(coapi, name, namespace, handler_name)
         if result is True:
-            logger.info("Handler '%s' finished (success=True)", handler_name)
+            logger.info("Handler '%s' finished", handler_name)
             return
         if result is None and seen:
             logger.info("Handler '%s' finished (annotation cleaned up)", handler_name)


### PR DESCRIPTION
## Summary of changes

`test_gc_change_exposure_loadbalancer_to_traefik` failed all three reruns in the last nightly integration run with `Handler 'operator.cloud.crate.io/cluster_create' did not finish within 300s` — against a healthy cluster. The operator log for the same run shows the opposite: every sub-handler (`sql_exporter_config`, `system_user`, `services`, `statefulset_data_hot`, `bootstrap`) succeeded on all three attempts, with no temporary failures, and `cluster_create` succeeded 24s after creation. The failure is in the wait helper, not the operator.

`wait_for_kopf_handler` polled the kopf progress annotation and treated the handler as done only once it had seen that annotation and then seen it disappear. kopf never writes a terminal `success` into it — it deletes every progress annotation of a handling cycle in a single patch:

```
Patching with: {'status': {'cluster_create': {}, ...,
  'cluster_create/bootstrap': {'success': True, ...}},
 'metadata': {'annotations': {
   'operator.cloud.crate.io/cluster_create': None,
   'operator.cloud.crate.io/cluster_create.bootstrap': None, ...}}}
```

So `_check_kopf_handler_status` could only ever return `False` (running) or `None` (absent); its `success` branch was unreachable. A wait that starts after the cycle ended sees only the absent annotation, never sets its `seen` flag, and times out on a handler that already succeeded.

This test hit it because it was the only one in the file leaving `wait_for_lb` at its default `True`, so `start_cluster` blocked on the load balancer address before the wait began. `cluster_create` finished and purged its annotations while the test was still waiting for that address. That is also why it is flaky rather than always red — it passes only when the load balancer wins the race against cluster bring-up.

Changes:

- `tests/utils.py`: an absent annotation is now resolved against the sub-handler records in the resource `status`, which kopf's purge leaves alone. This separates "already finished" from "not started yet", which the annotation alone cannot express. The wait also defaults to `CLUSTER_CREATE_TIMEOUT`, which #848 introduced for this class of flake but applied only to `tests/test_exposure.py`.
- `tests/test_create_grand_central.py`: pass `wait_for_lb=False`, as the four sibling tests already do. The test discards the return value and only inspects the Ingress and the HTTPRoute, so it never needs the address.
- `tests/test_kopf_handler_wait.py`: new unit tests, no cluster required.

With the status check disabled, `test_returns_when_handler_finished_before_first_poll` fails and the rest pass, so it pins this specific bug. Full non-k8s suite: 396 passed.

The k8s test itself has not been run against a cloud provider, so the end-to-end pass is unverified; the operator-side analysis comes from the nightly log.

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3056
- [ ] Relevant changes are reflected in `CHANGES.rst`: not applicable, tests only, as in #848
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
