### PR TITLE
Resolve node.attr.zone via the Node label instead of cloud IMDS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 Unreleased
 ----------
 
+* Changed ``-Cnode.attr.zone`` to resolve the pod's Node
+  ``topology.kubernetes.io/zone`` label via the in-cluster API server on AWS,
+  Azure, GCP, and STACKIT, instead of querying each cloud's instance metadata
+  service. Requires pod egress to the Kubernetes API server; no longer
+  requires pod egress to ``169.254.169.254``.
+
 * Set the external-dns hostname annotation under both the alpha and new prefix.
 
 * Bumped sql_exporter to ``0.24.8`` for CVE fixes.

--- a/crate/operator/constants.py
+++ b/crate/operator/constants.py
@@ -49,6 +49,11 @@ GC_USER_SECRET_NAME = "user-gc-{name}"
 
 CONNECT_TIMEOUT = 10.0
 
+# Shared, idempotently-(re)created ClusterRole granting read-only access to Node
+# objects, used by CrateDB pods to resolve their own topology.kubernetes.io/zone
+# label at startup instead of querying each cloud's instance metadata service.
+NODE_ZONE_READER_CLUSTER_ROLE_NAME = "crate-node-zone-reader"
+
 KOPF_STATE_STORE_PREFIX = f"operator.{API_GROUP}"
 
 CLUSTER_UPDATE_ID = "cluster_update"

