### PR TITLE
SQL Exporter: 0.24.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 * Fixed the operator restarting the next node during a rolling restart before
   the cluster had actually recovered.
 
+* Bumped sql_exporter to ``0.24.6`` for CVE fixes.
+
 2.63.1 (2026-08-27)
 -------------------
 

--- a/crate/operator/config.py
+++ b/crate/operator/config.py
@@ -178,7 +178,7 @@ class Config:
     PROMETHEUS_PORT: int = 8080
 
     #: The sql_exporter image to use
-    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.24.3"
+    SQL_EXPORTER_IMAGE: str = "burningalchemist/sql_exporter:0.24.6"
 
     #: Name of the secret containing credentials to access the source
     #: backup when restoring a snapshot.


### PR DESCRIPTION
CVE addressed:

CVE-2026-39821
CVE-2026-56858
CVE-2026-33818
CVE-2026-46600
CVE-2026-56853
CVE-2026-56859
CVE-2026-56860
CVE-2026-56862
CVE-2026-56852
GHSA-hrxh-6v49-42gf

## Summary of changes


## Checklist

- [x] Link to issue this PR refers to: https://github.com/crate/cloud/issues/3045
- [x] Relevant changes are reflected in `CHANGES.rst`
- [ ] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [x] Changed code does not contain any breaking changes (or this is a major version change)
