### PR TITLE
Set the external-dns hostname annotation under both the alpha and new prefix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Set the external-dns hostname annotation under both the alpha and new prefix.
+
 2.64.0 (2026-09-02)
 -------------------
 

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -36,6 +36,13 @@ LABEL_NODE_NAME = f"{API_GROUP}/node-name"
 LABEL_NODE_DATA = f"{API_GROUP}/node-data"
 LABEL_USER_PASSWORD = f"operator.{API_GROUP}/user-password"
 
+# external-dns v0.22.0 changed its default annotation prefix from
+# "external-dns.alpha.kubernetes.io/" to "external-dns.kubernetes.io/" with no
+# fallback, so both are set until all external-dns controllers are on v0.22.0+.
+# Drop the alpha one afterwards.
+ANNOTATION_EXTERNAL_DNS_HOSTNAME_ALPHA = "external-dns.alpha.kubernetes.io/hostname"
+ANNOTATION_EXTERNAL_DNS_HOSTNAME = "external-dns.kubernetes.io/hostname"
+
 SYSTEM_USERNAME = "system"
 GC_USERNAME = "gc_admin"
 GC_USER_SECRET_NAME = "user-gc-{name}"

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -94,6 +94,8 @@ from kubernetes_asyncio.client import (
 
 from crate.operator.config import config
 from crate.operator.constants import (
+    ANNOTATION_EXTERNAL_DNS_HOSTNAME,
+    ANNOTATION_EXTERNAL_DNS_HOSTNAME_ALPHA,
     API_GROUP,
     CRATE_CONTROL_PORT,
     DATA_PVC_NAME_PREFIX,
@@ -1305,7 +1307,8 @@ def _lb_annotations_to_add(dns_record: Optional[str]) -> dict:
             }
         )
     if dns_record:
-        annotations["external-dns.alpha.kubernetes.io/hostname"] = dns_record
+        annotations[ANNOTATION_EXTERNAL_DNS_HOSTNAME_ALPHA] = dns_record
+        annotations[ANNOTATION_EXTERNAL_DNS_HOSTNAME] = dns_record
     return annotations
 
 
@@ -1327,7 +1330,8 @@ def _lb_annotations_to_remove() -> dict:
         "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": None,  # noqa
         "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset": None,
         "service.beta.kubernetes.io/azure-load-balancer-tcp-idle-timeout": None,
-        "external-dns.alpha.kubernetes.io/hostname": None,
+        ANNOTATION_EXTERNAL_DNS_HOSTNAME_ALPHA: None,
+        ANNOTATION_EXTERNAL_DNS_HOSTNAME: None,
     }
 
 