--- a/crate/operator/create.py
+++ b/crate/operator/create.py
@@ -38,6 +38,8 @@ from kubernetes_asyncio.client import (
     RbacV1Subject,
     V1Affinity,
     V1Capabilities,
+    V1ClusterRole,
+    V1ClusterRoleBinding,
     V1ConfigMap,
     V1ConfigMapVolumeSource,
     V1Container,
@@ -108,6 +110,7 @@ from crate.operator.constants import (
     LABEL_NODE_DATA,
     LABEL_NODE_NAME,
     LABEL_PART_OF,
+    NODE_ZONE_READER_CLUSTER_ROLE_NAME,
     SHARED_NODE_SELECTOR_KEY,
     SHARED_NODE_SELECTOR_VALUE,
     SHARED_NODE_TOLERATION_EFFECT,
@@ -592,32 +595,32 @@ def get_statefulset_crate_command(
         settings["-Cnetwork.host"] = "0.0.0.0"
         settings["-Cnetwork.publish_host"] = "$(POD_IP)"
 
-    # Availability zone retrieval at pod launch time
-    if config.CLOUD_PROVIDER == CloudProvider.AWS:
-        aws_cmd = (
-            "curl -s -X PUT 'http://169.254.169.254/latest/api/token' "
-            "-H 'X-aws-ec2-metadata-token-ttl-seconds: 120' | "
-            "xargs -I {} curl -s "
-            "'http://169.254.169.254/latest/meta-data/placement/availability-zone'"
-            " -H 'X-aws-ec2-metadata-token: {}'"
+    # Availability zone retrieval at pod launch time. Reads the Node object's
+    # well-known topology.kubernetes.io/zone label via the in-cluster API server
+    # instead of querying each cloud's instance metadata service. One code path
+    # for every provider, and it doesn't require pod egress to
+    # 169.254.169.254 (crate/cloud#3850, crate/cloud#3851).
+    #
+    # ${NODE_NAME} is injected into the crate container's environment via the
+    # Downward API (spec.nodeName); see get_statefulset_crate_env. Reading the
+    # Node object requires the pod's ServiceAccount to be bound to the
+    # crate-node-zone-reader ClusterRole (created below, in create_statefulset).
+    if config.CLOUD_PROVIDER in (
+        CloudProvider.AWS,
+        CloudProvider.AZURE,
+        CloudProvider.GCP,
+        CloudProvider.STACKIT,
+    ):
+        zone_cmd = (
+            "curl -s "
+            "--cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt "
+            '-H "Authorization: Bearer '
+            '$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" '
+            '"https://kubernetes.default.svc/api/v1/nodes/${NODE_NAME}" | '
+            "sed -n "
+            '\'s/.*"topology\\.kubernetes\\.io\\/zone": *"\\([^"]*\\)".*/\\1/p\''
         )
-        settings["-Cnode.attr.zone"] = f"$({aws_cmd})"
-    elif config.CLOUD_PROVIDER == CloudProvider.AZURE:
-        url = "http://169.254.169.254/metadata/instance/compute/zone?api-version=2020-06-01&format=text"  # noqa
-        settings["-Cnode.attr.zone"] = f"$(curl -s '{url}' -H 'Metadata: true')"
-    elif config.CLOUD_PROVIDER == CloudProvider.GCP:
-        url = "http://169.254.169.254/computeMetadata/v1/instance/zone"  # noqa
-        # projects/<account-id>/zones/us-central1-a
-        settings["-Cnode.attr.zone"] = (
-            f"$(curl -s '{url}' -H 'Metadata-Flavor: Google' | awk -F'/' '{{print $NF}}')"  # noqa
-        )
-    elif config.CLOUD_PROVIDER == CloudProvider.STACKIT:
-        # STACKIT runs on OpenStack, which serves the EC2-compatible metadata API
-        # as well, so the zone comes back as a bare string and needs no parsing.
-        # Same path as AWS above, minus the IMDSv2 token: OpenStack does not
-        # require one.
-        url = "http://169.254.169.254/latest/meta-data/placement/availability-zone"  # noqa
-        settings["-Cnode.attr.zone"] = f"$(curl -s '{url}')"
+        settings["-Cnode.attr.zone"] = f"$({zone_cmd})"
 
     if cluster_settings:
         for k, v in cluster_settings.items():
@@ -710,6 +713,25 @@ def get_statefulset_crate_env(
                 value_from=V1EnvVarSource(
                     field_ref=V1ObjectFieldSelector(
                         api_version="v1", field_path="status.podIP"
+                    )
+                ),
+            )
+        )
+
+    # Referenced as ``${NODE_NAME}`` by the ``-Cnode.attr.zone`` Node lookup
+    # above, on every provider that resolves zone awareness that way.
+    if config.CLOUD_PROVIDER in (
+        CloudProvider.AWS,
+        CloudProvider.AZURE,
+        CloudProvider.GCP,
+        CloudProvider.STACKIT,
+    ):
+        crate_env.append(
+            V1EnvVar(
+                name="NODE_NAME",
+                value_from=V1EnvVarSource(
+                    field_ref=V1ObjectFieldSelector(
+                        api_version="v1", field_path="spec.nodeName"
                     )
                 ),
             )
@@ -1161,6 +1183,68 @@ def get_pod_disruption_budget(
     )
 
 
+async def create_node_zone_reader_rbac(
+    api_client: Any,
+    namespace: str,
+    name: str,
+    logger: logging.Logger,
+) -> None:
+    """
+    Grant this cluster's default ServiceAccount read-only access to its own
+    Node object, so the crate container can resolve
+    ``topology.kubernetes.io/zone`` for ``-Cnode.attr.zone`` at startup instead
+    of querying the cloud's instance metadata service
+    (crate/cloud#3850, crate/cloud#3851).
+
+    Nodes are cluster-scoped, so - unlike the per-cluster ``Role`` used for
+    StatefulSet access - this needs a ``ClusterRole``. That role is shared
+    across every CrateDB cluster in every namespace and (re)created
+    idempotently on every call; only the binding is per-cluster.
+
+    A namespaced CrateDB CR cannot own a cluster-scoped object, so neither
+    object here is covered by ``owner_references`` garbage collection - the
+    binding is explicitly deleted in ``delete_cratedb`` instead.
+    """
+    if config.CLOUD_PROVIDER not in (
+        CloudProvider.AWS,
+        CloudProvider.AZURE,
+        CloudProvider.GCP,
+        CloudProvider.STACKIT,
+    ):
+        return
+
+    rbac = RbacAuthorizationV1Api(api_client)
+
+    cluster_role = V1ClusterRole(
+        metadata=V1ObjectMeta(name=NODE_ZONE_READER_CLUSTER_ROLE_NAME),
+        rules=[V1PolicyRule(api_groups=[""], resources=["nodes"], verbs=["get"])],
+    )
+    await call_kubeapi(
+        rbac.create_cluster_role,
+        logger,
+        continue_on_conflict=True,
+        body=cluster_role,
+    )
+
+    cluster_role_binding = V1ClusterRoleBinding(
+        metadata=V1ObjectMeta(name=f"crate-node-zone-reader-{namespace}-{name}"),
+        role_ref=V1RoleRef(
+            api_group="rbac.authorization.k8s.io",
+            kind="ClusterRole",
+            name=NODE_ZONE_READER_CLUSTER_ROLE_NAME,
+        ),
+        subjects=[
+            RbacV1Subject(kind="ServiceAccount", name="default", namespace=namespace)
+        ],
+    )
+    await call_kubeapi(
+        rbac.create_cluster_role_binding,
+        logger,
+        continue_on_conflict=True,
+        body=cluster_role_binding,
+    )
+
+
 async def create_statefulset(
     owner_references: Optional[List[V1OwnerReference]],
     namespace: str,
@@ -1282,6 +1366,8 @@ async def create_statefulset(
             namespace=namespace,
             body=role_binding,
         )
+
+        await create_node_zone_reader_rbac(api_client, namespace, name, logger)
 
 
 def _lb_annotations_to_add(dns_record: Optional[str]) -> dict:

--- a/crate/operator/handlers/handle_delete_cratedb.py
+++ b/crate/operator/handlers/handle_delete_cratedb.py
@@ -21,7 +21,11 @@
 
 import logging
 
-from kubernetes_asyncio.client import ApiException, CustomObjectsApi
+from kubernetes_asyncio.client import (
+    ApiException,
+    CustomObjectsApi,
+    RbacAuthorizationV1Api,
+)
 
 from crate.operator.config import config
 from crate.operator.constants import CloudProvider
@@ -39,10 +43,11 @@ async def delete_cratedb(
 
     Namespace-scoped resources (Services, Secrets, StatefulSets, etc.)
     are cleaned up automatically via owner references. However,
-    SecurityContextConstraints are cluster-scoped and require explicit
-    deletion here.
+    SecurityContextConstraints and the node-zone-reader ClusterRoleBinding
+    are cluster-scoped and require explicit deletion here.
     """
     await _delete_crate_scc(namespace, name, logger)
+    await _delete_node_zone_reader_binding(namespace, name, logger)
 
 
 async def _delete_crate_scc(
@@ -76,6 +81,37 @@ async def _delete_crate_scc(
                     "Could not delete SCC %s (status=%s reason=%s) — "
                     "it may need to be removed manually",
                     scc_name,
+                    e.status,
+                    e.reason,
+                )
+
+
+async def _delete_node_zone_reader_binding(
+    namespace: str,
+    name: str,
+    logger: logging.Logger,
+) -> None:
+    """
+    Delete the per-cluster ClusterRoleBinding created by
+    ``create_node_zone_reader_rbac``. The shared ``ClusterRole`` itself is
+    left in place - it may still be bound for other CrateDB clusters.
+    """
+    binding_name = f"crate-node-zone-reader-{namespace}-{name}"
+
+    async with GlobalApiClient() as api_client:
+        rbac = RbacAuthorizationV1Api(api_client)
+        try:
+            await rbac.delete_cluster_role_binding(name=binding_name)
+            logger.info("Deleted ClusterRoleBinding %s", binding_name)
+        except ApiException as e:
+            if e.status == 404:
+                logger.info("ClusterRoleBinding %s already deleted", binding_name)
+            else:
+                logger.warning(
+                    "Could not delete ClusterRoleBinding %s "
+                    "(status=%s reason=%s) — it may need to be removed "
+                    "manually",
+                    binding_name,
                     e.status,
                     e.reason,
                 )

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -681,31 +681,15 @@ class TestStatefulSetCrateCommand:
         assert "-Cnode.attr.some_cluster_setting=cluster" in cmd
 
     @pytest.mark.parametrize(
-        "provider, url, header",
+        "provider",
         [
-            (
-                CloudProvider.AWS,
-                "-X PUT 'http://169.254.169.254/latest/api/token'",
-                " -H 'X-aws-ec2-metadata-token-ttl-seconds: 120' | xargs -I {} curl -s 'http://169.254.169.254/latest/meta-data/placement/availability-zone' -H 'X-aws-ec2-metadata-token: {}'",  # noqa
-            ),
-            (
-                CloudProvider.AZURE,
-                "'http://169.254.169.254/metadata/instance/compute/zone?api-version=2020-06-01&format=text'",  # noqa
-                " -H 'Metadata: true'",
-            ),
-            (
-                CloudProvider.GCP,
-                "'http://169.254.169.254/computeMetadata/v1/instance/zone'",
-                " -H 'Metadata-Flavor: Google' | awk -F'/' '{print $NF}'",
-            ),
-            (
-                CloudProvider.STACKIT,
-                "'http://169.254.169.254/latest/meta-data/placement/availability-zone'",  # noqa
-                "",
-            ),
+            CloudProvider.AWS,
+            CloudProvider.AZURE,
+            CloudProvider.GCP,
+            CloudProvider.STACKIT,
         ],
     )
-    def test_zone_attr(self, provider, url, header):
+    def test_zone_attr(self, provider):
         with mock.patch("crate.operator.create.config.CLOUD_PROVIDER", provider):
             cmd = get_statefulset_crate_command(
                 namespace="some-namespace",
@@ -730,7 +714,43 @@ class TestStatefulSetCrateCommand:
                 crate_version="4.6.3",
                 cloud_settings={},
             )
-        assert f"-Cnode.attr.zone=$(curl -s {url}{header})" in cmd
+        zone_attr = next(a for a in cmd if a.startswith("-Cnode.attr.zone="))
+        # Every provider resolves the zone the same way now: reading the pod's
+        # own Node object via the in-cluster API server, not a cloud metadata
+        # service - so it doesn't need pod egress to 169.254.169.254.
+        assert "169.254.169.254" not in zone_attr
+        assert "${NODE_NAME}" in zone_attr
+        assert "kubernetes.default.svc/api/v1/nodes/" in zone_attr
+        assert "topology" in zone_attr and "zone" in zone_attr
+
+    def test_zone_attr_openshift_not_set(self):
+        with mock.patch(
+            "crate.operator.create.config.CLOUD_PROVIDER", CloudProvider.OPENSHIFT
+        ):
+            cmd = get_statefulset_crate_command(
+                namespace="some-namespace",
+                name="cluster1",
+                master_nodes=["node-0", "node-1", "node-2"],
+                total_nodes_count=3,
+                data_nodes_count=3,
+                crate_node_name_prefix="node-",
+                cluster_name="my-cluster",
+                node_name="node",
+                node_spec={
+                    "resources": {
+                        "requests": {"cpu": 1},
+                        "limits": {"cpu": 1},
+                        "disk": {"count": 1},
+                    }
+                },
+                cluster_settings=None,
+                has_ssl=False,
+                is_master=True,
+                is_data=True,
+                crate_version="4.6.3",
+                cloud_settings={},
+            )
+        assert not any(a.startswith("-Cnode.attr.zone=") for a in cmd)
 
     @pytest.mark.parametrize(
         "node_settings, cluster_settings",

--- a/tests/test_stackit.py
+++ b/tests/test_stackit.py
@@ -40,12 +40,6 @@ OTHER_PROVIDERS = [
     CloudProvider.OPENSHIFT,
 ]
 
-METADATA_URL = "http://169.254.169.254/latest/meta-data/placement/availability-zone"
-
-#: The whole zone snippet. AWS reads the same path, so tests that assert a
-#: provider does *not* use it have to compare the snippet, not just the URL.
-ZONE_SETTING = f"-Cnode.attr.zone=$(curl -s '{METADATA_URL}')"
-
 
 def crate_command(provider):
     with mock.patch("crate.operator.create.config.CLOUD_PROVIDER", provider):
@@ -147,25 +141,6 @@ class TestStackitNetworkSettings:
         assert "-Cauth.host_based.config.99.method=password" in cmd
 
 
-class TestStackitZoneAttribute:
-    """
-    ``node.attr.zone`` comes from the EC2-compatible metadata API that OpenStack
-    serves alongside its own. It answers with the bare zone name (``eu01-3``), so
-    there is nothing to parse - unlike AWS, no IMDSv2 token is needed either.
-    """
-
-    def test_reads_the_zone_from_the_metadata_service(self):
-        cmd = crate_command(CloudProvider.STACKIT)
-
-        assert ZONE_SETTING in cmd
-
-    @pytest.mark.parametrize("provider", OTHER_PROVIDERS)
-    def test_other_providers_are_untouched(self, provider):
-        cmd = crate_command(provider)
-
-        assert ZONE_SETTING not in cmd
-
-
 class TestStackitTopologySpread:
     def test_pods_are_spread_over_three_zones(self, faker):
         """
@@ -207,7 +182,7 @@ class TestStackitCrateEnv:
         assert pod_ip[0].value_from.field_ref.field_path == "status.podIP"
         assert pod_ip[0].value_from.field_ref.api_version == "v1"
 
-    @pytest.mark.parametrize("provider", OTHER_PROVIDERS)
+    @pytest.mark.parametrize("provider", [None, CloudProvider.OPENSHIFT])
     def test_other_providers_have_no_pod_ip(self, provider):
         node_spec = {"resources": {"memory": "123Mi", "heapRatio": 0.456}}
 
@@ -237,4 +212,42 @@ class TestStackitCrateEnv:
             "KEYSTORE_KEY_PASSWORD",
             "KEYSTORE_PASSWORD",
             "POD_IP",
+            "NODE_NAME",
         ]
+
+
+class TestStackitNodeNameEnv:
+    """
+    ``${NODE_NAME}`` feeds the Node lookup behind ``-Cnode.attr.zone`` on every
+    provider that resolves zone awareness that way - STACKIT included.
+    """
+
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            CloudProvider.AWS,
+            CloudProvider.AZURE,
+            CloudProvider.GCP,
+            CloudProvider.STACKIT,
+        ],
+    )
+    def test_zone_aware_providers_get_node_name(self, provider):
+        node_spec = {"resources": {"memory": "123Mi", "heapRatio": 0.456}}
+
+        with mock.patch("crate.operator.create.config.CLOUD_PROVIDER", provider):
+            env = get_statefulset_crate_env(node_spec, 1234, 5678, None)
+
+        node_name = [e for e in env if e.name == "NODE_NAME"]
+        assert len(node_name) == 1
+        assert node_name[0].value is None
+        assert node_name[0].value_from.field_ref.field_path == "spec.nodeName"
+        assert node_name[0].value_from.field_ref.api_version == "v1"
+
+    @pytest.mark.parametrize("provider", [None, CloudProvider.OPENSHIFT])
+    def test_other_providers_have_no_node_name(self, provider):
+        node_spec = {"resources": {"memory": "123Mi", "heapRatio": 0.456}}
+
+        with mock.patch("crate.operator.create.config.CLOUD_PROVIDER", provider):
+            env = get_statefulset_crate_env(node_spec, 1234, 5678, None)
+
+        assert not any(e.name == "NODE_NAME" for e in env)


### PR DESCRIPTION
## Summary of changes
CrateDB's node.attr.zone (used for zone-aware shard allocation) was queried per-provider from each cloud's instance metadata service at 169.254.169.254. That endpoint needs pod egress to survive on all four providers, and it's a classic SSRF/pivot target — closing it off at the NetworkPolicy layer (crate/cloud#3850, crate/cloud#3851) breaks zone detection on every cluster.

Read the pod's own Node object via the in-cluster API server instead: the topology.kubernetes.io/zone label is already populated consistently by AWS, Azure, GCP and STACKIT's cloud-controller-managers. One code path for all four providers, and no pod egress to IMDS required.

Requires a ClusterRole/ClusterRoleBinding granting the cluster's default ServiceAccount read-only access to its own Node object; the binding is per-cluster and explicitly cleaned up on delete, since a namespaced CrateDB CR can't own a cluster-scoped object via owner_references.

Every provider's crate pod restarts once to pick up the new command and NODE_NAME env var.


## Checklist

- [ ] Link to issue this PR refers to:
- [x] Relevant changes are reflected in `CHANGES.rst`
- [x] Added or changed code is covered by tests
- [ ] Documentation has been updated if necessary
- [ ] Changed code does not contain any breaking changes (or this is a major version change)