--- a/crate/operator/grand_central.py
+++ b/crate/operator/grand_central.py
@@ -69,6 +69,8 @@ from kubernetes_asyncio.client import (
 from crate.operator.bootstrap import bootstrap_gc_admin_user
 from crate.operator.config import config
 from crate.operator.constants import (
+    ANNOTATION_EXTERNAL_DNS_HOSTNAME,
+    ANNOTATION_EXTERNAL_DNS_HOSTNAME_ALPHA,
     GC_USER_SECRET_NAME,
     GC_USERNAME,
     GRAND_CENTRAL_BACKEND_API_PORT,
@@ -904,7 +906,8 @@ def get_grand_central_ingress(
         or "$http_origin"
     )
     annotations = {
-        "external-dns.alpha.kubernetes.io/hostname": hostname,
+        ANNOTATION_EXTERNAL_DNS_HOSTNAME_ALPHA: hostname,
+        ANNOTATION_EXTERNAL_DNS_HOSTNAME: hostname,
         "nginx.ingress.kubernetes.io/proxy-body-size": "1G",
         "nginx.ingress.kubernetes.io/configuration-snippet": (
             """

--- a/devtools/backfill_external_dns_annotation.py
+++ b/devtools/backfill_external_dns_annotation.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "click>=8",
+#     "kubernetes>=31",
+#     "urllib3>=2",
+# ]
+# ///
+"""Backfill the new external-dns hostname annotation on CrateDB resources.
+
+external-dns v0.22.0 changed its default annotation prefix from
+"external-dns.alpha.kubernetes.io/" to "external-dns.kubernetes.io/" with no
+fallback to the old one. The operator sets both prefixes on newly created
+resources; this script adds the new annotation to existing operator-managed
+Services and Ingresses. Run once per Kubernetes cluster. Resources that
+already carry the new annotation are skipped, so re-running is safe.
+"""
+
+import sys
+
+import click
+import urllib3
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+ALPHA = "external-dns.alpha.kubernetes.io/hostname"
+NEW = "external-dns.kubernetes.io/hostname"
+SELECTOR = "app.kubernetes.io/managed-by=crate-operator,app.kubernetes.io/part-of=cratedb"  # noqa
+
+
+@click.command(help=__doc__)
+@click.option("--apply", is_flag=True, help="Patch the resources (default: dry run).")
+@click.option("--context", help="kubeconfig context to use (default: current).")
+def main(apply: bool, context: str | None) -> None:
+    config.load_kube_config(context=context)
+    # Whether to verify TLS comes from the kubeconfig; don't also warn about it.
+    if not client.Configuration.get_default_copy().verify_ssl:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    _, active = config.list_kube_config_contexts()
+    click.echo(f"Context: {context or active['name']}")
+    core = client.CoreV1Api()
+    networking = client.NetworkingV1Api()
+    patched = skipped = failed = 0
+    for kind, list_fn, patch_fn in [
+        (
+            "service",
+            core.list_service_for_all_namespaces,
+            core.patch_namespaced_service,
+        ),
+        (
+            "ingress",
+            networking.list_ingress_for_all_namespaces,
+            networking.patch_namespaced_ingress,
+        ),
+    ]:
+        for item in list_fn(label_selector=SELECTOR).items:
+            annotations = item.metadata.annotations or {}
+            hostname = annotations.get(ALPHA)
+            if not hostname:
+                continue
+            if annotations.get(NEW):
+                skipped += 1
+                continue
+            ref = f"{kind} {item.metadata.namespace}/{item.metadata.name}"
+            if not apply:
+                click.echo(f"would annotate {ref} with {NEW}={hostname}")
+                patched += 1
+                continue
+            try:
+                patch_fn(
+                    item.metadata.name,
+                    item.metadata.namespace,
+                    {"metadata": {"annotations": {NEW: hostname}}},
+                )
+            except ApiException as e:
+                click.echo(f"failed to annotate {ref}: {e.reason}", err=True)
+                failed += 1
+            else:
+                click.echo(f"annotated {ref} with {NEW}={hostname}")
+                patched += 1
+    if apply:
+        click.echo(f"Annotated {patched}, skipped {skipped}, failed {failed}.")
+    else:
+        click.echo(f"Would annotate {patched}, {skipped} already done. Use --apply.")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1255,10 +1255,16 @@ class TestServiceModels:
                 in annotation_keys
             )
         if dns:
+            # Both prefixes must be set: external-dns v0.22.0 dropped the alpha
+            # one as its default, older controllers only know the alpha one.
             assert (
                 service.metadata.annotations[
                     "external-dns.alpha.kubernetes.io/hostname"
                 ]
+                == dns
+            )
+            assert (
+                service.metadata.annotations["external-dns.kubernetes.io/hostname"]
                 == dns
             )
 
@@ -1415,7 +1421,10 @@ class TestServices:
             additional_annotations=annotations,
         )
 
-        expected_annotations = {"external-dns.alpha.kubernetes.io/hostname": host}
+        expected_annotations = {
+            "external-dns.alpha.kubernetes.io/hostname": host,
+            "external-dns.kubernetes.io/hostname": host,
+        }
         if annotations:
             expected_annotations.update(annotations)
 
@@ -1693,6 +1702,10 @@ class TestCreateCustomResource:
         )
         assert (
             ingress.metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+            == "my-crate-cluster.gc.aks1.eastus.azure.cratedb-dev.net"
+        )
+        assert (
+            ingress.metadata.annotations["external-dns.kubernetes.io/hostname"]
             == "my-crate-cluster.gc.aks1.eastus.azure.cratedb-dev.net"
         )
 

--- a/tests/test_create_grand_central.py
+++ b/tests/test_create_grand_central.py
@@ -205,6 +205,10 @@ async def test_create_grand_central(faker, namespace, kopf_runner, api_client):
         == "my-crate-cluster.gc.aks1.eastus.azure.cratedb-dev.net"
     )
     assert (
+        ingress.metadata.annotations["external-dns.kubernetes.io/hostname"]
+        == "my-crate-cluster.gc.aks1.eastus.azure.cratedb-dev.net"
+    )
+    assert (
         ingress.metadata.annotations[
             "nginx.ingress.kubernetes.io/cors-allow-credentials"
         ]


### PR DESCRIPTION
## Summary of changes

external-dns [v0.22.0](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.22.0) changes the default annotation prefix from `external-dns.alpha.kubernetes.io/` to `external-dns.kubernetes.io/`, with no fallback to the old prefix. The operator now sets the hostname annotation under both prefixes (option 1 in the issue: "two won't hurt") on:

- the data service (`_lb_annotations_to_add`, plus removal via `_lb_annotations_to_remove` when switching to Traefik)
- the grand-central nginx `Ingress`

Both keys live in `constants.py` with a note to drop the alpha one once all external-dns controllers are confirmed on v0.22.0+.

For existing clusters (item 2 in the issue), `devtools/backfill_external_dns_annotation.py` — a uv script (PEP 723 inline metadata, click CLI) — copies the alpha annotation's value to the new key on operator-managed Services and Ingresses only, selected via `app.kubernetes.io/managed-by=crate-operator,app.kubernetes.io/part-of=cratedb`. It dry-runs by default, takes `--apply` to patch and `--context` to pick a kubeconfig context, skips resources that already have the new annotation, and reports per-resource failures without aborting the sweep (non-zero exit if any). Run once per region:

```
uv run devtools/backfill_external_dns_annotation.py --context <ctx>          # dry run
uv run devtools/backfill_external_dns_annotation.py --context <ctx> --apply
```

Still out of scope: pinning `--annotation-prefix` / bumping external-dns on the deployments in kubernetes-gitops (item 3).

## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3080
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [x] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
